### PR TITLE
Update BoundsCheckableList doc page title

### DIFF
--- a/english/java/com.aspose.pdf.boundscheckablelist/_index.md
+++ b/english/java/com.aspose.pdf.boundscheckablelist/_index.md
@@ -1,5 +1,5 @@
 ---
-title: BoundsCheckableList
+title: com.aspose.pdf.boundscheckablelist
 second_title: Aspose.PDF for Java API Reference
 description: Represents BoundsCheckableList - wrapper around System.Collections.Generic.List.
 type: docs


### PR DESCRIPTION
Align the Java API reference front matter title with the fully qualified package name by changing it from `BoundsCheckableList` to `com.aspose.pdf.boundscheckablelist`.