### PR TITLE
[auto] Translate GO-CPP API Reference to Turkish

### DIFF
--- a/turkish/go-cpp/_index.md
+++ b/turkish/go-cpp/_index.md
@@ -1,0 +1,286 @@
+---
+title: "Aspose.PDF for Go via C++"
+description: "Aspose.PDF for Go via C++"
+keywords:  "Go, Golang, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /tr/go-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Go via C++ allows developers manipulate them PDF files directly in the Go.
+
+# Types
+
+## Document
+Belge bir PDF-dokümanını temsil eder.
+
+```go
+type Document struct {
+}
+```
+
+# Functions
+
+## Convert from PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [SaveDocX](./convert/savedocx/) | Önceden açılmış PDF-dokümanını DocX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveDoc](./convert/savedoc/) | Önceden açılmış PDF-dokümanını Doc-dokümanı olarak dönüştür ve kaydet. |
+| [SaveXlsX](./convert/savexlsx/) | Önceden açılmış PDF-dokümanını XlsX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTxt](./convert/savetxt/) | Önceden açılmış PDF-dokümanını Txt-dokümanı olarak dönüştür ve kaydet. |
+| [SavePptX](./convert/savepptx/) | Önceden açılmış PDF-dokümanını PptX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveXps](./convert/savexps/) | Önceden açılmış PDF-dokümanını Xps-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTeX](./convert/savetex/) | Önceden açılmış PDF-dokümanını TeX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveEpub](./convert/saveepub/) | Önceden açılmış PDF-dokümanını Epub-dokümanı olarak dönüştür ve kaydet. |
+| [SaveBooklet](./convert/savebooklet/) | Önceden açılmış PDF-dokümanını kitapçık PDF-dokümanı olarak dönüştür ve kaydet. |
+| [SaveNUp](./convert/savenup/) | Önceden açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştür ve kaydet. |
+| [SaveMarkdown](./convert/savemarkdown/) | Önceden açılmış PDF-dokümanını Markdown-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTiff](./convert/savetiff/) | Önceden açılmış PDF-dokümanını Tiff-dokümanı olarak dönüştür ve kaydet. |
+| [SaveDocXEnhanced](./convert/savedocxenhanced/) | Önceden açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DocX-dokümanı olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar). |
+| [SaveSvgZip](./convert/savesvgzip/) | Önceden açılmış PDF-dokümanını SVG arşivi olarak dönüştür ve kaydet. |
+| [ExportFdf](./convert/exportfdf/) | AcroForm içeren önceden açılmış PDF-dokümanını FDF-dokümanına dışa aktar. |
+| [ExportXfdf](./convert/exportxfdf/) | AcroForm içeren önceden açılmış PDF-dokümanını XFDF-dokümanına dışa aktar. |
+| [ExportXml](./convert/exportxml/) | AcroForm içeren önceden açılmış PDF-dokümanını XML-dokümanına dışa aktar. |
+| [PageToJpg](./convert/pagetojpg/) | Belirtilen sayfayı Jpg-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToPng](./convert/pagetopng/) | Belirtilen sayfayı Png-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToBmp](./convert/pagetobmp/) | Belirtilen sayfayı Bmp-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToTiff](./convert/pagetotiff/) | Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToSvg](./convert/pagetosvg/) | Belirtilen sayfayı Svg görüntüsü olarak dönüştür ve kaydet. |
+| [PageToPdf](./convert/pagetopdf/) | Belirtilen sayfayı Pdf olarak dönüştür ve kaydet. |
+| [PageToDICOM](./convert/pagetodicom/) | Belirtilen sayfayı DICOM görüntüsü olarak dönüştür ve kaydet. |
+
+
+## Organize PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [Optimize](./organize/optimize/) | PDF belgesi içeriğini optimize et. |
+| [OptimizeResource](./organize/optimizeresource/) | PDF belgesi kaynaklarını optimize et. |
+| [Grayscale](./organize/grayscale/) | PDF belgesini siyah beyaza dönüştür. |
+| [Rotate](./organize/rotate/) | PDF belgesini döndür. |
+| [SetBackground](./organize/setbackground/) | PDF belgesi arka plan rengini ayarla. |
+| [Repair](./organize/repair/) | PDF belgesini onar. |
+| [ReplaceText](./organize/replacetext/) | PDF belgesindeki metni değiştir. |
+| [AddPageNum](./organize/addpagenum/) | PDF belgesine sayfa numarası ekle. |
+| [AddTextHeader](./organize/addtextheader/) | PDF belgesinin üstbilgi kısmına metin ekle. |
+| [AddTextFooter](./organize/addtextfooter/) | PDF belgesinin altbilgi kısmına metin ekle. |
+| [Flatten](./organize/flatten/) | PDF belgesini düzleştir. |
+| [RemoveAnnotations](./organize/removeannotations/) | PDF belgesinden ek açıklamaları kaldır. |
+| [RemoveAttachments](./organize/removeattachments/) | PDF belgesinden ekleri kaldır. |
+| [RemoveBlankPages](./organize/removeblankpages/) | PDF belgesinden boş sayfaları kaldır. |
+| [RemoveBookmarks](./organize/removebookmarks/) | PDF belgesinden yer imlerini kaldır. |
+| [RemoveHiddenText](./organize/removehiddentext/) | PDF belgesinden gizli metni kaldır. |
+| [RemoveImages](./organize/removeimages/) | PDF belgesinden görüntüleri kaldır. |
+| [RemoveJavaScripts](./organize/removejavascripts/) | PDF belgesinden java script'leri kaldır. |
+| [RemoveTables](./organize/removetables/) | PDF belgesinden tabloları kaldır. |
+| [RemoveWatermarks](./organize/removewatermarks/) | PDF belgesinden filigranları kaldır. |
+| [AddWatermark](./organize/addwatermark/) | PDF belgesine filigran ekle. |
+| [EmbedFonts](./organize/embedfonts/) | PDF belgesine yazı tiplerini göm. |
+| [UnembedFonts](./organize/unembedfonts/) | PDF-document'tan gömülü yazı tiplerini kaldır. |
+| [OptimizeFileSize](./organize/optimizefilesize/) | PDF-document boyutunu görüntü sıkıştırma kalitesiyle optimize et. |
+| [RemoveTextHeaders](./organize/removetextheaders/) | PDF-document'tan metin başlıklarını kaldır. |
+| [RemoveTextFooters](./organize/removetextfooters/) | PDF-document'tan metin altbilgilerini kaldır. |
+| [Crop](./organize/crop/) | PDF-document sayfalarını kırp. |
+| [ReplaceFont](./organize/replacefont/) | PDF-document'taki yazı tipini değiştir. |
+| [Convert](./organize/convert/) | PDF-document'ı belirtilen PDF formatıyla bir PDF-document'a dönüştür. |
+| [Validate](./organize/validate/) | PDF-document'ın PDF formatına uygunluğunu doğrula. |
+| [RemovePdfaCompliance](./organize/removepdfacompliance/) | PDF-document'tan PDF/A uyumluluğunu kaldır. |
+| [RemovePdfUaCompliance](./organize/removepdfuacompliance/) | PDF-document'tan PDF/UA uyumluluğunu kaldır. |
+| [IsPdfaCompliant](./organize/ispdfacompliant/) | PDF-document'ın PDF/A uyumlu olup olmadığını al. |
+| [IsPdfUaCompliant](./organize/ispdfuacompliant/) | PDF-document'ın PDF/UA uyumlu olup olmadığını al. |
+| [PageRotate](./organize/pagerotate/) | Sayfayı döndür. |
+| [PageSetSize](./organize/pagesetsize/) | Sayfanın boyutunu ayarla. |
+| [PageGrayscale](./organize/pagegrayscale/) | Sayfayı siyah beyaza dönüştür. |
+| [PageAddText](./organize/pageaddtext/) | Sayfaya metin ekle. |
+| [PageReplaceText](./organize/pagereplacetext/) | Sayfadaki metni değiştir. |
+| [PageAddPageNum](./organize/pageaddpagenum/) | Sayfaya sayfa numarası ekle. |
+| [PageAddTextHeader](./organize/pageaddtextheader/) | Sayfa başlığına metin ekle. |
+| [PageAddTextFooter](./organize/pageaddtextfooter/) | Sayfa altbilgisine metin ekle. |
+| [PageRemoveAnnotations](./organize/pageremoveannotations/) | Sayfadaki ek açıklamaları kaldır. |
+| [PageRemoveHiddenText](./organize/pageremovehiddentext/) | Sayfadaki gizli metni kaldır. |
+| [PageRemoveImages](./organize/pageremoveimages/) | Sayfadaki görüntüleri kaldır. |
+| [PageRemoveTables](./organize/pageremovetables/) | Sayfadaki tabloları kaldır. |
+| [PageRemoveWatermarks](./organize/pageremovewatermarks/) | Sayfadaki filigranları kaldır. |
+| [PageAddWatermark](./organize/pageaddwatermark/) | Sayfaya filigran ekle. |
+| [PageRemoveTextHeaders](./organize/pageremovetextheaders/) | Sayfadaki metin başlıklarını kaldır. |
+| [PageRemoveTextFooters](./organize/pageremovetextfooters/) | Sayfadaki metin altbilgilerini kaldır. |
+| [PageCrop](./organize/pagecrop/) | Sayfayı kırp. |
+| [PageReplaceFont](./organize/pagereplacefont/) | Sayfadaki yazı tipini değiştir. |
+| [PageMergeLayers](./organize/pagemergelayers/) | Sayfadaki tüm katmanları, belirtilen yeni katman adıyla tek bir katmanda birleştir. |
+| [PageLayers](./organize/pagelayers/) | Sayfadaki katman adlarını al. |
+
+
+## Core PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [New](./core/new/) | Yeni bir PDF-dökümanı oluştur. |
+| [Open](./core/open/) | Dosya adıyla bir PDF-dökümanı aç. |
+| [Save](./core/save/) | Önceden açılmış PDF-dökümanı kaydet. |
+| [SaveAs](./core/saveas/) | Önceden açılmış PDF-dökümanı yeni dosya adıyla kaydet. |
+| [Close](./core/close/) | PDF-dökümanı için ayrılan kaynakları serbest bırak. |
+| [SetLicense](./core/setlicense/) | Dosya adıyla lisansı ayarla. |
+| [ExtractText](./core/extracttext/) | PDF-dökümanının içeriğini düz metin olarak döndür. |
+| [WordCount](./core/wordcount/) | PDF-dökümanındaki kelime sayısını döndür. |
+| [CharacterCount](./core/charactercount/) | PDF-dökümanındaki karakter sayısını döndür. |
+| [Append](./core/append/) | Başka bir PDF-dökümandan sayfaları ekle. |
+| [AppendPages](./core/appendpages/) | Başka bir PDF-dökümandan seçilen sayfaları ekle. |
+| [MergeDocuments](./core/mergedocuments/) | Sağlanan PDF-dökümanları birleştirerek yeni bir PDF-dökümanı oluştur. |
+| [SplitDocument](./core/splitdocument/) | Kaynak PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur. |
+| [Split](./core/split/) | Mevcut PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur. |
+| [SplitAtPage](./core/splitatpage/) | PDF-dökümanını iki yeni PDF-dökümanına böl. |
+| [SplitAt](./core/splitat/) | Mevcut PDF-dökümanını iki yeni PDF-dökümanına böl. |
+| [Bytes](./core/bytes/) | PDF-dökümanının içeriğini bayt dilimi olarak döndür. |
+| [GetMetaInfo](./core/getmetainfo/) | PDF-dökümanının meta bilgi değerini al.. |
+| [SetMetaInfo](./core/setmetainfo/) | PDF-dokümanının meta bilgi değerini ayarla.. |
+| [ClearMetaInfo](./core/clearmetainfo/) | PDF-dokümanının tüm meta bilgi değerlerini temizle.. |
+| [IsLinearized](./core/islinearized/) | Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al. |
+| [PageAdd](./core/pageadd/) | PDF-dokümanına yeni sayfa ekle. |
+| [PageInsert](./core/pageinsert/) | PDF-dokümanında belirtilen konuma yeni sayfa ekle. |
+| [PageDelete](./core/pagedelete/) | PDF-dokümanındaki belirtilen sayfayı sil. |
+| [PageCount](./core/pagecount/) | PDF-dokümanındaki sayfa sayısını döndür. |
+| [PageWordCount](./core/pagewordcount/) | PDF-dokümanındaki belirtilen sayfadaki kelime sayısını döndür. |
+| [PageCharacterCount](./core/pagecharactercount/) | PDF-dokümanındaki belirtilen sayfadaki karakter sayısını döndür. |
+| [PageIsBlank](./core/pageisblank/) | PDF-dokümanındaki sayfanın boş olup olmadığını döndür. |
+
+
+## Security
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [OpenWithPassword](./security/openwithpassword/) | Şifre korumalı PDF-dokümanını aç. |
+| [Encrypt](./security/encrypt/) | PDF-dokümanını şifrele. |
+| [Decrypt](./security/decrypt/) | PDF-dokümanının şifresini çöz. |
+| [SetPermissions](./security/setpermissions/) | PDF-dokümanı için izinleri ayarla. |
+| [GetPermissions](./security/getpermissions/) | PDF-dokümanının mevcut izinlerini al. |
+| [IsEncrypted](./security/isencrypted/) | PDF-dokümanının şifrelenme durumunu al. |
+| [SignPKCS7](./security/signpkcs7/) | PDF-dokümanını PKCS#7 dijital imzalarıyla imzala. |
+| [SignPKCS7Detached](./security/signpkcs7detached/) | PDF-dokümanını PKCS#7 Ayrık dijital imzalarıyla imzala. |
+| [IsSigned](./security/issigned/) | PDF-dokümanının imzalı durumunu al. |
+| [RemoveSigns](./security/removesigns/) | PDF-dokümanından imzaları kaldır. |
+
+
+## Miscellaneous
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [About](./miscellaneous/about/) | C++ üzerinden Aspose.PDF for Go hakkında meta veri bilgilerini döndür. |
+
+
+# Types secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Go via C++.
+```go
+type ProductInfo struct {
+	Product     string `json:"product"`     // Name
+	Family      string `json:"family"`      // Family (e.g., "Aspose.PDF")
+	Version     string `json:"version"`     // Version
+	ReleaseDate string `json:"releasedate"` // Release date in ISO format (YYYY-MM-DD)
+	Producer    string `json:"producer"`    // Producer
+	IsLicensed  bool   `json:"islicensed"`  // License status (true if licensed)
+}
+```
+
+
+# Constants
+
+## Enumeration of possible rotation values.
+```go
+const (
+    RotationNone  int32 = 0 // Non-rotated.
+    RotationOn90  int32 = 1 // Rotated on 90 degrees clockwise.
+    RotationOn180 int32 = 2 // Rotated on 180 degrees.
+    RotationOn270 int32 = 3 // Rotated on 270 degrees clockwise.
+    RotationOn360 int32 = 4 // Rotated on 360 degrees clockwise.
+)
+```
+
+## Enumeration of possible page size values.
+```go
+const (
+    PageSizeA0         int32 = 0  // A0 size.
+    PageSizeA1         int32 = 1  // A1 size.
+    PageSizeA2         int32 = 2  // A2 size.
+    PageSizeA3         int32 = 3  // A3 size.
+    PageSizeA4         int32 = 4  // A4 size.
+    PageSizeA5         int32 = 5  // A5 size.
+    PageSizeA6         int32 = 6  // A6 size.
+    PageSizeB5         int32 = 7  // B5 size.
+    PageSizePageLetter int32 = 8  // PageLetter size.
+    PageSizePageLegal  int32 = 9  // PageLegal size.
+    PageSizePageLedger int32 = 10 // PageLedger size.
+    PageSizeP11x17     int32 = 11 // P11x17 size.
+)
+```
+
+## Enumeration of possible crypto algorithms.
+```go
+type CryptoAlgorithm int32
+const (
+	RC4x40  CryptoAlgorithm = 0 // RC4 with key length 40.
+	RC4x128 CryptoAlgorithm = 1 // RC4 with key length 128.
+	AESx128 CryptoAlgorithm = 2 // AES with key length 128.
+	AESx256 CryptoAlgorithm = 3 // AES with key length 256.
+)
+```
+
+## Enumeration of possible PDF formats.
+```go
+type PdfFormat int32
+const (
+	PDF_A_1A      PdfFormat = iota // Pdf/A-1a format.
+	PDF_A_1B                       // Pdf/A-1b format.
+	PDF_A_2A                       // Pdf/A-2a format.
+	PDF_A_3A                       // Pdf/A-3a format.
+	PDF_A_2B                       // Pdf/A-2b format.
+	PDF_A_2U                       // Pdf/A-2u format.
+	PDF_A_3B                       // Pdf/A-3b format.
+	PDF_A_3U                       // Pdf/A-3u format.
+	V_1_0                          // Adobe version 1.0.
+	V_1_1                          // Adobe version 1.1.
+	V_1_2                          // Adobe version 1.2.
+	V_1_3                          // Adobe version 1.3.
+	V_1_4                          // Adobe version 1.4.
+	V_1_5                          // Adobe version 1.5.
+	V_1_6                          // Adobe version 1.6.
+	V_1_7                          // Adobe version 1.7.
+	V_2_0                          // ISO Standard PDF 2.0.
+	PDF_UA_1                       // PDF/UA-1 format.
+	PDF_X_1A_2001                  // PDF/X-1a-2001 format.
+	PDF_X_1A                       // PDF/X-1a format.
+	PDF_X_3                        // PDF/X-3 format.
+	ZUGFeRD                        // ZUGFeRD format.
+	PDF_A_4                        // PDF/A-4 format.
+	PDF_A_4E                       // PDF/A-4e format.
+	PDF_A_4F                       // PDF/A-4f format.
+	PDF_X_4                        // PDF/X-4 format.
+	PDF_E_1                        // PDF/E-1 (PDF 1.6) format.
+)
+```
+
+## Enumeration of possible conversion errors action.
+```go
+type ConvertErrorAction int32
+const (
+	Delete ConvertErrorAction = iota // Delete convert errors.
+	None                             // Do nothing with convert errors.
+)
+```
+
+## Bitflag set representing PDF permission capabilities.
+```go
+type Permissions int32
+const (
+    PrintDocument                  Permissions = 1 << 2  // 4
+    ModifyContent                  Permissions = 1 << 3  // 8
+    ExtractContent                 Permissions = 1 << 4  // 16
+    ModifyTextAnnotations          Permissions = 1 << 5  // 32
+    FillForm                       Permissions = 1 << 8  // 256
+    ExtractContentWithDisabilities Permissions = 1 << 9  // 512
+    AssembleDocument               Permissions = 1 << 10 // 1024
+    PrintingQuality                Permissions = 1 << 11 // 2048
+)
+```

