### PR TITLE
Clean Java docs metadata and URL formatting

### DIFF
--- a/english/java/_index.md
+++ b/english/java/_index.md
@@ -9,6 +9,7 @@ description: Aspose.PDF is a PDF document creation API that enables Java applica
 is_root: true
 ---
 ## Packages
+
 | Package | Description |
 | --- | --- |
 | [com.aspose.pdf](./com.aspose.pdf) | The com.aspose.pdf is a root package for all classes of Aspose.PDF for Java library which are either directly in it like Document or indirectly through several subpackages. |

--- a/english/java/com.aspose.pdf.boundscheckablelist/_index.md
+++ b/english/java/com.aspose.pdf.boundscheckablelist/_index.md
@@ -5,7 +5,7 @@ second_title: Aspose.PDF for Java API Reference
 description: Represents BoundsCheckableList - wrapper around System.Collections.Generic.List.
 type: docs
 weight: 10
-url: /java/com.aspose.pdf.boundscheckablelist//
+url: /java/com.aspose.pdf.boundscheckablelist/
 ---
 **Inheritance:**
 java.lang.Object, com.aspose.pdf.boundscheckablelist.BoundsCheckableList<T>

--- a/english/java/com.aspose.pdf/_index.md
+++ b/english/java/com.aspose.pdf/_index.md
@@ -1,6 +1,5 @@
 ---
 title: com.aspose.pdf
-linktitle: com.aspose.pdf
 second_title: Aspose.PDF for Java API Reference
 description: The com.aspose.pdf is a root package for all classes of Aspose.PDF for Java library which are either directly in it like Document or indirectly through several subpackages.
 type: docs


### PR DESCRIPTION
Tidied Java API reference markdown by removing redundant `linktitle` from `com.aspose.pdf`, fixing an extra trailing slash in `com.aspose.pdf.boundscheckablelist` URL, and adding spacing before the packages table in `english/java/_index.md` for cleaner rendering.