--- a/turkish/go-cpp/convert/_index.md
+++ b/turkish/go-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "PDF'den dönüştürme işlevleri"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF dosyalarından dönüştürme işlevleri."
+type: docs
+url: /tr/go-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [SaveDocX](./savedocx/) | Önceden açılmış PDF-dokümanını DocX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveDoc](./savedoc/) | Önceden açılmış PDF-dokümanını Doc-dokümanı olarak dönüştür ve kaydet. |
+| [SaveXlsX](./savexlsx/) | Önceden açılmış PDF-dokümanını XlsX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTxt](./savetxt/) | Önceden açılmış PDF-dokümanını Txt-dokümanı olarak dönüştür ve kaydet. |
+| [SavePptX](./savepptx/) | Önceden açılmış PDF-dokümanını PptX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveXps](./savexps/) | Önceden açılmış PDF-dokümanını Xps-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTeX](./savetex/) | Önceden açılmış PDF-dokümanını TeX-dokümanı olarak dönüştür ve kaydet. |
+| [SaveEpub](./saveepub/) | Önceden açılmış PDF-dokümanını Epub-dokümanı olarak dönüştür ve kaydet. |
+| [SaveBooklet](./savebooklet/) | Önceden açılmış PDF-dokümanını kitapçık PDF-dokümanı olarak dönüştür ve kaydet. |
+| [SaveNUp](./savenup/) | Önceden açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştür ve kaydet. |
+| [SaveMarkdown](./savemarkdown/) | Önceden açılmış PDF-dokümanını Markdown-dokümanı olarak dönüştür ve kaydet. |
+| [SaveTiff](./savetiff/) | Önceden açılmış PDF-dokümanını Tiff-dokümanı olarak dönüştür ve kaydet. |
+| [SaveDocXEnhanced](./savedocxenhanced/) | Önceden açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DocX-dokümanı olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar). |
+| [SaveSvgZip](./savesvgzip/) | Önceden açılmış PDF-dokümanını SVG arşivi olarak dönüştür ve kaydet. |
+| [ExportFdf](./exportfdf/) | AcroForm içeren önceden açılmış PDF-dokümanını FDF-dokümanına dışa aktar. |
+| [ExportXfdf](./exportxfdf/) | AcroForm içeren önceden açılmış PDF-dokümanını XFDF-dokümanına dışa aktar. |
+| [ExportXml](./exportxml/) | AcroForm içeren önceden açılmış PDF-dokümanını XML-dokümanına dışa aktar. |
+| [PageToJpg](./pagetojpg/) | Belirtilen sayfayı Jpg-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToPng](./pagetopng/) | Belirtilen sayfayı Png-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToBmp](./pagetobmp/) | Belirtilen sayfayı Bmp-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToTiff](./pagetotiff/) | Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet. |
+| [PageToSvg](./pagetosvg/) | Belirtilen sayfayı Svg görüntüsü olarak dönüştür ve kaydet. |
+| [PageToPdf](./pagetopdf/) | Belirtilen sayfayı Pdf olarak dönüştür ve kaydet. |
+| [PageToDICOM](./pagetodicom/) | Belirtilen sayfayı DICOM görüntüsü olarak dönüştür ve kaydet. |
+
+
+## Detailed Description
+
+PDF dosyalarından dönüştürme işlevleri.
+

--- a/turkish/go-cpp/convert/exportfdf/_index.md
+++ b/turkish/go-cpp/convert/exportfdf/_index.md
@@ -1,0 +1,43 @@
+---
+title: "ExportFdf"
+second_title: "Aspose.PDF for Go via C++"
+description: "AcroForm içeren önceden açılmış PDF-dokümanını FDF-dokümanına dışa aktar."
+type: docs
+url: /tr/go-cpp/convert/exportfdf/
+---
+
+_AcroForm ile daha önce açılmış PDF-dokümandan FDF-dokümana dışa aktar._
+
+```go
+func (document *Document) ExportFdf(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ExportFdf(filename string) AcroForm ile daha önce açılmış PDF-dokümandan FDF-dokümana dosya adıyla dışa aktarır
+	err = pdf.ExportFdf("sample.fdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/exportxfdf/_index.md
+++ b/turkish/go-cpp/convert/exportxfdf/_index.md
@@ -1,0 +1,43 @@
+---
+title: "ExportXfdf"
+second_title: "Aspose.PDF for Go via C++"
+description: "AcroForm içeren önceden açılmış PDF-dokümanını XFDF-dokümanına dışa aktar."
+type: docs
+url: /tr/go-cpp/convert/exportxfdf/
+---
+
+_AcroForm içeren daha önce açılmış PDF-belgeden XFDF-belgesine dışa aktar._
+
+```go
+func (document *Document) ExportXfdf(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ExportXfdf(filename string) daha önce açılmış PDF-dokümandan AcroForm ile XFDF-dokümana dosya adıyla dışa aktarır
+	err = pdf.ExportXfdf("sample.xfdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/exportxml/_index.md
+++ b/turkish/go-cpp/convert/exportxml/_index.md
@@ -1,0 +1,43 @@
+---
+title: "ExportXml"
+second_title: "Aspose.PDF for Go via C++"
+description: "AcroForm içeren önceden açılmış PDF-dokümanını XML-dokümanına dışa aktar."
+type: docs
+url: /tr/go-cpp/convert/exportxml/
+---
+
+_AcroForm içeren önceden açılmış PDF-belgesinden XML-belgesine dışa aktar._
+
+```go
+func (document *Document) ExportXml(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ExportXml(filename string) AcroForm içeren önceden açılmış PDF-belgesini dosya adıyla XML-belgesi olarak dışa aktarır
+	err = pdf.ExportXml("sample.xml")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetobmp/_index.md
+++ b/turkish/go-cpp/convert/pagetobmp/_index.md
@@ -1,0 +1,45 @@
+---
+title: "PageToBmp"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Bmp-görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetobmp/
+---
+
+_Belirtilen sayfayı Bmp-görüntüsü olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToBmp(num int32, resolution_dpi int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **resolution_dpi** - resolution in DPI of the resulting file
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToBmp(num int32, resolution_dpi int32, filename string) belirtilen sayfayı Bmp-görüntü dosyası olarak kaydeder
+	err = pdf.PageToBmp(1, 100, "sample_page1.bmp")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetodicom/_index.md
+++ b/turkish/go-cpp/convert/pagetodicom/_index.md
@@ -1,0 +1,45 @@
+---
+title: "PageToDICOM"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı DICOM görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetodicom/
+---
+
+_Belirtilen sayfayı DICOM-görüntüsü olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToDICOM(num int32, resolution_dpi int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **resolution_dpi** - resolution in DPI of the resulting file
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToDICOM(num int32, resolution_dpi int32, filename string) belirtilen sayfayı DICOM-görüntü dosyası olarak kaydeder
+	err = pdf.PageToDICOM(1, 100, "sample_page1.dcm")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetojpg/_index.md
+++ b/turkish/go-cpp/convert/pagetojpg/_index.md
@@ -1,0 +1,45 @@
+---
+title: "PageToJpg"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Jpg-görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetojpg/
+---
+
+_Belirtilen sayfayı Jpg-görüntüsü olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToJpg(num int32, resolution_dpi int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **resolution_dpi** - resolution in DPI of the resulting file
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToJpg(num int32, resolution_dpi int32, filename string) belirtilen sayfayı Jpg-görüntüsü dosyası olarak kaydeder
+	err = pdf.PageToJpg(1, 100, "sample_page1.jpg")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetopdf/_index.md
+++ b/turkish/go-cpp/convert/pagetopdf/_index.md
@@ -1,0 +1,44 @@
+---
+title: "PageToPdf"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Pdf olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetopdf/
+---
+
+_Belirtilen sayfayı Pdf olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToPdf(num int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToPdf(num int32, filename string) belirtilen sayfayı Pdf dosyası olarak kaydeder
+	err = pdf.PageToPdf(1, "sample_page1.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetopng/_index.md
+++ b/turkish/go-cpp/convert/pagetopng/_index.md
@@ -1,0 +1,45 @@
+---
+title: "PageToPng"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Png-görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetopng/
+---
+
+_Belirtilen sayfayı Png resmi olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToPng(num int32, resolution_dpi int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **resolution_dpi** - resolution in DPI of the resulting file
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToPng(num int32, resolution_dpi int32, filename string) belirtilen sayfayı Png resmi dosyası olarak kaydeder
+	err = pdf.PageToPng(1, 100, "sample_page1.png")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetosvg/_index.md
+++ b/turkish/go-cpp/convert/pagetosvg/_index.md
@@ -1,0 +1,44 @@
+---
+title: "PageToSvg"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Svg görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetosvg/
+---
+
+_Belirtilen sayfayı Svg-görüntüsü olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToSvg(num int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToSvg(num int32, filename string) belirtilen sayfayı Svg-görüntü dosyası olarak kaydeder
+	err = pdf.PageToSvg(1, "sample_page1.svg")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/pagetotiff/_index.md
+++ b/turkish/go-cpp/convert/pagetotiff/_index.md
@@ -1,0 +1,45 @@
+---
+title: "PageToTiff"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/pagetotiff/
+---
+
+_Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) PageToTiff(num int32, resolution_dpi int32, filename string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **resolution_dpi** - resolution in DPI of the resulting file
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageToTiff(num int32, resolution_dpi int32, filename string) belirtilen sayfayı Tiff-görüntüsü dosyası olarak kaydeder
+	err = pdf.PageToTiff(1, 100, "sample_page1.tiff")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savebooklet/_index.md
+++ b/turkish/go-cpp/convert/savebooklet/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveBooklet"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını kitapçık PDF-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savebooklet/
+---
+
+_Önceden açılmış PDF-belgesini kitapçık PDF-belgesi olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveBooklet(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveBooklet(filename string) önceden açılmış PDF-belgesini dosya adıyla kitapçık PDF-belgesi olarak kaydeder
+	err = pdf.SaveBooklet("sample_Booklet.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savedoc/_index.md
+++ b/turkish/go-cpp/convert/savedoc/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveDoc"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Doc-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savedoc/
+---
+
+_Daha önce açılmış PDF-dokümanı Doc-dokümanı olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveDoc(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveDoc(filename string) daha önce açılmış PDF-dokümanı Doc-dokümanı olarak dosya adıyla kaydeder
+	err = pdf.SaveDoc("sample.doc")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savedocx/_index.md
+++ b/turkish/go-cpp/convert/savedocx/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveDocX"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını DocX-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savedocx/
+---
+
+_Daha önce açılmış PDF-dokümanı DocX-dokümanı olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveDocX(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveDocX(filename string) daha önce açılmış PDF-dokümanı DocX-dokümanı olarak dosya adıyla kaydeder
+	err = pdf.SaveDocX("sample.docx")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savedocxenhanced/_index.md
+++ b/turkish/go-cpp/convert/savedocxenhanced/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveDocXEnhanced"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DocX-dokümanı olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar)."
+type: docs
+url: /tr/go-cpp/convert/savedocxenhanced/
+---
+
+_Önceden açılmış PDF-belgesini Gelişmiş Tanıma Modu ile DocX-belgesi olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar)._
+
+```go
+func (document *Document) SaveDocXEnhanced(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveDocX(filename string) önceden açılmış PDF-belgesini dosya adıyla Gelişmiş Tanıma Modu DocX-belgesi olarak kaydeder
+	err = pdf.SaveDocXEnhanced("sampleEnhanced.docx")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/saveepub/_index.md
+++ b/turkish/go-cpp/convert/saveepub/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveEpub"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Epub-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/saveepub/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini Epub-belgesi olarak kaydet._
+
+```go
+func (document *Document) SaveEpub(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveEpub(filename string) daha önce açılmış PDF-belgesini Epub-belgesi olarak dosya adıyla kaydeder
+	err = pdf.SaveEpub("sample.epub")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savemarkdown/_index.md
+++ b/turkish/go-cpp/convert/savemarkdown/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveMarkdown"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Markdown-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savemarkdown/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini Markdown-belgesi olarak kaydet._
+
+```go
+func (document *Document) SaveMarkdown(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveMarkdown(filename string) daha önce açılmış PDF-belgesini Markdown-belgesi olarak dosya adıyla kaydeder
+	err = pdf.SaveMarkdown("sample.md")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savenup/_index.md
+++ b/turkish/go-cpp/convert/savenup/_index.md
@@ -1,0 +1,45 @@
+---
+title: "SaveNUp"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savenup/
+---
+
+_Daha önce açılmış PDF-dokümanı N-Up PDF-dokümanı olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveNUp(filename string, columns int32, rows int32) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+  * **columns** - number of columns
+  * **rows** - number of rows
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveNUp(filename string, columns int32, rows int32) daha önce açılmış PDF-dokümanı N-Up PDF-dokümanı olarak dosya adıyla kaydeder
+	err = pdf.SaveNUp("sample_NUp.pdf", 2, 2)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savepptx/_index.md
+++ b/turkish/go-cpp/convert/savepptx/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SavePptX"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını PptX-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savepptx/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini PptX-belgesi olarak kaydet._
+
+```go
+func (document *Document) SavePptX(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SavePptX(filename string) daha önce açılmış PDF-belgesini PptX-belgesi olarak dosya adıyla kaydeder
+	err = pdf.SavePptX("sample.pptx")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savesvgzip/_index.md
+++ b/turkish/go-cpp/convert/savesvgzip/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveSvgZip"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını SVG arşivi olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savesvgzip/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini SVG-arşivi olarak kaydet._
+
+```go
+func (document *Document) SaveSvgZip(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveSvgZip(filename string) daha önce açılmış PDF-belgesini SVG-arşivi olarak dosya adıyla kaydeder
+	err = pdf.SaveSvgZip("sample_svg.zip")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savetex/_index.md
+++ b/turkish/go-cpp/convert/savetex/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveTeX"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını TeX-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savetex/
+---
+
+_Daha önce açılmış PDF-dokümanı TeX-dokümanı olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveTeX(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveTeX(filename string) daha önce açılmış PDF-dokümanı TeX-dokümanı olarak dosya adıyla kaydeder
+	err = pdf.SaveTeX("sample.tex")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savetiff/_index.md
+++ b/turkish/go-cpp/convert/savetiff/_index.md
@@ -1,0 +1,44 @@
+---
+title: "SaveTiff"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Tiff-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savetiff/
+---
+
+_Daha önce açılmış PDF-dokümanı Tiff-dokümanı olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveTiff(filename string, resolution_dpi ...int32) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+  * **resolution_dpi (optional)** - resolution in DPI of the resulting file, defaults to 100 DPI
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // SaveTiff(filename string) daha önce açılmış PDF-dokümanı Tiff-dokümanı olarak dosya adıyla kaydeder
+        err = pdf.SaveTiff("sample.tiff")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/convert/savetxt/_index.md
+++ b/turkish/go-cpp/convert/savetxt/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveTxt"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Txt-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savetxt/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini Txt-belgesi olarak kaydet._
+
+```go
+func (document *Document) SaveTxt(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveTxt(filename string) daha önce açılmış PDF-belgesini Txt-belgesi olarak dosya adıyla kaydeder
+	err = pdf.SaveTxt("sample.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savexlsx/_index.md
+++ b/turkish/go-cpp/convert/savexlsx/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveXlsX"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını XlsX-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savexlsx/
+---
+
+_Önceden açılmış PDF-belgesini XlsX-belgesi olarak dönüştür ve kaydet._
+
+```go
+func (document *Document) SaveXlsX(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveXlsX(filename string) önceden açılmış PDF-belgesini dosya adıyla XlsX-belgesi olarak kaydeder
+	err = pdf.SaveXlsX("sample.xlsx")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/convert/savexps/_index.md
+++ b/turkish/go-cpp/convert/savexps/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveXps"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dokümanını Xps-dokümanı olarak dönüştür ve kaydet."
+type: docs
+url: /tr/go-cpp/convert/savexps/
+---
+
+_Dönüştür ve daha önce açılmış PDF-belgesini Xps-belgesi olarak kaydet._
+
+```go
+func (document *Document) SaveXps(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveXps(filename string) daha önce açılmış PDF-belgesini Xps-belgesi olarak dosya adıyla kaydeder
+	err = pdf.SaveXps("sample.xps")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/_index.md
+++ b/turkish/go-cpp/core/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Temel PDF işlevleri"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF dosyalarıyla çalışmak için temel işlevler."
+type: docs
+url: /tr/go-cpp/core/
+---
+
+## Core PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [New](./new/) | Yeni bir PDF-dökümanı oluştur. |
+| [Open](./open/) | Dosya adıyla bir PDF-dökümanı aç. |
+| [Save](./save/) | Önceden açılmış PDF-dökümanı kaydet. |
+| [SaveAs](./saveas/) | Önceden açılmış PDF-dökümanı yeni dosya adıyla kaydet. |
+| [Close](./close/) | PDF-dökümanı için ayrılan kaynakları serbest bırak. |
+| [SetLicense](./setlicense/) | Dosya adıyla lisansı ayarla. |
+| [ExtractText](./extracttext/) | PDF-dökümanının içeriğini düz metin olarak döndür. |
+| [WordCount](./wordcount/) | PDF-dökümanındaki kelime sayısını döndür. |
+| [CharacterCount](./charactercount/) | PDF-dökümanındaki karakter sayısını döndür. |
+| [Append](./append/) | Başka bir PDF-dökümandan sayfaları ekle. |
+| [AppendPages](./appendpages/) | Başka bir PDF-dökümandan seçilen sayfaları ekle. |
+| [MergeDocuments](./mergedocuments/) | Sağlanan PDF-dökümanları birleştirerek yeni bir PDF-dökümanı oluştur. |
+| [SplitDocument](./splitdocument/) | Kaynak PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur. |
+| [Split](./split/) | Mevcut PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur. |
+| [SplitAtPage](./splitatpage/) | PDF-dökümanını iki yeni PDF-dökümanına böl. |
+| [SplitAt](./splitat/) | Mevcut PDF-dökümanını iki yeni PDF-dökümanına böl. |
+| [Bytes](./bytes/) | PDF-dökümanının içeriğini bayt dilimi olarak döndür. |
+| [GetMetaInfo](./getmetainfo/) | PDF-dökümanının meta bilgi değerini al.. |
+| [SetMetaInfo](./setmetainfo/) | PDF-dokümanının meta bilgi değerini ayarla.. |
+| [ClearMetaInfo](./clearmetainfo/) | PDF-dokümanının tüm meta bilgi değerlerini temizle.. |
+| [IsLinearized](./islinearized/) | Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al. |
+| [PageAdd](./pageadd/) | PDF-dokümanına yeni sayfa ekle. |
+| [PageInsert](./pageinsert/) | PDF-dokümanında belirtilen konuma yeni sayfa ekle. |
+| [PageDelete](./pagedelete/) | PDF-dokümanındaki belirtilen sayfayı sil. |
+| [PageCount](./pagecount/) | PDF-dokümanındaki sayfa sayısını döndür. |
+| [PageWordCount](./pagewordcount/) | PDF-dokümanındaki belirtilen sayfadaki kelime sayısını döndür. |
+| [PageCharacterCount](./pagecharactercount/) | PDF-dokümanındaki belirtilen sayfadaki karakter sayısını döndür. |
+| [PageIsBlank](./pageisblank/) | PDF-dokümanındaki sayfanın boş olup olmadığını döndür. |
+
+
+## Detailed Description
+
+PDF dosyalarıyla çalışmak için temel işlevler.
+

--- a/turkish/go-cpp/core/append/_index.md
+++ b/turkish/go-cpp/core/append/_index.md
@@ -1,0 +1,61 @@
+---
+title: "Append"
+second_title: "Aspose.PDF for Go via C++"
+description: "Başka bir PDF-dökümandan sayfaları ekle."
+type: docs
+url: /tr/go-cpp/core/append/
+---
+
+_Başka bir PDF belgesinden sayfaları ekle._
+
+```go
+func (document *Document) Append(anotherdocument *Document) error
+```
+
+**Parameters**: 
+  * **anotherdocument** - reference to PDF-document instance
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// Open(filename string) belirtilen dosya adıyla başka bir PDF belgesini açar
+	anotherpdf, err := asposepdf.Open("sample1page.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer anotherpdf.Close()
+
+	// Append(anotherdocument *Document) başka bir PDF belgesinden sayfaları ekler.
+	err = pdf.Append(anotherpdf)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Append.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/appendpages/_index.md
+++ b/turkish/go-cpp/core/appendpages/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AppendPages"
+second_title: "Aspose.PDF for Go via C++"
+description: "Başka bir PDF-dökümandan seçilen sayfaları ekle."
+type: docs
+url: /tr/go-cpp/core/appendpages/
+---
+
+_Başka bir PDF-dokümanından seçilen sayfaları ekle._
+
+```go
+func (document *Document) AppendPages(anotherdocument *Document, pagerange string) error
+```
+
+**Parameters**: 
+  * **anotherdocument** - reference to PDF-document instance
+  * **pagerange** - string that specifies which pages to append. Supports individual pages, ranges, and open-ended intervals. For example: "1,3,5", "2-4", "-3", "4-", or "-" for all pages
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample1page.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Open(filename string) belirtilen dosya adıyla başka bir PDF belgesini açar
+	anotherpdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer anotherpdf.Close()
+	// AppendPages(anotherdocument *Document, pagerange string) başka bir PDF-dokümanından belirli sayfaları ekler.
+	err = pdf.AppendPages(anotherpdf, "1,3")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_AppendPages.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/bytes/_index.md
+++ b/turkish/go-cpp/core/bytes/_index.md
@@ -1,0 +1,52 @@
+---
+title: "Bytes"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanının içeriğini bayt dilimi olarak döndür."
+type: docs
+url: /tr/go-cpp/core/bytes/
+---
+
+_PDF-belgesinin içeriğini bir bayt dilimi olarak döndür._
+
+```go
+func (document *Document) Bytes() ([]byte, error)
+```
+
+**Parameters**: 
+
+**Return**:
+  * **\[\]byte** - raw bytes of the PDF-document
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+        "github.com/aspose-pdf/aspose-pdf-go-cpp"
+        "log"
+        "os"
+)
+
+func main() {
+        // New yeni bir PDF belgesi oluşturur
+        pdf, err := asposepdf.New()
+        if err != nil {
+                log.Fatal(err)
+        }
+        defer pdf.Close()
+
+        // Bytes PDF-belgesinin içeriğini bir bayt dilimi olarak döndürür
+        bytes, err := pdf.Bytes()
+        if err != nil {
+                log.Fatal(err)
+        }
+
+        // Bayt dilimini bir dosyaya kaydet.
+        err = os.WriteFile("sample_Bytes.pdf", bytes, 0644)
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/core/charactercount/_index.md
+++ b/turkish/go-cpp/core/charactercount/_index.md
@@ -1,0 +1,46 @@
+---
+title: "CharacterCount"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanındaki karakter sayısını döndür."
+type: docs
+url: /tr/go-cpp/core/charactercount/
+---
+
+_PDF belgesindeki karakter sayısını döndür._
+
+```go
+func (document *Document) CharacterCount() (int32, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **int32** - character count of the PDF-document
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// CharacterCount() PDF belgesindeki karakter sayısını döndürür
+	character_count, err := pdf.CharacterCount()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Character count:", character_count)
+}
+```

--- a/turkish/go-cpp/core/clearmetainfo/_index.md
+++ b/turkish/go-cpp/core/clearmetainfo/_index.md
@@ -1,0 +1,47 @@
+---
+title: "ClearMetaInfo"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanının tüm meta bilgi değerlerini temizle."
+type: docs
+url: /tr/go-cpp/core/clearmetainfo/
+---
+
+_PDF-dokümanının tüm meta bilgi değerlerini temizle._
+
+```go
+func (document *Document) ClearMetaInfo() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ClearMetaInfo() PDF-dokümanının tüm meta bilgi değerlerini temizler
+	err = pdf.ClearMetaInfo()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_ClearMetaInfo.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/close/_index.md
+++ b/turkish/go-cpp/core/close/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Kapat"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanı için ayrılan kaynakları serbest bırak."
+type: docs
+url: /tr/go-cpp/core/close/
+---
+
+_PDF-document için ayrılan kaynakları serbest bırak._
+
+```go
+func (document *Document) Close() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_New_SaveAs.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/extracttext/_index.md
+++ b/turkish/go-cpp/core/extracttext/_index.md
@@ -1,0 +1,46 @@
+---
+title: "ExtractText"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanının içeriğini düz metin olarak döndür."
+type: docs
+url: /tr/go-cpp/core/extracttext/
+---
+
+_PDF-document içeriğini düz metin olarak döndür._
+
+```go
+func (document *Document) ExtractText() (string, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **string** - PDF-document contents as plain text
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ExtractText() PDF-document içeriğini düz metin olarak döndürür
+	txt, err := pdf.ExtractText()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Extracted text:\n", txt)
+}
+```

--- a/turkish/go-cpp/core/getmetainfo/_index.md
+++ b/turkish/go-cpp/core/getmetainfo/_index.md
@@ -1,0 +1,47 @@
+---
+title: "GetMetaInfo"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'in meta bilgi değerini al."
+type: docs
+url: /tr/go-cpp/core/getmetainfo/
+---
+
+_PDF-document'in meta bilgi değerini al._
+
+```go
+func (document *Document) GetMetaInfo(key string) (string, error)
+```
+
+**Parameters**: 
+  * **key** - key whose value to get
+
+**Return**: 
+  * **string** - value associated with the specified key
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// GetMetaInfo(key string) PDF-document'in meta bilgi değerini alır
+	value, err := pdf.GetMetaInfo("Author")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Author: ", value)
+}
+```

--- a/turkish/go-cpp/core/islinearized/_index.md
+++ b/turkish/go-cpp/core/islinearized/_index.md
@@ -1,0 +1,46 @@
+---
+title: "IsLinearized"
+second_title: "Aspose.PDF for Go via C++"
+description: "Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al."
+type: docs
+url: /tr/go-cpp/core/islinearized/
+---
+
+_Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al._
+
+```go
+func (document *Document) IsLinearized() (bool, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **bool** - the document is linearized
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// IsLinearized() belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer alır
+	isLinearized, _ := pdf.IsLinearized()
+	if isLinearized {
+		fmt.Println("IsLinearized() is true")
+	} else {
+		fmt.Println("IsLinearized() is false")
+	}
+}
+```

--- a/turkish/go-cpp/core/mergedocuments/_index.md
+++ b/turkish/go-cpp/core/mergedocuments/_index.md
@@ -1,0 +1,62 @@
+---
+title: "MergeDocuments"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sağlanan PDF-dökümanları birleştirerek yeni bir PDF-dökümanı oluştur."
+type: docs
+url: /tr/go-cpp/core/mergedocuments/
+---
+
+_Sağlanan PDF-belgelerini birleştirerek yeni bir PDF-belgesi oluştur._
+
+```go
+func MergeDocuments(documents []*Document) (*Document, error)
+```
+
+**Parameters**: 
+  * **documents** - slice of PDF-documents to be merged
+
+**Return**: 
+  * **\*Document** - new PDF-document containing all pages from the provided PDF-documents
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf1, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf1.Close()
+	err = pdf1.PageAdd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf2, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf2.Close()
+	// MergeDocuments(documents []*Document) sağlanan belgeleri birleştirerek yeni bir PDF-belgesi oluşturur.
+	pdf_merged, err := asposepdf.MergeDocuments([]*asposepdf.Document{pdf1, pdf2})
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf_merged.Close()
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf_merged.SaveAs("sample_MergeDocuments.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/new/_index.md
+++ b/turkish/go-cpp/core/new/_index.md
@@ -1,0 +1,43 @@
+---
+title: "New"
+second_title: "Aspose.PDF for Go via C++"
+description: "Yeni bir PDF-dökümanı oluştur."
+type: docs
+url: /tr/go-cpp/core/new/
+---
+
+_Yeni bir PDF-belgesi oluştur._
+
+```go
+func New() (*Document, error)
+```
+
+**Parameters**: 
+
+**Return**:
+  * **\*Document** - pointer to document
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_New_SaveAs.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/open/_index.md
+++ b/turkish/go-cpp/core/open/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Aç"
+second_title: "Aspose.PDF for Go via C++"
+description: "Dosya adıyla bir PDF-dökümanı aç."
+type: docs
+url: /tr/go-cpp/core/open/
+---
+
+_PDF-dokümanını dosya adıyla aç._
+
+```go
+func Open(filename string) (*Document, error)
+```
+
+**Parameters**: 
+  * **\*Document** - pointer to document
+  * **filename** - full file name of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/pageadd/_index.md
+++ b/turkish/go-cpp/core/pageadd/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PageAdd"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanına yeni sayfa ekle."
+type: docs
+url: /tr/go-cpp/core/pageadd/
+---
+
+_PDF-document'e yeni sayfa ekle._
+
+```go
+func (document *Document) PageAdd() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageAdd() PDF-document'e yeni sayfa ekler
+	err = pdf.PageAdd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/pagecharactercount/_index.md
+++ b/turkish/go-cpp/core/pagecharactercount/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PageCharacterCount"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanındaki belirtilen sayfadaki karakter sayısını döndür."
+type: docs
+url: /tr/go-cpp/core/pagecharactercount/
+---
+
+_PDF-document'taki belirtilen sayfada karakter sayısını döndür._
+
+```go
+func (document *Document) PageCharacterCount(num int32) (int32, error)
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **int32** - character count on the page
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageCharacterCount(num int32) belirtilen sayfadaki karakter sayısını PDF-document içinde döndürür.
+	page_character_count, err := pdf.PageCharacterCount(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Character count on the first page:", page_character_count)
+}
+```

--- a/turkish/go-cpp/core/pagecount/_index.md
+++ b/turkish/go-cpp/core/pagecount/_index.md
@@ -1,0 +1,46 @@
+---
+title: "PageCount"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanındaki sayfa sayısını döndür."
+type: docs
+url: /tr/go-cpp/core/pagecount/
+---
+
+_PDF belgesindeki sayfa sayısını döndür._
+
+```go
+func (document *Document) PageCount() (int32, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **int32** - page count of the PDF-document
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageCount() PDF belgesindeki sayfa sayısını döndürür
+	count, err := pdf.PageCount()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Count:", count)
+}
+```

--- a/turkish/go-cpp/core/pagedelete/_index.md
+++ b/turkish/go-cpp/core/pagedelete/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageDelete"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanındaki belirtilen sayfayı sil."
+type: docs
+url: /tr/go-cpp/core/pagedelete/
+---
+
+_PDF belgesindeki belirtilen sayfayı sil._
+
+```go
+func (document *Document) PageDelete(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageDelete(num int32) PDF belgesindeki belirtilen sayfayı siler
+	err = pdf.PageDelete(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/pageinsert/_index.md
+++ b/turkish/go-cpp/core/pageinsert/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageInsert"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanında belirtilen konuma yeni sayfa ekle."
+type: docs
+url: /tr/go-cpp/core/pageinsert/
+---
+
+_PDF-belgesinde belirtilen konuma yeni bir sayfa ekle._
+
+```go
+func (document *Document) PageInsert(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageInsert(num int32) PDF-belgesinde belirtilen konuma yeni bir sayfa ekler
+	err = pdf.PageInsert(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/pageisblank/_index.md
+++ b/turkish/go-cpp/core/pageisblank/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PageIsBlank"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanındaki sayfanın boş olup olmadığını döndür."
+type: docs
+url: /tr/go-cpp/core/pageisblank/
+---
+
+_PDF-belgesindeki sayfanın boş olduğunu döndür._
+
+```go
+func (document *Document) PageIsBlank(num int32) (bool, error)
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **bool** - the page is blank
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageIsBlank(num int32) PDF-belgesindeki sayfanın boş olduğunu döndürür.
+	page_is_blank, err := pdf.PageIsBlank(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("The first page is blank?:", page_is_blank == true)
+}
+```

--- a/turkish/go-cpp/core/pagewordcount/_index.md
+++ b/turkish/go-cpp/core/pagewordcount/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PageWordCount"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanındaki belirtilen sayfadaki kelime sayısını döndür."
+type: docs
+url: /tr/go-cpp/core/pagewordcount/
+---
+
+_PDF-document'taki belirtilen sayfada kelime sayısını döndür._
+
+```go
+func (document *Document) PageWordCount(num int32) (int32, error)
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **int32** - word count on the page
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageWordCount(num int32) belirtilen sayfadaki kelime sayısını PDF-document içinde döndürür.
+	page_word_count, err := pdf.PageWordCount(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Word count on the first page:", page_word_count)
+}
+```

--- a/turkish/go-cpp/core/save/_index.md
+++ b/turkish/go-cpp/core/save/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Kaydet"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dökümanı kaydet."
+type: docs
+url: /tr/go-cpp/core/save/
+---
+
+_Daha önce açılmış PDF-document'i kaydet._
+
+```go
+func (document *Document) Save() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/saveas/_index.md
+++ b/turkish/go-cpp/core/saveas/_index.md
@@ -1,0 +1,43 @@
+---
+title: "SaveAs"
+second_title: "Aspose.PDF for Go via C++"
+description: "Önceden açılmış PDF-dökümanı yeni dosya adıyla kaydet."
+type: docs
+url: /tr/go-cpp/core/saveas/
+---
+
+_Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet._
+
+```go
+func (document *Document) SaveAs(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_New_SaveAs.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/setlicense/_index.md
+++ b/turkish/go-cpp/core/setlicense/_index.md
@@ -1,0 +1,45 @@
+---
+title: "SetLicense"
+second_title: "Aspose.PDF for Go via C++"
+description: "Dosya adıyla lisansı ayarla."
+type: docs
+url: /tr/go-cpp/core/setlicense/
+---
+
+_Lisansı dosya adıyla ayarla._
+
+```go
+func (document *Document) SetLicense(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - full name of the license file
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SetLicense(filename string) lisansları dosya adıyla ayarlar
+	err = pdf.SetLicense("Aspose.PDF.GoViaCPP.lic")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// PDF-dokümanıyla çalışmak
+	// ...
+}
+```

--- a/turkish/go-cpp/core/setmetainfo/_index.md
+++ b/turkish/go-cpp/core/setmetainfo/_index.md
@@ -1,0 +1,49 @@
+---
+title: "SetMetaInfo"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanının meta bilgi değerini ayarla."
+type: docs
+url: /tr/go-cpp/core/setmetainfo/
+---
+
+_PDF-dokümanının meta bilgi değerini ayarla._
+
+```go
+func (document *Document) SetMetaInfo(key, value string) error
+```
+
+**Parameters**: 
+  * **key** - key whose value to set
+  * **value** - value to be set
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SetMetaInfo(key, value string) PDF-dokümanının meta bilgi değerini ayarlar
+	err = pdf.SetMetaInfo("Author", "Aspose")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_SetMetaInfo.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/split/_index.md
+++ b/turkish/go-cpp/core/split/_index.md
@@ -1,0 +1,59 @@
+---
+title: "Split"
+second_title: "Aspose.PDF for Go via C++"
+description: "Mevcut PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur."
+type: docs
+url: /tr/go-cpp/core/split/
+---
+
+_Mevcut PDF-document'tan sayfalar çıkararak birden fazla yeni PDF-document oluştur._
+
+```go
+func (document *Document) Split(pagerange string) ([]*Document, error)
+```
+
+**Parameters**: 
+  * **pagerange** - string that defines how to split the PDF-document. Each segment, separated by `;`, specifies the page range for a separate output PDF document. The page range syntax supports individual pages, ranges, and open-ended intervals. For example: "1,3,5;7-10", "-3;4-", or "1;2-3;5-"
+
+**Return**: 
+  * **[]\*Document** - slice of new PDF-documents, each containing the pages defined by a corresponding segment of the specified page range
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf_split, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf_split.Close()
+
+	// Split(pagerange string) mevcut PDF-document'tan sayfalar çıkararak birden fazla yeni PDF-document oluşturur
+	pdfs, err := pdf_split.Split("1-2;3;4-")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Her bölünmüş PDF-document'i ayrı bir dosya olarak kaydet
+	for i, pdf := range pdfs {
+		defer pdf.Close()
+		filename := fmt.Sprintf("sample_Split_part%d.pdf", i+1)
+		// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+		err := pdf.SaveAs(filename)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+```

--- a/turkish/go-cpp/core/splitat/_index.md
+++ b/turkish/go-cpp/core/splitat/_index.md
@@ -1,0 +1,61 @@
+---
+title: "SplitAt"
+second_title: "Aspose.PDF for Go via C++"
+description: "Mevcut PDF-dökümanını iki yeni PDF-dökümanına böl."
+type: docs
+url: /tr/go-cpp/core/splitat/
+---
+
+_Mevcut PDF-dokümanını iki yeni PDF-dokümanına böl._
+
+```go
+func (document *Document) SplitAt(page int) (*Document, *Document, error)
+```
+
+**Parameters**: 
+  * **page** - page number at which to split the PDF-document. Pages up to and including this page go into the first PDF-document
+
+**Return**: 
+  * **\*Document** - new PDF-document containing pages 1 to page (inclusive)
+  * **\*Document** - new PDF-document containing pages from page + 1 to the end
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf_split, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf_split.Close()
+
+	// SplitAt(page int) mevcut PDF-dokümanını iki yeni PDF-dokümanına böler.
+	left, right, err := pdf_split.SplitAt(2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() sonuçlanan PDF-dokümanları için tahsis edilen kaynakları serbest bırakır
+	defer left.Close()
+	defer right.Close()
+
+	// Her bölümü ayrı bir dosya olarak kaydet
+	err = left.SaveAs("sample_SplitAt_left.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = right.SaveAs("sample_SplitAt_right.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/splitatpage/_index.md
+++ b/turkish/go-cpp/core/splitatpage/_index.md
@@ -1,0 +1,62 @@
+---
+title: "SplitAtPage"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanını iki yeni PDF-dökümanına böl."
+type: docs
+url: /tr/go-cpp/core/splitatpage/
+---
+
+_PDF-belgesini iki yeni PDF-belgesine böl._
+
+```go
+func SplitAtPage(document *Document, page int) (*Document, *Document, error)
+```
+
+**Parameters**: 
+  * **document** - pointer to document
+  * **page** - page number at which to split the PDF-document. Pages up to and including this page go into the first PDF-document
+
+**Return**: 
+  * **\*Document** - new PDF-document containing pages 1 to page (inclusive)
+  * **\*Document** - new PDF-document containing pages from page + 1 to the end
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf_split, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf_split.Close()
+
+	// SplitAtPage(document *Document, page int) iki yeni PDF-belgesi oluşturur
+	left, right, err := asposepdf.SplitAtPage(pdf_split, 2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() sonuçlanan PDF-dokümanları için tahsis edilen kaynakları serbest bırakır
+	defer left.Close()
+	defer right.Close()
+
+	// Her bölümü ayrı bir dosya olarak kaydet
+	err = left.SaveAs("sample_SplitAtPage_left.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = right.SaveAs("sample_SplitAtPage_right.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/core/splitdocument/_index.md
+++ b/turkish/go-cpp/core/splitdocument/_index.md
@@ -1,0 +1,60 @@
+---
+title: "SplitDocument"
+second_title: "Aspose.PDF for Go via C++"
+description: "Kaynak PDF-dökümanından sayfaları çıkararak birden fazla yeni PDF-dökümanı oluştur."
+type: docs
+url: /tr/go-cpp/core/splitdocument/
+---
+
+_Kaynak PDF-belgesinden sayfalar çıkararak birden fazla yeni PDF-belgesi oluştur._
+
+```go
+func SplitDocument(document *Document, pagerange string) ([]*Document, error)
+```
+
+**Parameters**: 
+  * **document** - pointer to document
+  * **pagerange** - string that defines how to split the PDF-document. Each segment, separated by `;`, specifies the page range for a separate output PDF document. The page range syntax supports individual pages, ranges, and open-ended intervals. For example: "1,3,5;7-10", "-3;4-", or "1;2-3;5-"
+
+**Return**: 
+  * **[]\*Document** - slice of new PDF-documents, each containing the pages defined by a corresponding segment of the specified page range
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf_split, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf_split.Close()
+
+	// SplitDocument(document *Document, pagerange string) birden fazla yeni PDF-belgesi oluşturur
+	pdfs, err := asposepdf.SplitDocument(pdf_split, "1-2;3;4-")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Her bölünmüş PDF-document'i ayrı bir dosya olarak kaydet
+	for i, pdf := range pdfs {
+		defer pdf.Close()
+		filename := fmt.Sprintf("sample_SplitDocument_part%d.pdf", i+1)
+		// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+		err := pdf.SaveAs(filename)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+```

--- a/turkish/go-cpp/core/wordcount/_index.md
+++ b/turkish/go-cpp/core/wordcount/_index.md
@@ -1,0 +1,46 @@
+---
+title: "WordCount"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanındaki kelime sayısını döndür."
+type: docs
+url: /tr/go-cpp/core/wordcount/
+---
+
+_PDF-dokümanındaki kelime sayısını döndür._
+
+```go
+func (document *Document) WordCount() (int32, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **int32** - word count of the PDF-document
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// WordCount() PDF-dokümanındaki kelime sayısını döndürür
+	word_count, err := pdf.WordCount()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Word count:", word_count)
+}
+```

--- a/turkish/go-cpp/miscellaneous/_index.md
+++ b/turkish/go-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Çeşitli işlevler"
+second_title: "Aspose.PDF for Go via C++"
+description: "Çalışmak için çeşitli işlevler."
+type: docs
+url: /tr/go-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [About](./about/) | C++ üzerinden Aspose.PDF for Go hakkında meta veri bilgilerini döndür. |
+
+
+## Detailed Description
+
+Çalışmak için çeşitli işlevler.
+

--- a/turkish/go-cpp/miscellaneous/about/_index.md
+++ b/turkish/go-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,62 @@
+---
+title: "Hakkında"
+second_title: "Aspose.PDF for Go via C++"
+description: "C++ üzerinden Aspose.PDF for Go hakkında meta veri bilgilerini döndür."
+type: docs
+url: /tr/go-cpp/miscellaneous/about/
+---
+
+_Aspose.PDF for Go via C++ hakkında meta veri bilgilerini döndür._
+
+```go
+func (document *Document) About() (*ProductInfo, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **ProductInfo** - struct, includes product name, version, release date, licensing status, and related details
+```go
+type ProductInfo struct {
+	Product     string `json:"product"`     // Name
+	Family      string `json:"family"`      // Family (e.g., "Aspose.PDF")
+	Version     string `json:"version"`     // Version
+	ReleaseDate string `json:"releasedate"` // Release date in ISO format (YYYY-MM-DD)
+	Producer    string `json:"producer"`    // Producer
+	IsLicensed  bool   `json:"islicensed"`  // License status (true if licensed)
+}
+```
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// About() Aspose.PDF for Go via C++ hakkında meta veri bilgilerini döndürür
+	info, err := pdf.About()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print
+	fmt.Println("Aspose.PDF Product Info:")
+	fmt.Println("  Product:     ", info.Product)
+	fmt.Println("  Family:      ", info.Family)
+	fmt.Println("  Version:     ", info.Version)
+	fmt.Println("  ReleaseDate: ", info.ReleaseDate)
+	fmt.Println("  Producer:    ", info.Producer)
+	fmt.Println("  IsLicensed:  ", info.IsLicensed)
+}
+```

--- a/turkish/go-cpp/organize/_index.md
+++ b/turkish/go-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PDF işlevlerini düzenleme"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF dosyalarını düzenlemek için işlevler."
+type: docs
+url: /tr/go-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [Optimize](./optimize/) | PDF belgesi içeriğini optimize et. |
+| [OptimizeResource](./optimizeresource/) | PDF belgesi kaynaklarını optimize et. |
+| [Grayscale](./grayscale/) | PDF belgesini siyah beyaza dönüştür. |
+| [Rotate](./rotate/) | PDF belgesini döndür. |
+| [SetBackground](./setbackground/) | PDF belgesi arka plan rengini ayarla. |
+| [Repair](./repair/) | PDF belgesini onar. |
+| [ReplaceText](./replacetext/) | PDF belgesindeki metni değiştir. |
+| [AddPageNum](./addpagenum/) | PDF belgesine sayfa numarası ekle. |
+| [AddTextHeader](./addtextheader/) | PDF belgesinin üstbilgi kısmına metin ekle. |
+| [AddTextFooter](./addtextfooter/) | PDF belgesinin altbilgi kısmına metin ekle. |
+| [Flatten](./flatten/) | PDF belgesini düzleştir. |
+| [RemoveAnnotations](./removeannotations/) | PDF belgesinden ek açıklamaları kaldır. |
+| [RemoveAttachments](./removeattachments/) | PDF belgesinden ekleri kaldır. |
+| [RemoveBlankPages](./removeblankpages/) | PDF belgesinden boş sayfaları kaldır. |
+| [RemoveBookmarks](./removebookmarks/) | PDF belgesinden yer imlerini kaldır. |
+| [RemoveHiddenText](./removehiddentext/) | PDF belgesinden gizli metni kaldır. |
+| [RemoveImages](./removeimages/) | PDF belgesinden görüntüleri kaldır. |
+| [RemoveJavaScripts](./removejavascripts/) | PDF belgesinden java script'leri kaldır. |
+| [RemoveTables](./removetables/) | PDF belgesinden tabloları kaldır. |
+| [RemoveWatermarks](./removewatermarks/) | PDF belgesinden filigranları kaldır. |
+| [AddWatermark](./addwatermark/) | PDF belgesine filigran ekle. |
+| [EmbedFonts](./embedfonts/) | PDF belgesine yazı tiplerini göm. |
+| [UnembedFonts](./unembedfonts/) | PDF-document'tan gömülü yazı tiplerini kaldır. |
+| [OptimizeFileSize](./optimizefilesize/) | PDF-document boyutunu görüntü sıkıştırma kalitesiyle optimize et. |
+| [RemoveTextHeaders](./removetextheaders/) | PDF-document'tan metin başlıklarını kaldır. |
+| [RemoveTextFooters](./removetextfooters/) | PDF-document'tan metin altbilgilerini kaldır. |
+| [Crop](./crop/) | PDF-document sayfalarını kırp. |
+| [ReplaceFont](./replacefont/) | PDF-document'taki yazı tipini değiştir. |
+| [Convert](./convert/) | PDF-document'ı belirtilen PDF formatıyla bir PDF-document'a dönüştür. |
+| [Validate](./validate/) | PDF-document'ın PDF formatına uygunluğunu doğrula. |
+| [RemovePdfaCompliance](./removepdfacompliance/) | PDF-document'tan PDF/A uyumluluğunu kaldır. |
+| [RemovePdfUaCompliance](./removepdfuacompliance/) | PDF-document'tan PDF/UA uyumluluğunu kaldır. |
+| [IsPdfaCompliant](./ispdfacompliant/) | PDF-document'ın PDF/A uyumlu olup olmadığını al. |
+| [IsPdfUaCompliant](./ispdfuacompliant/) | PDF-document'ın PDF/UA uyumlu olup olmadığını al. |
+| [PageRotate](./pagerotate/) | Sayfayı döndür. |
+| [PageSetSize](./pagesetsize/) | Sayfanın boyutunu ayarla. |
+| [PageGrayscale](./pagegrayscale/) | Sayfayı siyah beyaza dönüştür. |
+| [PageAddText](./pageaddtext/) | Sayfaya metin ekle. |
+| [PageReplaceText](./pagereplacetext/) | Sayfadaki metni değiştir. |
+| [PageAddPageNum](./pageaddpagenum/) | Sayfaya sayfa numarası ekle. |
+| [PageAddTextHeader](./pageaddtextheader/) | Sayfa başlığına metin ekle. |
+| [PageAddTextFooter](./pageaddtextfooter/) | Sayfa altbilgisine metin ekle. |
+| [PageRemoveAnnotations](./pageremoveannotations/) | Sayfadaki ek açıklamaları kaldır. |
+| [PageRemoveHiddenText](./pageremovehiddentext/) | Sayfadaki gizli metni kaldır. |
+| [PageRemoveImages](./pageremoveimages/) | Sayfadaki görüntüleri kaldır. |
+| [PageRemoveTables](./pageremovetables/) | Sayfadaki tabloları kaldır. |
+| [PageRemoveWatermarks](./pageremovewatermarks/) | Sayfadaki filigranları kaldır. |
+| [PageAddWatermark](./pageaddwatermark/) | Sayfaya filigran ekle. |
+| [PageRemoveTextHeaders](./pageremovetextheaders/) | Sayfadaki metin başlıklarını kaldır. |
+| [PageRemoveTextFooters](./pageremovetextfooters/) | Sayfadaki metin altbilgilerini kaldır. |
+| [PageCrop](./pagecrop/) | Sayfayı kırp. |
+| [PageReplaceFont](./pagereplacefont/) | Sayfadaki yazı tipini değiştir. |
+| [PageMergeLayers](./pagemergelayers/) | Sayfadaki tüm katmanları, belirtilen yeni katman adıyla tek bir katmanda birleştir. |
+| [PageLayers](./pagelayers/) | Sayfadaki katman adlarını al. |
+
+
+## Detailed Description
+
+PDF dosyalarını düzenlemek için işlevler.

--- a/turkish/go-cpp/organize/addpagenum/_index.md
+++ b/turkish/go-cpp/organize/addpagenum/_index.md
@@ -1,0 +1,47 @@
+---
+title: "AddPageNum"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesine sayfa numarası ekle."
+type: docs
+url: /tr/go-cpp/organize/addpagenum/
+---
+
+_Bir PDF belgesine sayfa numarası ekle._
+
+```go
+func (document *Document) AddPageNum() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// AddPageNum() bir PDF belgesine sayfa numarası ekler
+	err = pdf.AddPageNum()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_AddPageNum.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/addtextfooter/_index.md
+++ b/turkish/go-cpp/organize/addtextfooter/_index.md
@@ -1,0 +1,48 @@
+---
+title: "AddTextFooter"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinin altbilgi kısmına metin ekle."
+type: docs
+url: /tr/go-cpp/organize/addtextfooter/
+---
+
+_PDF-dokümanının altbilgi kısmına metin ekle._
+
+```go
+func (document *Document) AddTextFooter(footer string) error
+```
+
+**Parameters**: 
+  * **footer** - pages footer
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// AddTextFooter(footer string) PDF belgesinin Altbilgisinde metin ekler
+	err = pdf.AddTextFooter("Footer")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_AddTextFooter.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/addtextheader/_index.md
+++ b/turkish/go-cpp/organize/addtextheader/_index.md
@@ -1,0 +1,48 @@
+---
+title: "AddTextHeader"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinin üstbilgi kısmına metin ekle."
+type: docs
+url: /tr/go-cpp/organize/addtextheader/
+---
+
+_PDF belgesinin başlığına metin ekle._
+
+```go
+func (document *Document) AddTextHeader(header string) error
+```
+
+**Parameters**: 
+  * **header** - pages header
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// AddTextHeader(header string) PDF belgesinin başlığına metin ekler
+	err = pdf.AddTextHeader("Header")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_AddTextHeader.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/addwatermark/_index.md
+++ b/turkish/go-cpp/organize/addwatermark/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AddWatermark"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesine filigran ekle."
+type: docs
+url: /tr/go-cpp/organize/addwatermark/
+---
+
+_PDF-dokümanına filigran ekle._
+
+```go
+func (document *Document) AddWatermark(text string, fontName string, fontSize float64, foregroundColor string, xPosition int32, yPosition int32, rotation int32, isBackground bool, opacity float64) error
+```
+
+**Parameters**: 
+  * **text** - watermark text
+  * **fontName** - font name
+  * **fontSize** - font size
+  * **foregroundColor** - text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **xPosition** - x watermark position
+  * **yPosition** - y watermark position
+  * **rotation** - watermark rotation (0-360)
+  * **isBackground** - background
+  * **opacity** - opacity (decimal)
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // AddWatermark(text string, fontName string, fontSize float64, foregroundColor string, xPosition int32, yPosition int32, rotation int32, isBackground bool, opacity float64) PDF-dokümanına filigran ekler
+        err = pdf.AddWatermark("Watermark", "Arial", 16, "#010101", 100, 100, 45, true, 0.5)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_AddWatermark.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/convert/_index.md
+++ b/turkish/go-cpp/organize/convert/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Convert"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'ı belirtilen PDF formatıyla bir PDF-document'a dönüştür."
+type: docs
+url: /tr/go-cpp/organize/convert/
+---
+
+_Belirtilen PDF formatı ile bir PDF belgesini başka bir PDF belgesine dönüştür._
+
+```go
+func (document *Document) Convert(pdfFormat PdfFormat, action ConvertErrorAction) (bool, string, error)
+```
+
+**Parameters**: 
+  * **pdfFormat** - PDF format:
+```go
+type PdfFormat int32
+const (
+	PDF_A_1A      PdfFormat = iota // Pdf/A-1a format.
+	PDF_A_1B                       // Pdf/A-1b format.
+	PDF_A_2A                       // Pdf/A-2a format.
+	PDF_A_3A                       // Pdf/A-3a format.
+	PDF_A_2B                       // Pdf/A-2b format.
+	PDF_A_2U                       // Pdf/A-2u format.
+	PDF_A_3B                       // Pdf/A-3b format.
+	PDF_A_3U                       // Pdf/A-3u format.
+	V_1_0                          // Adobe version 1.0.
+	V_1_1                          // Adobe version 1.1.
+	V_1_2                          // Adobe version 1.2.
+	V_1_3                          // Adobe version 1.3.
+	V_1_4                          // Adobe version 1.4.
+	V_1_5                          // Adobe version 1.5.
+	V_1_6                          // Adobe version 1.6.
+	V_1_7                          // Adobe version 1.7.
+	V_2_0                          // ISO Standard PDF 2.0.
+	PDF_UA_1                       // PDF/UA-1 format.
+	PDF_X_1A_2001                  // PDF/X-1a-2001 format.
+	PDF_X_1A                       // PDF/X-1a format.
+	PDF_X_3                        // PDF/X-3 format.
+	ZUGFeRD                        // ZUGFeRD format.
+	PDF_A_4                        // PDF/A-4 format.
+	PDF_A_4E                       // PDF/A-4e format.
+	PDF_A_4F                       // PDF/A-4f format.
+	PDF_X_4                        // PDF/X-4 format.
+	PDF_E_1                        // PDF/E-1 (PDF 1.6) format.
+)
+```
+  * **action** - conversion errors action:
+```go
+// Olası dönüşüm hataları eyleminin enumarasyonu.
+type ConvertErrorAction int32
+const (
+	Delete ConvertErrorAction = iota // Delete convert errors.
+	None                             // Do nothing with convert errors.
+)
+```
+
+**Return**: 
+  * **bool** - contains conversion result
+  * **string** - contains conversion log
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// Convert(pdfFormat PdfFormat, action ConvertErrorAction) PDF belgesini PDF/A'ya dönüştürür
+	ok, logStr, err := pdf.Convert(asposepdf.PDF_A_2A, asposepdf.Delete)
+	if err != nil {
+		log.Fatal("Convert PDF/A error:", err)
+	}
+
+	// Dönüşüm sonucunu ve tam günlüğü yazdır
+	fmt.Printf("Convert PDF/A result: %v\n", ok)
+	fmt.Printf("Convert PDF/A log:\n%s\n", logStr)
+
+	// Dönüştürülmüş PDF belgesini kaydet
+	err = pdf.SaveAs("sample_Convert.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/crop/_index.md
+++ b/turkish/go-cpp/organize/crop/_index.md
@@ -1,0 +1,48 @@
+---
+title: "Crop"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document sayfalarını kırp."
+type: docs
+url: /tr/go-cpp/organize/crop/
+---
+
+_PDF-belgenin sayfalarını kırp._
+
+```go
+func (document *Document) Crop(margin float64) error
+```
+
+**Parameters**: 
+  * **margin** - page margin
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // Crop(margin float64) PDF-belgenin sayfalarını kırpar
+        err = pdf.Crop(0)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_Crop.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/embedfonts/_index.md
+++ b/turkish/go-cpp/organize/embedfonts/_index.md
@@ -1,0 +1,47 @@
+---
+title: "EmbedFonts"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesine yazı tiplerini göm."
+type: docs
+url: /tr/go-cpp/organize/embedfonts/
+---
+
+_PDF-dokümanına yazı tiplerini göm._
+
+```go
+func (document *Document) EmbedFonts() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // EmbedFonts() PDF-dokümanına yazı tiplerini gömer
+        err = pdf.EmbedFonts()
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_EmbedFonts.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/flatten/_index.md
+++ b/turkish/go-cpp/organize/flatten/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Flatten"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesini düzleştir."
+type: docs
+url: /tr/go-cpp/organize/flatten/
+---
+
+_PDF-dokümanını düzleştir._
+
+```go
+func (document *Document) Flatten() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Flatten() PDF-dokümanını düzleştirir
+	err = pdf.Flatten()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Flatten.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/grayscale/_index.md
+++ b/turkish/go-cpp/organize/grayscale/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Grayscale"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesini siyah beyaza dönüştür."
+type: docs
+url: /tr/go-cpp/organize/grayscale/
+---
+
+_PDF-dokümanını siyah beyaza dönüştür._
+
+```go
+func (document *Document) Grayscale() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Grayscale() PDF-dokümanını siyah beyaza dönüştürür
+	err = pdf.Grayscale()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Grayscale.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/ispdfacompliant/_index.md
+++ b/turkish/go-cpp/organize/ispdfacompliant/_index.md
@@ -1,0 +1,46 @@
+---
+title: "IsPdfaCompliant"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'ın PDF/A uyumlu olup olmadığını al."
+type: docs
+url: /tr/go-cpp/organize/ispdfacompliant/
+---
+
+_Get PDF-dokümanının PDF/A uyumlu olduğunu al._
+
+```go
+func (document *Document) IsPdfaCompliant() (bool, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **bool** - the document is PDF/A compliant
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// IsPdfaCompliant() PDF-dokümanının PDF/A uyumluluk durumunu alır
+	isPdfa, _ := pdf.IsPdfaCompliant()
+	if isPdfa {
+		fmt.Println("IsPdfaCompliant() is true")
+	} else {
+		fmt.Println("IsPdfaCompliant() is false")
+	}
+}
+```

--- a/turkish/go-cpp/organize/ispdfuacompliant/_index.md
+++ b/turkish/go-cpp/organize/ispdfuacompliant/_index.md
@@ -1,0 +1,46 @@
+---
+title: "IsPdfUaCompliant"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'ın PDF/UA uyumlu olup olmadığını al."
+type: docs
+url: /tr/go-cpp/organize/ispdfuacompliant/
+---
+
+_PDF-belgesi PDF/UA uyumlu._
+
+```go
+func (document *Document) IsPdfUaCompliant() (bool, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **bool** - the document is PDF/UA compliant
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// IsPdfUaCompliant() PDF-belgenin PDF/UA uyumluluk durumunu alır
+	isPdfua, _ := pdf.IsPdfUaCompliant()
+	if isPdfua {
+		fmt.Println("IsPdfUaCompliant() is true")
+	} else {
+		fmt.Println("IsPdfUaCompliant() is false")
+	}
+}
+```

--- a/turkish/go-cpp/organize/optimize/_index.md
+++ b/turkish/go-cpp/organize/optimize/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Optimize"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesi içeriğini optimize et."
+type: docs
+url: /tr/go-cpp/organize/optimize/
+---
+
+_PDF belgesi içeriğini optimize et._
+
+```go
+func (document *Document) Optimize() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Optimize() PDF belgesi içeriğini optimize eder
+	err = pdf.Optimize()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Optimize.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/optimizefilesize/_index.md
+++ b/turkish/go-cpp/organize/optimizefilesize/_index.md
@@ -1,0 +1,48 @@
+---
+title: "OptimizeFileSize"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document boyutunu görüntü sıkıştırma kalitesiyle optimize et."
+type: docs
+url: /tr/go-cpp/organize/optimizefilesize/
+---
+
+_PDF-belgenin boyutunu görüntü sıkıştırma kalitesiyle optimize et._
+
+```go
+func (document *Document) OptimizeFileSize(imageQuality int32) error
+```
+
+**Parameters**: 
+  * **imageQuality** - image compression quality 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // OptimizeFileSize(imageQuality int32) PDF-belgenin boyutunu görüntü sıkıştırma kalitesiyle optimize eder
+        err = pdf.OptimizeFileSize(20)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_OptimizeFileSize.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/optimizeresource/_index.md
+++ b/turkish/go-cpp/organize/optimizeresource/_index.md
@@ -1,0 +1,47 @@
+---
+title: "OptimizeResource"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesi kaynaklarını optimize et."
+type: docs
+url: /tr/go-cpp/organize/optimizeresource/
+---
+
+_PDF-belgenin kaynaklarını optimize et._
+
+```go
+func (document *Document) OptimizeResource() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// OptimizeResource() PDF-belgenin kaynaklarını optimize eder
+	err = pdf.OptimizeResource()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_OptimizeResource.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageaddpagenum/_index.md
+++ b/turkish/go-cpp/organize/pageaddpagenum/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageAddPageNum"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfaya sayfa numarası ekle."
+type: docs
+url: /tr/go-cpp/organize/pageaddpagenum/
+---
+
+_Sayfaya sayfa numarası ekle._
+
+```go
+func (document *Document) PageAddPageNum(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageAddPageNum(num int32) sayfaya sayfa numarası ekler
+	err = pdf.PageAddPageNum(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_AddPageNum.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageaddtext/_index.md
+++ b/turkish/go-cpp/organize/pageaddtext/_index.md
@@ -1,0 +1,49 @@
+---
+title: "PageAddText"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfaya metin ekle."
+type: docs
+url: /tr/go-cpp/organize/pageaddtext/
+---
+
+_Sayfaya metin ekle._
+
+```go
+func (document *Document) PageAddText(num int32, addText string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **addText** - added text
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageAddText(num int32, addText string) sayfaya metin ekler
+	err = pdf.PageAddText(1, "added text")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Save() daha önce açılmış PDF belgesini kaydeder
+	err = pdf.Save()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageaddtextfooter/_index.md
+++ b/turkish/go-cpp/organize/pageaddtextfooter/_index.md
@@ -1,0 +1,49 @@
+---
+title: "PageAddTextFooter"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfa altbilgisine metin ekle."
+type: docs
+url: /tr/go-cpp/organize/pageaddtextfooter/
+---
+
+_Sayfa altbilgi kısmına metin ekle._
+
+```go
+func (document *Document) PageAddTextFooter(num int32, footer string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **footer** - pages footer
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageAddTextFooter(num int32, footer string) sayfa altbilgisinde metin ekler
+	err = pdf.PageAddTextFooter(1, "Footer")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_PageAddTextFooter.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageaddtextheader/_index.md
+++ b/turkish/go-cpp/organize/pageaddtextheader/_index.md
@@ -1,0 +1,49 @@
+---
+title: "PageAddTextHeader"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfa başlığına metin ekle."
+type: docs
+url: /tr/go-cpp/organize/pageaddtextheader/
+---
+
+_Sayfa üstbilgisinde metin ekle._
+
+```go
+func (document *Document) PageAddTextHeader(num int32, header string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **header** - pages header
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageAddTextHeader(num int32, header string) sayfa üstbilgisinde metin ekler
+	err = pdf.PageAddTextHeader(1, "Header")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_PageAddTextHeader.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageaddwatermark/_index.md
+++ b/turkish/go-cpp/organize/pageaddwatermark/_index.md
@@ -1,0 +1,57 @@
+---
+title: "PageAddWatermark"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfaya filigran ekle."
+type: docs
+url: /tr/go-cpp/organize/pageaddwatermark/
+---
+
+_Sayfaya filigran ekle._
+
+```go
+func (document *Document) PageAddWatermark(num int32, text string, fontName string, fontSize float64, foregroundColor string, xPosition int32, yPosition int32, rotation int32, isBackground bool, opacity float64) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **text** - watermark text
+  * **fontName** - font name
+  * **fontSize** - font size
+  * **foregroundColor** - text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **xPosition** - x watermark position
+  * **yPosition** - y watermark position
+  * **rotation** - watermark rotation (0-360)
+  * **isBackground** - background
+  * **opacity** - opacity (decimal)
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageAddWatermark(num int32, text string, fontName string, fontSize float64, foregroundColor string, xPosition int32, yPosition int32, rotation int32, isBackground bool, opacity float64) sayfaya filigran ekler
+        err = pdf.PageAddWatermark(1, "Watermark", "Arial", 16, "#010101", 100, 100, 45, true, 0.5)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_PageAddWatermark.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pagecrop/_index.md
+++ b/turkish/go-cpp/organize/pagecrop/_index.md
@@ -1,0 +1,49 @@
+---
+title: "PageCrop"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfayı kırp."
+type: docs
+url: /tr/go-cpp/organize/pagecrop/
+---
+
+_Sayfayı kırp._
+
+```go
+func (document *Document) PageCrop(num int32, margin float64) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **margin** - page margin
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageCrop(num int32, margin float64) sayfayı kırpar
+        err = pdf.PageCrop(1, 11.3)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_page1_Crop.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pagegrayscale/_index.md
+++ b/turkish/go-cpp/organize/pagegrayscale/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageGrayscale"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfayı siyah beyaza dönüştür."
+type: docs
+url: /tr/go-cpp/organize/pagegrayscale/
+---
+
+_Sayfayı siyah beyaza dönüştür._
+
+```go
+func (document *Document) PageGrayscale(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageGrayscale(num int32) sayfayı siyah beyaza dönüştürür
+	err = pdf.PageGrayscale(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_Grayscale.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pagelayers/_index.md
+++ b/turkish/go-cpp/organize/pagelayers/_index.md
@@ -1,0 +1,53 @@
+---
+title: "PageLayers"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki katman adlarını al."
+type: docs
+url: /tr/go-cpp/organize/pagelayers/
+---
+
+_Sayfadaki katmanların adlarını al._
+
+```go
+func (document *Document) PageLayers(num int32) ([]string, error)
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **[]string** - contains an array layers' names
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample_layers.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// PageLayers(num int32) sayfadaki katmanların adlarını alır
+	layers, err := pdf.PageLayers(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Layers on page 1:")
+	for i, layer := range layers {
+		fmt.Printf("  [%d] %s\n", i, layer)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pagemergelayers/_index.md
+++ b/turkish/go-cpp/organize/pagemergelayers/_index.md
@@ -1,0 +1,49 @@
+---
+title: "PageMergeLayers"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki tüm katmanları, belirtilen yeni katman adıyla tek bir katmanda birleştir."
+type: docs
+url: /tr/go-cpp/organize/pagemergelayers/
+---
+
+_Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmana birleştir._
+
+```go
+func (document *Document) PageMergeLayers(num int32, newLayerName string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **newLayerName** - name of the new layer after merging
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageMergeLayers(num int32, newLayerName string) sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmana birleştirir
+	err = pdf.PageMergeLayers(1, "newLayerName")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_PageMergeLayers.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageremoveannotations/_index.md
+++ b/turkish/go-cpp/organize/pageremoveannotations/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveAnnotations"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki ek açıklamaları kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremoveannotations/
+---
+
+_Sayfada ek açıklamaları kaldır._
+
+```go
+func (document *Document) PageRemoveAnnotations(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageRemoveAnnotations(num int32) sayfada ek açıklamaları kaldırır
+	err = pdf.PageRemoveAnnotations(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_RemoveAnnotations.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageremovehiddentext/_index.md
+++ b/turkish/go-cpp/organize/pageremovehiddentext/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveHiddenText"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki gizli metni kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremovehiddentext/
+---
+
+_Sayfadaki gizli metni kaldır._
+
+```go
+func (document *Document) PageRemoveHiddenText(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageRemoveHiddenText(num int32) sayfadaki gizli metni kaldırır
+	err = pdf.PageRemoveHiddenText(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_RemoveHiddenText.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageremoveimages/_index.md
+++ b/turkish/go-cpp/organize/pageremoveimages/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveImages"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki görüntüleri kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremoveimages/
+---
+
+_Sayfadaki görselleri kaldır._
+
+```go
+func (document *Document) PageRemoveImages(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageRemoveImages(num int32) sayfadaki görselleri kaldırır
+	err = pdf.PageRemoveImages(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_RemoveImages.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageremovetables/_index.md
+++ b/turkish/go-cpp/organize/pageremovetables/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveTables"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki tabloları kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremovetables/
+---
+
+_Sayfadaki tabloları kaldır._
+
+```go
+func (document *Document) PageRemoveTables(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageRemoveTables(num int32) sayfadaki tabloları kaldırır
+	err = pdf.PageRemoveTables(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_RemoveTables.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pageremovetextfooters/_index.md
+++ b/turkish/go-cpp/organize/pageremovetextfooters/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveTextFooters"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki metin altbilgilerini kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremovetextfooters/
+---
+
+_Sayfada metin altbilgilerini kaldır._
+
+```go
+func (document *Document) PageRemoveTextFooters(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageRemoveTextFooters(num int32) sayfada metin altbilgilerini kaldırır
+        err = pdf.PageRemoveTextFooters(1)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_page1_RemoveTextFooters.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pageremovetextheaders/_index.md
+++ b/turkish/go-cpp/organize/pageremovetextheaders/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveTextHeaders"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki metin başlıklarını kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremovetextheaders/
+---
+
+_Sayfadaki metin üstbilgilerini kaldır._
+
+```go
+func (document *Document) PageRemoveTextHeaders(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageRemoveTextHeaders(num int32) sayfadaki metin üstbilgilerini kaldırır
+        err = pdf.PageRemoveTextHeaders(1)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_page1_RemoveTextHeaders.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pageremovewatermarks/_index.md
+++ b/turkish/go-cpp/organize/pageremovewatermarks/_index.md
@@ -1,0 +1,48 @@
+---
+title: "PageRemoveWatermarks"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki filigranları kaldır."
+type: docs
+url: /tr/go-cpp/organize/pageremovewatermarks/
+---
+
+_Sayfadaki filigranları kaldır._
+
+```go
+func (document *Document) PageRemoveWatermarks(num int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageRemoveWatermarks(num int32) sayfadaki filigranları kaldırır
+        err = pdf.PageRemoveWatermarks(1)
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_page1_RemoveWatermarks.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pagereplacefont/_index.md
+++ b/turkish/go-cpp/organize/pagereplacefont/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PageReplaceFont"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki yazı tipini değiştir."
+type: docs
+url: /tr/go-cpp/organize/pagereplacefont/
+---
+
+_Sayfadaki yazı tipini değiştir._
+
+```go
+func (document *Document) PageReplaceFont(num int32, findFontName, replaceFontName string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **findFontName** - font name to search
+  * **replaceFontName** - font name to replace
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // PageReplaceFont(num int32, findFontName, replaceFontName string) sayfadaki yazı tipini değiştirir
+        err = pdf.PageReplaceFont(1, "Times-BoldItalic", "Helvetica-Bold")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_page1_ReplaceFont.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/pagereplacetext/_index.md
+++ b/turkish/go-cpp/organize/pagereplacetext/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PageReplaceText"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfadaki metni değiştir."
+type: docs
+url: /tr/go-cpp/organize/pagereplacetext/
+---
+
+_Sayfadaki metni değiştir._
+
+```go
+func (document *Document) PageReplaceText(num int32, findText, replaceText string) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **findText** - text fragment to search
+  * **replaceText** - text fragment to replace
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageReplaceText(num int32, findText, replaceText string) sayfadaki metni değiştirir
+	err = pdf.PageReplaceText(1, "PDF", "TXT")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_ReplaceText.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pagerotate/_index.md
+++ b/turkish/go-cpp/organize/pagerotate/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PageRotate"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfayı döndür."
+type: docs
+url: /tr/go-cpp/organize/pagerotate/
+---
+
+_Sayfayı döndür._
+
+```go
+func (document *Document) PageRotate(num int32, rotation int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **rotation** - page rotation:
+```go
+const (
+    RotationNone  int32 = 0 // Non-rotated.
+    RotationOn90  int32 = 1 // Rotated on 90 degrees clockwise.
+    RotationOn180 int32 = 2 // Rotated on 180 degrees.
+    RotationOn270 int32 = 3 // Rotated on 270 degrees clockwise.
+    RotationOn360 int32 = 4 // Rotated on 360 degrees clockwise.
+)
+```
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageRotate(num int32, rotation int32) sayfayı döndürür
+	err = pdf.PageRotate(1, asposepdf.RotationOn180)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_Rotate.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/pagesetsize/_index.md
+++ b/turkish/go-cpp/organize/pagesetsize/_index.md
@@ -1,0 +1,65 @@
+---
+title: "PageSetSize"
+second_title: "Aspose.PDF for Go via C++"
+description: "Sayfanın boyutunu ayarla."
+type: docs
+url: /tr/go-cpp/organize/pagesetsize/
+---
+
+_Sayfanın boyutunu ayarla._
+
+```go
+func (document *Document) PageSetSize(num int32, pageSize int32) error
+```
+
+**Parameters**: 
+  * **num** - page number of the PDF-document
+  * **pageSize** - page size:
+```go
+const (
+    PageSizeA0         int32 = 0  // A0 size.
+    PageSizeA1         int32 = 1  // A1 size.
+    PageSizeA2         int32 = 2  // A2 size.
+    PageSizeA3         int32 = 3  // A3 size.
+    PageSizeA4         int32 = 4  // A4 size.
+    PageSizeA5         int32 = 5  // A5 size.
+    PageSizeA6         int32 = 6  // A6 size.
+    PageSizeB5         int32 = 7  // B5 size.
+    PageSizePageLetter int32 = 8  // PageLetter size.
+    PageSizePageLegal  int32 = 9  // PageLegal size.
+    PageSizePageLedger int32 = 10 // PageLedger size.
+    PageSizeP11x17     int32 = 11 // P11x17 size.
+)
+```
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// PageSetSize(num int32, pageSize int32) sayfanın boyutunu ayarlar
+	err = pdf.PageSetSize(1, asposepdf.PageSizeA1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_page1_SetSize_A1.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removeannotations/_index.md
+++ b/turkish/go-cpp/organize/removeannotations/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveAnnotations"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden ek açıklamaları kaldır."
+type: docs
+url: /tr/go-cpp/organize/removeannotations/
+---
+
+_PDF belgesinden ek açıklamaları kaldır._
+
+```go
+func (document *Document) RemoveAnnotations() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveAnnotations() PDF belgesinden ek açıklamaları kaldırır
+	err = pdf.RemoveAnnotations()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveAnnotations.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removeattachments/_index.md
+++ b/turkish/go-cpp/organize/removeattachments/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveAttachments"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden ekleri kaldır."
+type: docs
+url: /tr/go-cpp/organize/removeattachments/
+---
+
+_PDF-dokümanından ekleri kaldır._
+
+```go
+func (document *Document) RemoveAttachments() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveAttachments() PDF-dokümanından ekleri kaldırır
+	err = pdf.RemoveAttachments()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveAttachments.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removeblankpages/_index.md
+++ b/turkish/go-cpp/organize/removeblankpages/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveBlankPages"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden boş sayfaları kaldır."
+type: docs
+url: /tr/go-cpp/organize/removeblankpages/
+---
+
+_PDF-dokümanından boş sayfaları kaldır._
+
+```go
+func (document *Document) RemoveBlankPages() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveBlankPages() PDF-dokümanından boş sayfaları kaldırır
+	err = pdf.RemoveBlankPages()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveBlankPages.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removebookmarks/_index.md
+++ b/turkish/go-cpp/organize/removebookmarks/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveBookmarks"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden yer imlerini kaldır."
+type: docs
+url: /tr/go-cpp/organize/removebookmarks/
+---
+
+_PDF belgesinden yer imlerini kaldır._
+
+```go
+func (document *Document) RemoveBookmarks() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveBookmarks() PDF belgesinden yer imlerini kaldırır
+	err = pdf.RemoveBookmarks()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveBookmarks.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removehiddentext/_index.md
+++ b/turkish/go-cpp/organize/removehiddentext/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveHiddenText"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden gizli metni kaldır."
+type: docs
+url: /tr/go-cpp/organize/removehiddentext/
+---
+
+_PDF-dokümanından gizli metni kaldır._
+
+```go
+func (document *Document) RemoveHiddenText() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveHiddenText() PDF-dokümanından gizli metni kaldırır
+	err = pdf.RemoveHiddenText()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveHiddenText.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removeimages/_index.md
+++ b/turkish/go-cpp/organize/removeimages/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveImages"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden görüntüleri kaldır."
+type: docs
+url: /tr/go-cpp/organize/removeimages/
+---
+
+_PDF-dokümanından görüntüleri kaldır._
+
+```go
+func (document *Document) RemoveImages() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveImages() PDF-dokümanından görüntüleri kaldırır
+	err = pdf.RemoveImages()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveImages.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removejavascripts/_index.md
+++ b/turkish/go-cpp/organize/removejavascripts/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveJavaScripts"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden java script'leri kaldır."
+type: docs
+url: /tr/go-cpp/organize/removejavascripts/
+---
+
+_PDF belgesinden Java betiklerini kaldır._
+
+```go
+func (document *Document) RemoveJavaScripts() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveJavaScripts() PDF belgesinden Java betiklerini kaldırır
+	err = pdf.RemoveJavaScripts()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveJavaScripts.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removepdfacompliance/_index.md
+++ b/turkish/go-cpp/organize/removepdfacompliance/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemovePdfaCompliance"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'tan PDF/A uyumluluğunu kaldır."
+type: docs
+url: /tr/go-cpp/organize/removepdfacompliance/
+---
+
+_Bir PDF-belgeden PDF/A uyumluluğunu kaldır._
+
+```go
+func (document *Document) RemovePdfaCompliance() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemovePdfaCompliance() PDF-belgeden PDF/A uyumluluğunu kaldırır
+	err = pdf.RemovePdfaCompliance()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemovePdfaCompliance.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removepdfuacompliance/_index.md
+++ b/turkish/go-cpp/organize/removepdfuacompliance/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemovePdfUaCompliance"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'tan PDF/UA uyumluluğunu kaldır."
+type: docs
+url: /tr/go-cpp/organize/removepdfuacompliance/
+---
+
+_Bir PDF belgesinden PDF/UA uyumluluğunu kaldır._
+
+```go
+func (document *Document) RemovePdfUaCompliance() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemovePdfUaCompliance() PDF belgesinden PDF/UA uyumluluğunu kaldırır
+	err = pdf.RemovePdfUaCompliance()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemovePdfUaCompliance.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removetables/_index.md
+++ b/turkish/go-cpp/organize/removetables/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveTables"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden tabloları kaldır."
+type: docs
+url: /tr/go-cpp/organize/removetables/
+---
+
+_PDF belgesinden tabloları kaldır._
+
+```go
+func (document *Document) RemoveTables() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveTables() PDF belgesinden tabloları kaldırır
+	err = pdf.RemoveTables()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_RemoveTables.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/removetextfooters/_index.md
+++ b/turkish/go-cpp/organize/removetextfooters/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveTextFooters"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'tan metin altbilgilerini kaldır."
+type: docs
+url: /tr/go-cpp/organize/removetextfooters/
+---
+
+_PDF belgesinden metin altbilgilerini kaldır._
+
+```go
+func (document *Document) RemoveTextFooters() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // RemoveTextFooters() PDF belgesinden metin altbilgilerini kaldırır
+        err = pdf.RemoveTextFooters()
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_RemoveTextFooters.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/removetextheaders/_index.md
+++ b/turkish/go-cpp/organize/removetextheaders/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveTextHeaders"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'tan metin başlıklarını kaldır."
+type: docs
+url: /tr/go-cpp/organize/removetextheaders/
+---
+
+_PDF belgesinden metin başlıklarını kaldır._
+
+```go
+func (document *Document) RemoveTextHeaders() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // RemoveTextHeaders() PDF belgesinden metin başlıklarını kaldırır
+        err = pdf.RemoveTextHeaders()
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_RemoveTextHeaders.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/removewatermarks/_index.md
+++ b/turkish/go-cpp/organize/removewatermarks/_index.md
@@ -1,0 +1,47 @@
+---
+title: "RemoveWatermarks"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesinden filigranları kaldır."
+type: docs
+url: /tr/go-cpp/organize/removewatermarks/
+---
+
+_PDF-belgeden filigranları kaldır._
+
+```go
+func (document *Document) RemoveWatermarks() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // RemoveWatermarks() PDF-belgeden filigranları kaldırır
+        err = pdf.RemoveWatermarks()
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_RemoveWatermarks.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/repair/_index.md
+++ b/turkish/go-cpp/organize/repair/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Repair"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesini onar."
+type: docs
+url: /tr/go-cpp/organize/repair/
+---
+
+_PDF belgesini onar._
+
+```go
+func (document *Document) Repair() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Repair() PDF belgesini onarır
+	err = pdf.Repair()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Repair.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/replacefont/_index.md
+++ b/turkish/go-cpp/organize/replacefont/_index.md
@@ -1,0 +1,49 @@
+---
+title: "ReplaceFont"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'taki yazı tipini değiştir."
+type: docs
+url: /tr/go-cpp/organize/replacefont/
+---
+
+_PDF-dokümanındaki yazı tipini değiştir._
+
+```go
+func (document *Document) ReplaceFont(findFontName, replaceFontName string) error
+```
+
+**Parameters**: 
+  * **findFontName** - font name to search
+  * **replaceFontName** - font name to replace
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // ReplaceFont(findFontName, replaceFontName string) PDF-dokümanındaki yazı tipini değiştirir
+        err = pdf.ReplaceFont("Helvetica", "Courier")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_ReplaceFont.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/replacetext/_index.md
+++ b/turkish/go-cpp/organize/replacetext/_index.md
@@ -1,0 +1,49 @@
+---
+title: "ReplaceText"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesindeki metni değiştir."
+type: docs
+url: /tr/go-cpp/organize/replacetext/
+---
+
+_PDF-belgede metni değiştir._
+
+```go
+func (document *Document) ReplaceText(findText, replaceText string) error
+```
+
+**Parameters**: 
+  * **findText** - text fragment to search
+  * **replaceText** - text fragment to replace
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// ReplaceText(findText, replaceText string) PDF-belgedeki metni değiştirir
+	err = pdf.ReplaceText("PDF", "TXT")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_ReplaceText.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/rotate/_index.md
+++ b/turkish/go-cpp/organize/rotate/_index.md
@@ -1,0 +1,57 @@
+---
+title: "Rotate"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesini döndür."
+type: docs
+url: /tr/go-cpp/organize/rotate/
+---
+
+_PDF belgesini döndür._
+
+```go
+func (document *Document) Rotate(rotation int32) error
+```
+
+**Parameters**: 
+  * **rotation** - pages rotation:
+```go
+const (
+    RotationNone  int32 = 0 // Non-rotated.
+    RotationOn90  int32 = 1 // Rotated on 90 degrees clockwise.
+    RotationOn180 int32 = 2 // Rotated on 180 degrees.
+    RotationOn270 int32 = 3 // Rotated on 270 degrees clockwise.
+    RotationOn360 int32 = 4 // Rotated on 360 degrees clockwise.
+)
+```
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Rotate(rotation int32) PDF belgesini döndürür
+	err = pdf.Rotate(asposepdf.RotationOn270)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_Rotate.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/setbackground/_index.md
+++ b/turkish/go-cpp/organize/setbackground/_index.md
@@ -1,0 +1,50 @@
+---
+title: "SetBackground"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF belgesi arka plan rengini ayarla."
+type: docs
+url: /tr/go-cpp/organize/setbackground/
+---
+
+_PDF-dokümanının arka plan rengini ayarla._
+
+```go
+func (document *Document) SetBackground(r, g, b int32) error
+```
+
+**Parameters**: 
+  * **r** - Red color of RGB color model (0-255)
+  * **g** - Green color of RGB color model (0-255)
+  * **b** - Blue color of RGB color model (0-255)
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// SetBackground(r, g, b int32) PDF-dokümanının arka plan rengini ayarlar
+	err = pdf.SetBackground(200, 100, 101)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_SetBackground.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/organize/unembedfonts/_index.md
+++ b/turkish/go-cpp/organize/unembedfonts/_index.md
@@ -1,0 +1,47 @@
+---
+title: "UnembedFonts"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'tan gömülü yazı tiplerini kaldır."
+type: docs
+url: /tr/go-cpp/organize/unembedfonts/
+---
+
+_PDF-dokümanından yazı tiplerini gömülü olmaktan çıkar._
+
+```go
+func (document *Document) UnembedFonts() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+        // Open(filename string) dosya adıyla bir PDF-belgesi açar
+        pdf, err := asposepdf.Open("sample.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+        // Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+        defer pdf.Close()
+        // UnembedFonts() PDF-dokümanından yazı tiplerini gömülü olmaktan çıkarır
+        err = pdf.UnembedFonts()
+        if err != nil {
+                log.Fatal(err)
+        }
+        // SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+        err = pdf.SaveAs("sample_UnembedFonts.pdf")
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/turkish/go-cpp/organize/validate/_index.md
+++ b/turkish/go-cpp/organize/validate/_index.md
@@ -1,0 +1,85 @@
+---
+title: "Validate"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-document'ın PDF formatına uygunluğunu doğrula."
+type: docs
+url: /tr/go-cpp/organize/validate/
+---
+
+_PDF belgesini PDF formatına uyumluluk açısından doğrula._
+
+```go
+func (document *Document) Validate(pdfFormat PdfFormat) (bool, string, error)
+```
+
+**Parameters**: 
+  * **pdfFormat** - PDF format:
+```go
+type PdfFormat int32
+const (
+	PDF_A_1A      PdfFormat = iota // Pdf/A-1a format.
+	PDF_A_1B                       // Pdf/A-1b format.
+	PDF_A_2A                       // Pdf/A-2a format.
+	PDF_A_3A                       // Pdf/A-3a format.
+	PDF_A_2B                       // Pdf/A-2b format.
+	PDF_A_2U                       // Pdf/A-2u format.
+	PDF_A_3B                       // Pdf/A-3b format.
+	PDF_A_3U                       // Pdf/A-3u format.
+	V_1_0                          // Adobe version 1.0.
+	V_1_1                          // Adobe version 1.1.
+	V_1_2                          // Adobe version 1.2.
+	V_1_3                          // Adobe version 1.3.
+	V_1_4                          // Adobe version 1.4.
+	V_1_5                          // Adobe version 1.5.
+	V_1_6                          // Adobe version 1.6.
+	V_1_7                          // Adobe version 1.7.
+	V_2_0                          // ISO Standard PDF 2.0.
+	PDF_UA_1                       // PDF/UA-1 format.
+	PDF_X_1A_2001                  // PDF/X-1a-2001 format.
+	PDF_X_1A                       // PDF/X-1a format.
+	PDF_X_3                        // PDF/X-3 format.
+	ZUGFeRD                        // ZUGFeRD format.
+	PDF_A_4                        // PDF/A-4 format.
+	PDF_A_4E                       // PDF/A-4e format.
+	PDF_A_4F                       // PDF/A-4f format.
+	PDF_X_4                        // PDF/X-4 format.
+	PDF_E_1                        // PDF/E-1 (PDF 1.6) format.
+)
+```
+
+**Return**: 
+  * **bool** - contains validation result
+  * **string** - contains validation log
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/aspose-pdf/aspose-pdf-go-cpp"
+	"log"
+)
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// Validate(pdfFormat PdfFormat) PDF-belgeyi PDF/A uyumluluğu için doğrular
+	ok, logStr, err := pdf.Validate(asposepdf.PDF_A_2A)
+	if err != nil {
+		log.Fatal("Validate PDF/A error:", err)
+	}
+
+	// Doğrulama sonucunu ve tam günlük kaydını yazdır
+	fmt.Printf("Validate PDF/A result: %v\n", ok)
+	fmt.Printf("Validate PDF/A log:\n%s\n", logStr)
+}
+```

--- a/turkish/go-cpp/security/_index.md
+++ b/turkish/go-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Güvenlik işlevleri"
+second_title: "Aspose.PDF for Go via C++"
+description: "Güvenlik işlevleri."
+type: docs
+url: /tr/go-cpp/security/
+---
+
+## Security
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [OpenWithPassword](./openwithpassword/) | Şifre korumalı PDF-dokümanını aç. |
+| [Encrypt](./encrypt/) | PDF-dokümanını şifrele. |
+| [Decrypt](./decrypt/) | PDF-dokümanının şifresini çöz. |
+| [SetPermissions](./setpermissions/) | PDF-dokümanı için izinleri ayarla. |
+| [GetPermissions](./getpermissions/) | PDF-dokümanının mevcut izinlerini al. |
+| [IsEncrypted](./isencrypted/) | PDF-dokümanının şifrelenme durumunu al. |
+| [SignPKCS7](./signpkcs7/) | PDF-dokümanını PKCS#7 dijital imzalarıyla imzala. |
+| [SignPKCS7Detached](./signpkcs7detached/) | PDF-dokümanını PKCS#7 Ayrık dijital imzalarıyla imzala. |
+| [IsSigned](./issigned/) | PDF-dokümanının imzalı durumunu al. |
+| [RemoveSigns](./removesigns/) | PDF-dokümanından imzaları kaldır. |
+
+
+## Detailed Description
+
+Güvenlik işlevleri.
+

--- a/turkish/go-cpp/security/decrypt/_index.md
+++ b/turkish/go-cpp/security/decrypt/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Decrypt"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanının şifresini çöz."
+type: docs
+url: /tr/go-cpp/security/decrypt/
+---
+
+_PDF-dökümanını şifre çöz._
+
+```go
+func (document *Document) Decrypt() error
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// OpenWithPassword(filename string, password string) şifre korumalı bir PDF-dökümanı açar
+	pdf, err := asposepdf.OpenWithPassword("sample_with_password.pdf", "ownerpass")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Decrypt() PDF-dökümanı şifre çözer
+	err = pdf.Decrypt()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_without_password.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/security/encrypt/_index.md
+++ b/turkish/go-cpp/security/encrypt/_index.md
@@ -1,0 +1,80 @@
+---
+title: "Encrypt"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanını şifrele."
+type: docs
+url: /tr/go-cpp/security/encrypt/
+---
+
+_PDF-dökümanını şifrele._
+
+```go
+func (document *Document) Encrypt(userPassword string, ownerPassword string, permissions Permissions, cryptoAlgorithm CryptoAlgorithm, usePdf20 bool) error
+```
+
+**Parameters**: 
+  * **userPassword** - user password
+  * **ownerPassword** - owner password
+  * **permissions** - bitmask of allowed PDF permissions (combine flags using `|`):
+```go
+type Permissions int32
+const (
+    PrintDocument                  Permissions = 1 << 2  // 4
+    ModifyContent                  Permissions = 1 << 3  // 8
+    ExtractContent                 Permissions = 1 << 4  // 16
+    ModifyTextAnnotations          Permissions = 1 << 5  // 32
+    FillForm                       Permissions = 1 << 8  // 256
+    ExtractContentWithDisabilities Permissions = 1 << 9  // 512
+    AssembleDocument               Permissions = 1 << 10 // 1024
+    PrintingQuality                Permissions = 1 << 11 // 2048
+)
+```
+  * **cryptoAlgorithm** - encryption algorithm:
+```go
+type CryptoAlgorithm int32
+const (
+	RC4x40  CryptoAlgorithm = 0 // RC4 with key length 40.
+	RC4x128 CryptoAlgorithm = 1 // RC4 with key length 128.
+	AESx128 CryptoAlgorithm = 2 // AES with key length 128.
+	AESx256 CryptoAlgorithm = 3 // AES with key length 256.
+)
+```
+  * **usePdf20** - if true, uses PDF 2.0 encryption (for AESx128/256); otherwise uses standard PDF 1.x encryption
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// Encrypt(userPassword, ownerPassword, permissions, cryptoAlgorithm, usePdf20) PDF-dökümanını şifreler
+	err = pdf.Encrypt(
+		"userpass",
+		"ownerpass",
+		asposepdf.PrintDocument|asposepdf.ModifyContent|asposepdf.FillForm,
+		asposepdf.AESx128,
+		true,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_with_password.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/security/getpermissions/_index.md
+++ b/turkish/go-cpp/security/getpermissions/_index.md
@@ -1,0 +1,86 @@
+---
+title: "GetPermissions"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dökümanı için izinleri al."
+type: docs
+url: /tr/go-cpp/security/getpermissions/
+---
+
+_PDF-dökümanı için izinleri al._
+
+```go
+func (document *Document) GetPermissions() (Permissions, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **Permissions** - bitmask of PDF permission flags:
+```go
+type Permissions int32
+const (
+    PrintDocument                  Permissions = 1 << 2  // 4
+    ModifyContent                  Permissions = 1 << 3  // 8
+    ExtractContent                 Permissions = 1 << 4  // 16
+    ModifyTextAnnotations          Permissions = 1 << 5  // 32
+    FillForm                       Permissions = 1 << 8  // 256
+    ExtractContentWithDisabilities Permissions = 1 << 9  // 512
+    AssembleDocument               Permissions = 1 << 10 // 1024
+    PrintingQuality                Permissions = 1 << 11 // 2048
+)
+```
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+var permissionNames = map[asposepdf.Permissions]string{
+	asposepdf.PrintDocument:                  "Allow printing",
+	asposepdf.ModifyContent:                  "Allow modifying content (except forms/annotations)",
+	asposepdf.ExtractContent:                 "Allow copying/extracting text and graphics",
+	asposepdf.ModifyTextAnnotations:          "Allow adding/modifying text annotations",
+	asposepdf.FillForm:                       "Allow filling interactive forms",
+	asposepdf.ExtractContentWithDisabilities: "Allow content extraction for accessibility",
+	asposepdf.AssembleDocument:               "Allow inserting/rotating/deleting pages or changing structure",
+	asposepdf.PrintingQuality:                "Allow high-quality / faithful printing",
+}
+
+func PermissionsToString(p asposepdf.Permissions) string {
+	var result []string
+	for flag, name := range permissionNames {
+		if p&flag != 0 {
+			result = append(result, name)
+		}
+	}
+	if len(result) == 0 {
+		return "None"
+	}
+	return strings.Join(result, ", ")
+}
+
+func main() {
+	// OpenWithPassword(filename string, password string) şifre korumalı bir PDF-dökümanı açar
+	pdf, err := asposepdf.OpenWithPassword("sample_with_permissions.pdf", "ownerpass")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// GetPermissions() PDF-dökümanının mevcut izinlerini alır
+	permissions, err := pdf.GetPermissions()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// İzinleri Yazdır
+	fmt.Println("Permissions:", PermissionsToString(permissions))
+}
+```

--- a/turkish/go-cpp/security/isencrypted/_index.md
+++ b/turkish/go-cpp/security/isencrypted/_index.md
@@ -1,0 +1,44 @@
+---
+title: "IsEncrypted"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanının şifrelenme durumunu al."
+type: docs
+url: /tr/go-cpp/security/isencrypted/
+---
+
+_PDF-belgenin şifrelenmiş durumunu al._
+
+```go
+func (document *Document) IsEncrypted() (bool, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **bool** - the document is encrypted
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// OpenWithPassword(filename string, password string) şifre korumalı bir PDF-dökümanı açar
+	pdf, err := asposepdf.OpenWithPassword("sample_with_password.pdf", "ownerpass")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// IsEncrypted() PDF-belgenin şifrelenmiş durumunu alır
+	isEnc, _ := pdf.IsEncrypted()
+	if isEnc {
+		fmt.Println("IsEncrypted() is true")
+	}
+}
+```

--- a/turkish/go-cpp/security/issigned/_index.md
+++ b/turkish/go-cpp/security/issigned/_index.md
@@ -1,0 +1,44 @@
+---
+title: "IsSigned"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanının imzalı durumunu al."
+type: docs
+url: /tr/go-cpp/security/issigned/
+---
+
+_PDF-dökümanının imzalı durumunu al._
+
+```go
+func (document *Document) IsSigned() (bool, error)
+```
+
+**Parameters**: 
+
+**Return**: 
+  * **bool** - the document is signed
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "fmt"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample_with_sign.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// IsSigned() PDF-dökümanının imzalı durumunu alır
+	isSig, _ := pdf.IsSigned()
+	if isSig {
+		fmt.Println("IsSigned() is true")
+	}
+}
+```

--- a/turkish/go-cpp/security/openwithpassword/_index.md
+++ b/turkish/go-cpp/security/openwithpassword/_index.md
@@ -1,0 +1,41 @@
+---
+title: "OpenWithPassword"
+second_title: "Aspose.PDF for Go via C++"
+description: "Şifre korumalı PDF-dokümanını aç."
+type: docs
+url: /tr/go-cpp/security/openwithpassword/
+---
+
+_Şifre korumalı bir PDF-dökümanı aç._
+
+```go
+func OpenWithPassword(filename string, password string) (*Document, error)
+```
+
+**Parameters**: 
+  * **\*Document** - pointer to document
+  * **filename** - full file name of the PDF-document
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// OpenWithPassword(filename string, password string) şifre korumalı bir PDF-dökümanı açar
+	pdf, err := asposepdf.OpenWithPassword("sample_with_password.pdf", "ownerpass")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// çalışıyor...
+}
+```

--- a/turkish/go-cpp/security/removesigns/_index.md
+++ b/turkish/go-cpp/security/removesigns/_index.md
@@ -1,0 +1,43 @@
+---
+title: "RemoveSigns"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanından imzaları kaldır."
+type: docs
+url: /tr/go-cpp/security/removesigns/
+---
+
+_PDF-belgeden imzaları kaldır._
+
+```go
+func (document *Document) RemoveSigns(filename string) error
+```
+
+**Parameters**: 
+  * **filename** - new filename, without signs
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample_with_sign.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+	// RemoveSigns(filename string) PDF-belgeden imzaları kaldırır
+	err = pdf.RemoveSigns("sample_RemoveSigns.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/security/setpermissions/_index.md
+++ b/turkish/go-cpp/security/setpermissions/_index.md
@@ -1,0 +1,70 @@
+---
+title: "SetPermissions"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanı için izinleri ayarla."
+type: docs
+url: /tr/go-cpp/security/setpermissions/
+---
+
+_PDF-dökümanı için izinleri ayarla._
+
+```go
+func (document *Document) SetPermissions(userPassword string, ownerPassword string, permissions Permissions) error
+```
+
+**Parameters**: 
+  * **userPassword** - user password
+  * **ownerPassword** - owner password
+  * **permissions** - bitmask of allowed PDF permissions (combine flags using `|`):
+```go
+type Permissions int32
+const (
+    PrintDocument                  Permissions = 1 << 2  // 4
+    ModifyContent                  Permissions = 1 << 3  // 8
+    ExtractContent                 Permissions = 1 << 4  // 16
+    ModifyTextAnnotations          Permissions = 1 << 5  // 32
+    FillForm                       Permissions = 1 << 8  // 256
+    ExtractContentWithDisabilities Permissions = 1 << 9  // 512
+    AssembleDocument               Permissions = 1 << 10 // 1024
+    PrintingQuality                Permissions = 1 << 11 // 2048
+)
+```
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+
+func main() {
+	// New yeni bir PDF belgesi oluşturur
+	pdf, err := asposepdf.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// SetPermissions(userPassword, ownerPassword, permissions) PDF-dökümanı için izinleri ayarlar
+	err = pdf.SetPermissions(
+		"userpass",
+		"ownerpass",
+		asposepdf.PrintDocument|
+			asposepdf.ModifyContent|
+			asposepdf.FillForm,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// SaveAs(filename string) daha önce açılmış PDF belgesini yeni dosya adıyla kaydeder
+	err = pdf.SaveAs("sample_with_permissions.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/security/signpkcs7/_index.md
+++ b/turkish/go-cpp/security/signpkcs7/_index.md
@@ -1,0 +1,60 @@
+---
+title: "SignPKCS7"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanını PKCS#7 dijital imzalarıyla imzala."
+type: docs
+url: /tr/go-cpp/security/signpkcs7/
+---
+
+_PKCS#7 dijital imzaları kullanarak bir PDF-dökümanını imzala._
+
+```go
+func (document *Document) SignPKCS7(num int32, signData []byte, pswSign string, setXIndent, setYIndent, setHeight, setWidth int32, reason, contact, location string, isVisible bool, appearanceData []byte, filename string) error
+```
+
+**Parameters**: 
+  * **num** - the page number of the PDF-document
+  * **signData** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **pswSign** - the password of the signature
+  * **setXIndent** - the x indent of the signature
+  * **setYIndent** - the y indent of the signature
+  * **setHeight** - the height of the signature
+  * **setWidth** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** -  the location of a signature
+  * **isVisible** - the visiblity of signature
+  * **appearanceData** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the new filename, with signature
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "os"
+
+func main() {
+	cert, _ := os.ReadFile("sign.pfx")
+	img, _ := os.ReadFile("sign.png")
+
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// SignPKCS7, PKCS#7 dijital imzaları kullanarak bir PDF-belgesi imzalar
+	err = pdf.SignPKCS7(1, cert, "Pa$$w0rd2023", 100, 100, 70, 100, "Reason", "Contact", "Location", true, img, "sample_SignPKCS7.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/turkish/go-cpp/security/signpkcs7detached/_index.md
+++ b/turkish/go-cpp/security/signpkcs7detached/_index.md
@@ -1,0 +1,60 @@
+---
+title: "SignPKCS7Detached"
+second_title: "Aspose.PDF for Go via C++"
+description: "PDF-dokümanını PKCS#7 Ayrık dijital imzalarıyla imzala."
+type: docs
+url: /tr/go-cpp/security/signpkcs7detached/
+---
+
+_PKCS#7 Detached dijital imzaları kullanarak bir PDF-belgesi imzalayın._
+
+```go
+func (document *Document) SignPKCS7Detached(num int32, signData []byte, pswSign string, setXIndent, setYIndent, setHeight, setWidth int32, reason, contact, location string, isVisible bool, appearanceData []byte, filename string) error
+```
+
+**Parameters**: 
+  * **num** - the page number of the PDF-document
+  * **signData** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **pswSign** - the password of the signature
+  * **setXIndent** - the x indent of the signature
+  * **setYIndent** - the y indent of the signature
+  * **setHeight** - the height of the signature
+  * **setWidth** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** -  the location of a signature
+  * **isVisible** - the visiblity of signature
+  * **appearanceData** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the new filename, with signature
+
+**Return**: 
+  * **error** - contains an error or nil if absent
+
+
+**Example**:
+```go
+package main
+
+import "github.com/aspose-pdf/aspose-pdf-go-cpp"
+import "log"
+import "os"
+
+func main() {
+	cert, _ := os.ReadFile("sign.pfx")
+	img, _ := os.ReadFile("sign.png")
+
+	// Open(filename string) dosya adıyla bir PDF-belgesi açar
+	pdf, err := asposepdf.Open("sample.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Close() PDF-belgesi için ayrılan kaynakları serbest bırakır
+	defer pdf.Close()
+
+	// SignPKCS7Detached, PKCS#7 Detached dijital imzaları kullanarak bir PDF-belgesi imzalar
+	err = pdf.SignPKCS7Detached(1, cert, "Pa$$w0rd2023", 100, 100, 70, 100, "Reason", "Contact", "Location", true, img, "sample_SignPKCS7Detached.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```


### PR DESCRIPTION
Automated translation of the GO-CPP API Reference to **Turkish** (`tr`) generated by RDA.

- Pages translated: 123/123
- Errors: 0
- Source: `english/go-cpp`
- Output: `turkish/go-cpp`

🤖 Generated by RDA