### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Swedish

### DIFF
--- a/swedish/javascript-cpp/_index.md
+++ b/swedish/javascript-cpp/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Aspose.PDF för JavaScript via C++"
+description: "Aspose.PDF för JavaScript via C++"
+keywords:  "JavaScript via C++, JavaScript PDF toolkit"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /sv/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for JavaScript via C++ allows developers manipulate them PDF files directly in the Web.
+Sådana operationer är mycket tidskrävande, så vi rekommenderar att använda Web Worker.
+
+
+## Convert from PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfPagesToJpg](./convert/asposepdfpagestojpg/) | Konvertera en PDF-fil till JPG. |
+| [AsposePdfPagesToPng](./convert/asposepdfpagestopng/) | Konvertera en PDF-fil till PNG. |
+| [AsposePdfPagesToTiff](./convert/asposepdfpagestotiff/) | Konvertera en PDF-fil till TIFF. |
+| [AsposePdfPagesToBmp](./convert/asposepdfpagestobmp/) | Konvertera en PDF-fil till BMP. |
+| [AsposePdfPagesToDICOM](./convert/asposepdfpagestodicom/) | Konvertera en PDF-fil till DICOM. |
+| [AsposePdfPagesToSvg](./convert/asposepdfpagestosvg/) | Konvertera en PDF-fil till SVG. |
+| [AsposePdfPagesToSvgZip](./convert/asposepdfpagestosvgzip/) | Konvertera en PDF-fil till SVG(zip). |
+| [AsposePdfToTeX](./convert/asposepdftotex/) | Konvertera en PDF-fil till TeX. |
+| [AsposePdfToXps](./convert/asposepdftoxps/) | Konvertera en PDF-fil till Xps. |
+| [AsposePdfTablesToCSV](./convert/asposepdftablestocsv/) | Konvertera en PDF-fil till CSV (extrahera tabeller). |
+| [AsposePdfToTxt](./convert/asposepdftotxt/) | Konvertera en PDF-fil till Txt. |
+| [AsposePdfConvertToGrayscale](./convert/asposepdfconverttograyscale/) | Konvertera en PDF-fil till gråskala. |
+| [AsposePdfConvertToPDFA](./convert/asposepdfconverttopdfa/) | Konvertera en PDF-fil till PDF/A. |
+| [AsposePdfAConvertToPDF](./convert/asposepdfaconverttopdf/) | Konvertera en PDF/A-fil till PDF. |
+| [AsposePdfToDocX](./convert/asposepdftodocx/) | Konvertera en PDF-fil till DocX. |
+| [AsposePdfToXlsX](./convert/asposepdftoxlsx/) | Konvertera en PDF-fil till XlsX. |
+| [AsposePdfToEPUB](./convert/asposepdftoepub/) | Konvertera en PDF-fil till ePub. |
+| [AsposePdfToDoc](./convert/asposepdftodoc/) | Konvertera en PDF-fil till Doc. |
+| [AsposePdfToPptX](./convert/asposepdftopptx/) | Konvertera en PDF-fil till PptX. |
+| [AsposePdfExtractText](./convert/asposepdfextracttext/) | Extrahera text från en PDF-fil. |
+| [AsposePdfExtractImage](./convert/asposepdfextractimage/) | Extrahera bild från en PDF-fil. |
+| [AsposePdfExportFdf](./convert/asposepdfexportfdf/) | Exportera från en PDF-fil med AcroForm till FDF. |
+| [AsposePdfExportXfdf](./convert/asposepdfexportxfdf/) | Exportera från en PDF-fil med AcroForm till XFDF. |
+| [AsposePdfExportXml](./convert/asposepdfexportxml/) | Exportera från en PDF-fil med AcroForm till XML. |
+| [AsposePdfPagesToPDF](./convert/asposepdfpagestopdf/) | Konvertera en PDF-fil till PDF (separata sidor). |
+| [AsposePdfToMarkdown](./convert/asposepdftomarkdown/) | Konvertera en PDF-fil till Markdown. |
+| [AsposePdfToDocXEnhanced](./convert/asposepdftodocxenhanced/) | Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge. |
+
+
+## Convert to PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfFromTxt](./convertpdf/asposepdffromtxt/) | Konvertera en TXT-fil till PDF. |
+| [AsposePdfFromImage](./convertpdf/asposepdffromimage/) | Konvertera en bildfil till PDF. |
+
+
+## Organize PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfOptimize](./organize/asposepdfoptimize/) | Optimera en PDF-fil. |
+| [AsposePdfMerge2Files](./organize/asposepdfmerge2files/) | Slå ihop två PDF-filer. |
+| [AsposePdfSplit2Files](./organize/asposepdfsplit2files/) | Dela upp i två PDF-filer. |
+| [AsposePdfRotateAllPages](./organize/asposepdfrotateallpages/) | Rotera PDF-sidor. |
+| [AsposePdfDeletePages](./organize/asposepdfdeletepages/) | Ta bort sidor från en PDF-fil. |
+| [AsposePdfAddStamp](./organize/asposepdfaddstamp/) | Lägg till stämpel i en PDF-fil. |
+| [AsposePdfAddStampPages](./organize/asposepdfaddstamppages/) | Lägg till stämpel på specifika sidor i en PDF-fil. |
+| [AsposePdfAddImage](./organize/asposepdfaddimage/) | Lägg till en bild i slutet av en PDF-fil. |
+| [AsposePdfAddPageNum](./organize/asposepdfaddpagenum/) | Lägg till sidnummer i en PDF-fil. |
+| [AsposePdfAddBackgroundImage](./organize/asposepdfaddbackgroundimage/) | Lägg till bakgrundsbild i en PDF-fil. |
+| [AsposePdfAddTextHeaderFooter](./organize/asposepdfaddtextheaderfooter/) | Lägg till text i sidhuvud/sidfot i en PDF-fil. |
+| [AsposePdfRepair](./organize/asposepdfrepair/) | Reparera en PDF-fil. |
+| [AsposePdfOptimizeResource](./organize/asposepdfoptimizeresource/) | Optimera resurser i PDF-filen. |
+| [AsposePdfSetBackgroundColor](./organize/asposepdfsetbackgroundcolor/) | Ställ in bakgrundsfärgen för PDF-filen. |
+| [AsposePdfDeleteAnnotations](./organize/asposepdfdeleteannotations/) | Ta bort anteckningar från en PDF-fil. |
+| [AsposePdfDeleteBookmarks](./organize/asposepdfdeletebookmarks/) | Ta bort bokmärken från en PDF-fil. |
+| [AsposePdfDeleteAttachments](./organize/asposepdfdeleteattachments/) | Ta bort bilagor från en PDF-fil. |
+| [AsposePdfDeleteImages](./organize/asposepdfdeleteimages/) | Ta bort bilder från en PDF-fil. |
+| [AsposePdfDeleteJavaScripts](./organize/asposepdfdeletejavascripts/) | Ta bort JavaScript från en PDF-fil. |
+| [AsposePdfAddAttachment](./organize/asposepdfaddattachment/) | Lägg till bilaga till en PDF-fil. |
+| [AsposePdfGetAttachment](./organize/asposepdfgetattachment/) | Hämta bilaga från en PDF-fil. |
+| [AsposePdfReplaceText](./organize/asposepdfreplacetext/) | Ersätt text i en PDF-fil. |
+| [AsposePdfReplaceTextPages](./organize/asposepdfreplacetextpages/) | Ersätt text på sidor i en PDF-fil. |
+| [AsposePdfFindText](./organize/asposepdffindtext/) | Hitta text i en PDF-fil. |
+| [AsposePdfReplaceFont](./organize/asposepdfreplacefont/) | Ersätt teckensnitt i en PDF-fil. |
+| [AsposePdfValidatePDFA](./organize/asposepdfvalidatepdfa/) | Validera PDF/A-kompatibilitet för en PDF-fil. |
+| [AsposePdfFindHiddenText](./organize/asposepdffindhiddentext/) | Hitta dold text i en PDF-fil. |
+| [AsposePdfDeleteHiddenText](./organize/asposepdfdeletehiddentext/) | Ta bort dold text från en PDF-fil. |
+| [AsposePdfAddWatermark](./organize/asposepdfaddwatermark/) | Lägg till vattenstämpel till en PDF-fil. |
+| [AsposePdfDeleteWatermarks](./organize/asposepdfdeletewatermarks/) | Ta bort vattenstämplar från en PDF-fil. |
+| [AsposePdfMergeLayers](./organize/asposepdfmergelayers/) | Slå samman lager i en PDF-fil. |
+| [AsposePdfFlatten](./organize/asposepdfflatten/) | Platta till en PDF-fil. |
+| [AsposePdfMakeBooklet](./organize/asposepdfmakebooklet/) | Skapa häfte från en PDF-fil. |
+| [AsposePdfMakeNUp](./organize/asposepdfmakenup/) | Skapa N-Up-dokument från en PDF-fil. |
+| [AsposePdfDeleteBlankPages](./organize/asposepdfdeleteblankpages/) | Ta bort tomma sidor från en PDF-fil. |
+| [AsposePdfEmbedFonts](./organize/asposepdfembedfonts/) | Bädda in teckensnitt i en PDF-fil. |
+| [AsposePdfUnembedFonts](./organize/asposepdfunembedfonts/) | Ta bort inbäddade teckensnitt från en PDF-fil. |
+| [AsposePdfOptimizeFileSize](./organize/asposepdfoptimizefilesize/) | Optimera storleken på PDF-filen med bildkomprimeringskvalitet. |
+| [AsposePdfDeleteTables](./organize/asposepdfdeletetables/) | Ta bort tabeller från en PDF-fil. |
+| [AsposePdfCropPages](./organize/asposepdfcroppages/) | Beskär PDF-sidor. |
+| [AsposePdfDeleteTextHeaders](./organize/asposepdfdeletetextheaders/) | Ta bort textrubriker från en PDF-fil. |
+| [AsposePdfDeleteTextFooters](./organize/asposepdfdeletetextfooters/) | Ta bort textfotnoter från en PDF-fil. |
+| [AsposePdfReplaceTextEx](./organize/asposepdfreplacetextex/) | Ersätt flera textfragment i en PDF-fil med justeringskontroll. |
+| [AsposePdfRecover](./organize/asposepdfrecover/) | Återskapa en PDF-filstruktur och rensa ogiltiga data. |
+| [AsposePdfRebuildXrefAndTrailer](./organize/asposepdfrebuildxrefandtrailer/) | Bygg om en PDF-fils korsreferenstabell och trailer-strukturer. |
+| [AsposePdfReversePages](./organize/asposepdfreversepages/) | Vänd på sidordningen i en PDF-fil. |
+
+
+## Metadata PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfSetInfo](./metadata/asposepdfsetinfo/) | Ställ in information (metadata) i en PDF-fil. |
+| [AsposePdfGetInfo](./metadata/asposepdfgetinfo/) | Hämta information (metadata) från en PDF-fil. |
+| [AsposePdfGetAllFonts](./metadata/asposepdfgetallfonts/) | Hämta lista över teckensnitt från en PDF-fil. |
+| [AsposePdfRemoveMetadata](./metadata/asposepdfremovemetadata/) | Ta bort metadata från en PDF-fil. |
+| [AsposePdfGetWordsCharactersCount](./metadata/asposepdfgetwordscharacterscount/) | Hämta antal ord och tecken i en PDF-fil. |
+| [AsposePdfGetPagesLayers](./metadata/asposepdfgetpageslayers/) | Hämta lista över lager från en PDF-fil. |
+
+
+## Security PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfEncrypt](./security/asposepdfencrypt/) | Kryptera en PDF-fil. |
+| [AsposePdfDecrypt](./security/asposepdfdecrypt/) | Dekryptera en PDF-fil. |
+| [AsposePdfSignPKCS7](./security/asposepdfsignpkcs7/) | Signera en PDF-fil med digitala signaturer. |
+| [AsposePdfSignPKCS7Detached](./security/asposepdfsignpkcs7detached/) | Signera en PDF-fil med fristående digitala signaturer. |
+| [AsposePdfChangePassword](./security/asposepdfchangepassword/) | Ändra lösenord för PDF-filen. |
+
+
+## Core Functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfPrepare](./core/asposepdfprepare/) | Spara BLOB:en i Memory FS för bearbetning. |
+| [AsposePdfPrepareBase64](./core/asposepdfpreparebase64/) | Spara strängrepresentationen av BLOB i Memory FS för bearbetning. |
+
+
+## Miscellaneous
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfAbout](./misc/asposepdfabout/) | Hämta information om Product. |
+| [DownloadFile](./misc/downloadfile/) | Skapa en länk i HTML för att ladda ner filen. |
+| [DownloadFileAuto](./misc/downloadfileauto) | Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder. |

--- a/swedish/javascript-cpp/convert/_index.md
+++ b/swedish/javascript-cpp/convert/_index.md
@@ -1,0 +1,55 @@
+---
+title: "Konvertera från PDF-funktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Funktioner för konvertering från PDF-filer."
+type: docs
+url: /sv/javascript-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfPagesToJpg](./asposepdfpagestojpg/) | Konvertera en PDF-fil till JPG. |
+| [AsposePdfPagesToPng](./asposepdfpagestopng/) | Konvertera en PDF-fil till PNG. |
+| [AsposePdfPagesToTiff](./asposepdfpagestotiff/) | Konvertera en PDF-fil till TIFF. |
+| [AsposePdfPagesToBmp](./asposepdfpagestobmp/) | Konvertera en PDF-fil till BMP. |
+| [AsposePdfPagesToDICOM](./asposepdfpagestodicom/) | Konvertera en PDF-fil till DICOM. |
+| [AsposePdfPagesToSvg](./asposepdfpagestosvg/) | Konvertera en PDF-fil till SVG. |
+| [AsposePdfPagesToSvgZip](./asposepdfpagestosvgzip/) | Konvertera en PDF-fil till SVG(zip). |
+| [AsposePdfToTeX](./asposepdftotex/) | Konvertera en PDF-fil till TeX. |
+| [AsposePdfToXps](./asposepdftoxps/) | Konvertera en PDF-fil till Xps. |
+| [AsposePdfTablesToCSV](./asposepdftablestocsv/) | Konvertera en PDF-fil till CSV (extrahera tabeller). |
+| [AsposePdfToTxt](./asposepdftotxt/) | Konvertera en PDF-fil till Txt. |
+| [AsposePdfConvertToGrayscale](./asposepdfconverttograyscale/) | Konvertera en PDF-fil till gråskala. |
+| [AsposePdfConvertToPDFA](./asposepdfconverttopdfa/) | Konvertera en PDF-fil till PDF/A. |
+| [AsposePdfAConvertToPDF](./asposepdfaconverttopdf/) | Konvertera en PDF/A-fil till PDF. |
+| [AsposePdfToDocX](./asposepdftodocx/) | Konvertera en PDF-fil till DocX. |
+| [AsposePdfToXlsX](./asposepdftoxlsx/) | Konvertera en PDF-fil till XlsX. |
+| [AsposePdfToEPUB](./asposepdftoepub/) | Konvertera en PDF-fil till ePub. |
+| [AsposePdfToDoc](./asposepdftodoc/) | Konvertera en PDF-fil till Doc. |
+| [AsposePdfToPptX](./asposepdftopptx/) | Konvertera en PDF-fil till PptX. |
+| [AsposePdfExtractText](./asposepdfextracttext/) | Extrahera text från en PDF-fil. |
+| [AsposePdfExtractImage](./asposepdfextractimage/) | Extrahera bild från en PDF-fil. |
+| [AsposePdfExportFdf](./asposepdfexportfdf/) | Exportera från en PDF-fil med AcroForm till FDF. |
+| [AsposePdfExportXfdf](./asposepdfexportxfdf/) | Exportera från en PDF-fil med AcroForm till XFDF. |
+| [AsposePdfExportXml](./asposepdfexportxml/) | Exportera från en PDF-fil med AcroForm till XML. |
+| [AsposePdfPagesToPDF](./asposepdfpagestopdf/) | Konvertera en PDF-fil till PDF (separata sidor). |
+| [AsposePdfToMarkdown](./asposepdftomarkdown/) | Konvertera en PDF-fil till Markdown. |
+| [AsposePdfToDocXEnhanced](./asposepdftodocxenhanced/) | Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge. |
+
+
+## Detailed Description
+
+Funktioner för konvertering från PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```
+

--- a/swedish/javascript-cpp/convert/asposepdfaconverttopdf/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfaconverttopdf/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfAConvertToPDF"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF/A-fil till PDF."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfaconverttopdf/
+---
+
+_Konvertera en PDF/A-fil till PDF._
+
+```js
+function AsposePdfAConvertToPDF(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfAConvertToPDF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAConvertToPDF', "params": [event.target.result, e.target.files[0].name, "ResultConvertToPDF.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfAConvertToPDF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+      const json = AsposePdfAConvertToPDF(event.target.result, e.target.files[0].name, "ResultConvertToPDF.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfconverttograyscale/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfconverttograyscale/_index.md
@@ -1,0 +1,83 @@
+---
+title: "AsposePdfConvertToGrayscale"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till gråskala."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfconverttograyscale/
+---
+
+_Konvertera en PDF-fil till gråskala._
+
+```js
+function AsposePdfConvertToGrayscale(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileConvertToGrayscale = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfConvertToGrayscale',
+          "params": [event.target.result, e.target.files[0].name, "ResultConvertToGrayscale.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileConvertToGrayscale = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+      const json = AsposePdfConvertToGrayscale(event.target.result, e.target.files[0].name, "ResultConvertToGrayscale.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfconverttopdfa/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfconverttopdfa/_index.md
@@ -1,0 +1,104 @@
+---
+title: "AsposePdfConvertToPDFA"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till PDF/A."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfconverttopdfa/
+---
+
+_Konvertera en PDF-fil till PDF/A._
+
+```js
+function AsposePdfConvertToPDFA(
+    fileBlob,
+    fileName,
+    pdfFormat,
+    fileNameResult,
+    fileNameLogResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name
+* **fileNameLogResult** result Log (xml) file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+  * **fileNameLogResult** - result Log (xml) file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}\n
+                  ${DownloadFile(evt.data.json.fileNameLogResult, "application/xml", evt.data.params[1])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfConvertToPDFA = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const pdfFormat = 'Module.PdfFormat.PDF_A_1A';
+      /*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+      /*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"- Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfConvertToPDFA',
+          "params": [event.target.result, e.target.files[0].name, pdfFormat, "ResultConvertToPDFA.pdf", "ResultConvertToPDFA.xml"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+var ffilePdfConvertToPDFA = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+      /*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+      const json = AsposePdfConvertToPDFA(event.target.result, e.target.files[0].name, Module.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFA.xml");
+      if (json.errorCode == 0)
+      {
+        document.getElementById('output').textContent = json.fileNameResult + "\nLog file (xml format): " + json.fileNameLogResult;
+        /*Make a link to download the result file*/
+        DownloadFile(json.fileNameResult, "application/pdf");
+      }
+      else document.getElementById('output').textContent = json.errorText + "\nLog file (xml format): " + json.fileNameLogResult;
+      /*Make a link to download the Log (xml)*/
+      DownloadFile(json.fileNameLogResult, "application/xml");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfexportfdf/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfexportfdf/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfExportFdf"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Exportera från en PDF-fil med AcroForm till FDF"
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfexportfdf/
+---
+
+_Exportera från en PDF-fil med AcroForm till FDF._
+
+```js
+function AsposePdfExportFdf(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.fdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileExportfdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Export from a PDF-file with AcroForm to FDF and save the "ResultPDFExportFdf.fdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfExportFdf', "params": [event.target.result, e.target.files[0].name, "ResultPDFExportFdf.fdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileExportFdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Export from a PDF-file with AcroForm to FDF and save the "ResultPDFExportFdf.fdf"*/
+      const json = AsposePdfExportFdf(event.target.result, e.target.files[0].name, "ResultPDFExportFdf.fdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.fdf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfexportxfdf/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfexportxfdf/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfExportXfdf"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Exportera från en PDF-fil med AcroForm till XFDF"
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfexportxfdf/
+---
+
+_Exportera från en PDF-fil med AcroForm till XFDF._
+
+```js
+function AsposePdfExportXfdf(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.adobe.xfdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileExportXfdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Export from a PDF-file with AcroForm to XFDF and save the "ResultPDFExportXfdf.xfdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfExportXfdf', "params": [event.target.result, e.target.files[0].name, "ResultPDFExportXfdf.xfdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileExportXfdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Export from a PDF-file with AcroForm to XFDF and save the "ResultPDFExportXfdf.xfdf"*/
+      const json = AsposePdfExportXfdf(event.target.result, e.target.files[0].name, "ResultPDFExportXfdf.xfdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.adobe.xfdf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfexportxml/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfexportxml/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfExportXml"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Exportera från en PDF-fil med AcroForm till XML"
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfexportxml/
+---
+
+_Exportera från en PDF-fil med AcroForm till XML._
+
+```js
+function AsposePdfExportXml(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/xml", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileExportXml = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Export from a PDF-file with AcroForm to XML and save the "ResultPDFExportXml.xml" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfExportXml', "params": [event.target.result, e.target.files[0].name, "ResultPDFExportXml.xml"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileExportXml = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Export from a PDF-file with AcroForm to XML and save the "ResultPDFExportXml.xml"*/
+      const json = AsposePdfExportXml(event.target.result, e.target.files[0].name, "ResultPDFExportXml.xml");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/xml");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfextractimage/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfextractimage/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposePdfExtractImage"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Extrahera bild från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfextractimage/
+---
+
+_Extrahera bild från en PDF-fil._
+
+```js
+function AsposePdfExtractImage(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfExtractImage{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - image files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(images) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/jpeg", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileExtractImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number),
+        resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfExtractImage', "params": [event.target.result, e.target.files[0].name, "ResultPdfExtractImage{0:D2}.jpg", 150] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileExtractImage = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfExtractImage(event.target.result, e.target.files[0].name, "ResultPdfExtractImage{0:D2}.jpg", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(images) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/jpeg");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfextracttext/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfextracttext/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposePdfExtractText"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Extrahera text från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfextracttext/
+---
+
+_Extrahera text från en PDF-fil._
+
+```js
+function AsposePdfExtractText(
+    fileBlob,
+    fileName 
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **extractText** - text from PDF
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        evt.data.json.extractText :
+        `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffileExtract = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Extract text from a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfExtractText', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileExtract = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Extract text from a PDF-file*/
+      const json = AsposePdfExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.extractText
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestobmp/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestobmp/_index.md
@@ -1,0 +1,83 @@
+---
+title: "AsposePdfPagesToBmp"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till BMP."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestobmp/
+---
+
+_Konvertera en PDF-fil till BMP._
+
+```
+function AsposePdfPagesToBmp(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToBmp{0:D2}.bmp" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - bmp files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/bmp", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToBmp = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToBmp', "params": [event.target.result, e.target.files[0].name, "ResultPdfToBmp{0:D2}.bmp", 150] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToBmp = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfPagesToBmp(event.target.result, e.target.files[0].name, "ResultPdfToBmp{0:D2}.bmp", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/bmp");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestodicom/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestodicom/_index.md
@@ -1,0 +1,84 @@
+---
+title: "AsposePdfPagesToDICOM"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till DICOM."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestodicom/
+---
+
+_Konvertera en PDF-fil till DICOM._
+
+```js
+function AsposePdfPagesToDICOM(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToDICOM{0:D2}.dcm" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - DICOM (.dcm) files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "application/dicom", element) ) ?? ""}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToDICOM = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToDICOM', "params": [event.target.result, e.target.files[0].name, "ResultPdfToDICOM{0:D2}.dcm", 150] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToDICOM = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfPagesToDICOM(event.target.result, e.target.files[0].name, "ResultPdfToDICOM{0:D2}.dcm", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "application/dicom");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestojpg/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestojpg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposePdfPagesToJpg"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till JPG."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestojpg/
+---
+
+_Konvertera en PDF-fil till JPG._
+
+```js
+function AsposePdfPagesToJpg(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToJpg{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - jpg files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/jpeg", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToJpg = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number),
+        resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPagesToJpg', "params": [event.target.result, e.target.files[0].name, "ResultPdfToJpg{0:D2}.jpg", 150] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToJpg = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfPagesToJpg(event.target.result, e.target.files[0].name, "ResultPdfToJpg{0:D2}.jpg", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/jpeg");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestopdf/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestopdf/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfPagesToPDF"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till PDF (separata sidor)."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestopdf/
+---
+
+_Konvertera en PDF-fil till PDF (separata sidor)._
+
+```
+function AsposePdfPagesToPDF(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfPagesToPDF{0:D2}.pdf" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - result files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "application/pdf", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToPDF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToPDF', "params": [event.target.result, e.target.files[0].name, "ResultPdfToPDF{0:D2}.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToPDF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+      const json = AsposePdfPagesToPDF(event.target.result, e.target.files[0].name, "ResultPdfToPDF{0:D2}.pdf");
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "application/pdf");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestopng/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestopng/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposePdfPagesToPng"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till PNG."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestopng/
+---
+
+_Konvertera en PDF-fil till PNG._
+
+```
+function AsposePdfPagesToPng(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToPng{0:D2}.png" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/png", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number),
+        resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPagesToPng', "params": [event.target.result, e.target.files[0].name, "ResultPdfToPng{0:D2}.png", 150] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfPagesToPng(event.target.result, e.target.files[0].name, "ResultPdfToPng{0:D2}.png", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestosvg/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestosvg/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfPagesToSvg"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till SVG."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestosvg/
+---
+
+_Konvertera en PDF-fil till SVG._
+
+```
+function AsposePdfPagesToSvg(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/svg", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToSvg = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to SVG - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToSvg', "params": [event.target.result, e.target.files[0].name, "ResultPdfToSvg.svg"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToSvg = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to SVG*/
+      const json = AsposePdfPagesToSvg(event.target.result, e.target.files[0].name, "ResultPdfToSvg.svg");
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/svg");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestosvgzip/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestosvgzip/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePdfPagesToSvgZip"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till SVG(zip)."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestosvgzip/
+---
+
+_Konvertera en PDF-fil till SVG(zip)._
+
+```
+function AsposePdfPagesToSvgZip(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/zip", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToSvgZip = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to SVG(zip) and save the "ResultPdfToSvgZip.zip" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToSvgZip', "params": [event.target.result, e.target.files[0].name, "ResultPdfToSvgZip.zip"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToSvgZip = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to SVG(zip) and save the "ResultPdfToSvgZip.zip"*/
+      const json = AsposePdfPagesToSvgZip(event.target.result, e.target.files[0].name, "ResultPdfToSvgZip.zip");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/zip");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdfpagestotiff/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdfpagestotiff/_index.md
@@ -1,0 +1,84 @@
+---
+title: "AsposePdfPagesToTiff"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till TIFF."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdfpagestotiff/
+---
+
+_Konvertera en PDF-fil till TIFF._
+
+```
+function AsposePdfPagesToTiff(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToTiff{0:D2}.tiff" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - tiff files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(pages) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "image/tiff", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToTiff = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPagesToTiff', "params": [event.target.result, e.target.files[0].name, "ResultPdfToTiff{0:D2}.tiff", 150] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToTiff = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+      const json = AsposePdfPagesToTiff(event.target.result, e.target.files[0].name, "ResultPdfToTiff{0:D2}.tiff", 150);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/tiff");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdftablestocsv/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftablestocsv/_index.md
@@ -1,0 +1,84 @@
+---
+title: "AsposePdfTablesToCSV"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till CSV (extrahera tabeller)."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftablestocsv/
+---
+
+_Konvertera en PDF-fil till CSV (extrahera tabeller)._
+
+```
+function AsposePdfTablesToCSV(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    delimiter
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfTablesToCSV{0:D2}.csv" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **delimiter** delimiter for csv (comma-separated value), default ";"
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - csv files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(tables) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "text/csv", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToCSV = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfTablesToCSV', "params": [event.target.result, e.target.files[0].name, "ResultPdfTablesToCSV{0:D2}.csv", "\t"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToCSV = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter*/
+      const json = AsposePdfTablesToCSV(event.target.result, e.target.files[0].name, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(tables) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "text/csv");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/convert/asposepdftodoc/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftodoc/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToDoc"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till Doc."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftodoc/
+---
+
+_Konvertera en PDF-fil till Doc._
+
+```js
+function AsposePdfToDoc(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/msword", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToDoc = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToDoc', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoDoc.doc"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToDoc = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+      const json = AsposePdfToDoc(event.target.result, e.target.files[0].name, "ResultPDFtoDoc.doc");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/msword");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftodocx/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftodocx/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfToDocX"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till DocX."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftodocx/
+---
+
+_Konvertera en PDF-fil till DocX._
+
+```js
+function AsposePdfToDocX(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToDocX = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfToDocX', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoDocX.docx"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToDocX = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+      const json = AsposePdfToDocX(event.target.result, e.target.files[0].name, "ResultPDFtoDocX.docx");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftodocxenhanced/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftodocxenhanced/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToDocXEnhanced"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftodocxenhanced/
+---
+
+_Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge (fullt redigerbara tabeller och stycken)._
+
+```js
+function AsposePdfToDocXEnhanced(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToDocXEnhanced = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to DocX and with Enhanced Recognition Mode (fully editable tables and paragraphs) save the "ResultPDFtoDocXEnhanced.docx" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToDocXEnhanced', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoDocXEnhanced.docx"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToDocXEnhanced = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+      const json = AsposePdfToDocXEnhanced(event.target.result, e.target.files[0].name, "ResultPDFtoDocXEnhanced.docx");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftoepub/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftoepub/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToEPUB"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till ePub."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftoepub/
+---
+
+_Konvertera en PDF-fil till ePub._
+
+```js
+function AsposePdfToEPUB(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/epub+zip", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToEPUB = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToEPUB', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoEPUB.epub"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToEPUB = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to EPUB and save the "ResultPDFtoEPUB.epub"*/
+      const json = AsposePdfToEPUB(event.target.result, e.target.files[0].name, "ResultPDFtoEPUB.epub");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/epub+zip");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftomarkdown/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftomarkdown/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToMarkdown"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till Markdown."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftomarkdown/
+---
+
+_Konvertera en PDF-fil till Markdown._
+
+```js
+function AsposePdfToMarkdown(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "text/markdown", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToMarkdown = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToMarkdown', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoMarkdown.md"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToMarkdown = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+      const json = AsposePdfToMarkdown(event.target.result, e.target.files[0].name, "ResultPDFtoMarkdown.md");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "text/markdown");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftopptx/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftopptx/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToPptX"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till PptX."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftopptx/
+---
+
+_Konvertera en PDF-fil till PptX._
+
+```js
+function AsposePdfToPptX(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.openxmlformats-officedocument.presentationml.presentation", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToPptX = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToPptX', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoPptX.pptx"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToPptX = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+      const json = AsposePdfToPptX(event.target.result, e.target.files[0].name, "ResultPDFtoPptX.pptx");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftotex/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftotex/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToTeX"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till TeX."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftotex/
+---
+
+_Konvertera en PDF-fil till TeX._
+
+```js
+function AsposePdfToTeX(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/x-tex", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToTeX = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToTeX', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoTeX.tex"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToTeX = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+      const json = AsposePdfToTeX(event.target.result, e.target.files[0].name, "ResultPDFtoTeX.tex");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/x-tex");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftotxt/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftotxt/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToTxt"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till Txt."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftotxt/
+---
+
+_Konvertera en PDF-fil till Txt._
+
+```js
+function AsposePdfToTxt(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "text/plain", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToTxt = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToTxt', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoTxt.txt"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToTxt = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+      const json = AsposePdfToTxt(event.target.result, e.target.files[0].name, "ResultPDFtoTxt.txt");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "text/plain");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftoxlsx/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftoxlsx/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfToXlsX"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till XlsX."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftoxlsx/
+---
+
+_Konvertera en PDF-fil till XlsX._
+
+```js
+function AsposePdfToXlsX(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToXlsX = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfToXlsX', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoXlsX.xlsx"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToXlsX = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+      const json = AsposePdfToXlsX(event.target.result, e.target.files[0].name, "ResultPDFtoXlsX.xlsx");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convert/asposepdftoxps/_index.md
+++ b/swedish/javascript-cpp/convert/asposepdftoxps/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfToXps"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en PDF-fil till Xps."
+type: docs
+url: /sv/javascript-cpp/convert/asposepdftoxps/
+---
+
+_Konvertera en PDF-fil till Xps._
+
+```js
+function AsposePdfToXps(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/vnd.ms-xpsdocument", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileToXps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfToXps', "params": [event.target.result, e.target.files[0].name, "ResultPDFtoXps.xps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileToXps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+      const json = AsposePdfToXps(event.target.result, e.target.files[0].name, "ResultPDFtoXps.xps");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/vnd.ms-xpsdocument");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convertpdf/_index.md
+++ b/swedish/javascript-cpp/convertpdf/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Konvertera till PDF-funktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Funktioner för konvertering till PDF-filer."
+type: docs
+url: /sv/javascript-cpp/convertpdf/
+---
+
+## Convert to PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfFromTxt](./asposepdffromtxt/) | Konvertera en TXT-fil till PDF. |
+| [AsposePdfFromImage](./asposepdffromimage/) | Konvertera en bildfil till PDF. |
+
+## Detailed Description
+
+Funktioner för konvertering till PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```
+

--- a/swedish/javascript-cpp/convertpdf/asposepdffromimage/_index.md
+++ b/swedish/javascript-cpp/convertpdf/asposepdffromimage/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposePdfFromImage"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en bildfil till PDF."
+type: docs
+url: /sv/javascript-cpp/convertpdf/asposepdffromimage/
+---
+
+_Konvertera en bildfil till PDF._
+
+```js
+function AsposePdfFromImage(
+    fileBlob,
+    fileName,
+    pdfPageSize,
+    margin,
+    isLandscape,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** image file name (support bmp, jpeg, png, tiff, gif formats)
+* **pdfPageSize**  page size:
+  * Module.PdfPageSize.A0
+  * Module.PdfPageSize.A1
+  * Module.PdfPageSize.A2
+  * Module.PdfPageSize.A3
+  * Module.PdfPageSize.A4
+  * Module.PdfPageSize.A5
+  * Module.PdfPageSize.A6
+  * Module.PdfPageSize.B5
+  * Module.PdfPageSize.PageLetter
+  * Module.PdfPageSize.PageLegal
+  * Module.PdfPageSize.PageLedger
+  * Module.PdfPageSize.P11x17
+  * Module.PdfPageSize.ImageSize
+* **margin** page margin
+* **isLandscape** page landscape mode (0 or 1)
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFromImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfFromImage', "params": [event.target.result, e.target.files[0].name, 'Module.PdfPageSize.A4', 0, true, "ResultPDFFromImage.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileFromImage = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+      const json = AsposePdfFromImage(event.target.result, e.target.files[0].name, Module.PdfPageSize.A4, 10, false, "ResultPDFFromImage.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/convertpdf/asposepdffromtxt/_index.md
+++ b/swedish/javascript-cpp/convertpdf/asposepdffromtxt/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfFromTxt"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Konvertera en TXT-fil till PDF."
+type: docs
+url: /sv/javascript-cpp/convertpdf/asposepdffromtxt/
+---
+
+_Konvertera en TXT-fil till PDF._
+
+```js
+function AsposePdfFromTxt(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFromTxt = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.txt" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfFromTxt', "params": [event.target.result, e.target.files[0].name, "ResultPDFFromTxt.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileFromTxt = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+      const json = AsposePdfFromTxt(event.target.result, e.target.files[0].name, "ResultPDFFromTxt.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/core/_index.md
+++ b/swedish/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Kärnfunktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Kärnfunktioner för att arbeta med PDF-filer."
+type: docs
+url: /sv/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfPrepare](./asposepdfprepare/) | Spara BLOB:en i Memory FS för bearbetning. |
+| [AsposePdfPrepareBase64](./asposepdfpreparebase64/) | Spara strängrepresentationen av BLOB i Memory FS för bearbetning. |
+
+## Detailed Description
+
+Kärnfunktioner för att arbeta med PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```

--- a/swedish/javascript-cpp/core/asposepdfprepare/_index.md
+++ b/swedish/javascript-cpp/core/asposepdfprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePdfPrepare"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Spara BLOB:en i Memory FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposepdfprepare/
+---
+
+_Spara BLOB:en i minnes-FS för bearbetning._
+
+```js
+function AsposePdfPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePdfAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/core/asposepdfpreparebase64/_index.md
+++ b/swedish/javascript-cpp/core/asposepdfpreparebase64/_index.md
@@ -1,0 +1,69 @@
+---
+title: "AsposePdfPrepareBase64"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Spara strängrepresentationen av BLOB i Memory FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposepdfpreparebase64/
+---
+
+_Spara BLOB:s strängrepresentation i minnes-FS för bearbetning._
+
+```js
+function AsposePdfPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+
+**Web Worker example:** doesn't work, use AsposePdfPrepare
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePdfPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePdfPrepareBase64 for Web Worker*/
+  const AsposePdfPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePDFWebWorker.postMessage(
+                 { "operation": 'AsposePdfPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileSignPKCS7 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePdfPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Sign a PDF-file and save the "ResultSignPKCS7.pdf"*/
+      const json = AsposePdfSignPKCS7(event.target.result, e.target.files[0].name, 1, "test.pfx", "Password", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, "/Aspose.jpg","ResultSignPKCS7.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/_index.md
+++ b/swedish/javascript-cpp/metadata/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Metadata PDF-funktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Funktioner för att arbeta med Metadata PDF-filer"
+type: docs
+url: /sv/javascript-cpp/metadata/
+---
+
+## Metadata PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfSetInfo](./asposepdfsetinfo/) | Ställ in information (metadata) i en PDF-fil. |
+| [AsposePdfGetInfo](./asposepdfgetinfo/) | Hämta information (metadata) från en PDF-fil. |
+| [AsposePdfGetAllFonts](./asposepdfgetallfonts/) | Hämta lista över teckensnitt från en PDF-fil. |
+| [AsposePdfRemoveMetadata](./asposepdfremovemetadata/) | Ta bort metadata från en PDF-fil. |
+| [AsposePdfGetWordsCharactersCount](./asposepdfgetwordscharacterscount/) | Hämta antal ord och tecken i en PDF-fil. |
+| [AsposePdfGetPagesLayers](./asposepdfgetpageslayers/) | Hämta lista över lager från en PDF-fil. |
+
+
+## Detailed Description
+
+Funktioner för att arbeta med Metadata PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```

--- a/swedish/javascript-cpp/metadata/asposepdfgetallfonts/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfgetallfonts/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfGetAllFonts"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta lista över teckensnitt från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfgetallfonts/
+---
+
+_Hämta lista med teckensnitt från en PDF-fil._
+
+```js
+function AsposePdfGetAllFonts(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fonts** - array of : 
+  * fontName - font name
+  * isEmbedded - indicates whether the font is embedded
+  * isAccessible - indicating whether the font is present
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `fonts:\n${JSON.stringify(evt.data.json.fonts, null, 4)}` :
+        `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffilePdfGetAllFonts = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get list fonts from a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfGetAllFonts', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffilePdfGetAllFonts = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Get list fonts from a PDF-file*/
+      const json = AsposePdfGetAllFonts(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) document.getElementById('output').textContent = "JSON:\n" + JSON.stringify(json, null, 4)
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/asposepdfgetinfo/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfgetinfo/_index.md
@@ -1,0 +1,163 @@
+---
+title: "AsposePdfGetInfo"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta information (metadata) från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfgetinfo/
+---
+
+_Hämta information (metadata) från en PDF-fil._
+
+```js
+function AsposePdfGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **title** - title
+* **creator** - creator
+* **author** - author
+* **subject** - subject
+* **keywords** - keywords
+* **creation** - creation date
+* **mod** - modify date
+* **format** - PDF format
+* **version** - PDF version
+* **ispdfa** - PDF is PDF/A
+* **ispdfua** - PDF is PDF/UA
+* **islinearized** - PDF is linearized
+* **isencrypted** - PDF is encrypted
+* **permission** - PDF permission
+* **size** - PDF page size
+* **pagecount** - Page count
+* **annotationcount** - Annotation count
+* **bookmarkcount** - Bookmark count
+* **attachmentcount** - Attachment count
+* **metadatacount** - Metadata count
+* **javascriptcount** - JavaScript count
+* **imagecount** - Image count
+* **tablecount** - Table count
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = (evt) =>
+  console.log(`Error from Web Worker: ${evt.message}`);
+AsposePDFWebWorker.onmessage = (evt) =>
+  (document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? `info:\n${JSON.stringify(evt.data.json, null, 4)}`
+      : `Error: ${evt.data.json.errorText}`);
+evt.data.json.errorCode !== 0
+  ? `Error: ${evt.data.json.errorText}`
+  : "Title               : " + evt.data.json.title +
+    "\nCreator           : " + evt.data.json.creator +
+    "\nAuthor            : " + evt.data.json.author +
+    "\nSubject           : " + evt.data.json.subject +
+    "\nKeywords          : " + evt.data.json.keywords +
+    "\nCreation Date     : " + evt.data.json.creation +
+    "\nModify Date       : " + evt.data.json.mod +
+    "\nPDF format        : " + evt.data.json.format +
+    "\nPDF version       : " + evt.data.json.version +
+    "\nPDF is PDF/A      : " + evt.data.json.ispdfa +
+    "\nPDF is PDF/UA     : " + evt.data.json.ispdfua +
+    "\nPDF is linearized : " + evt.data.json.islinearized +
+    "\nPDF is encrypted  : " + evt.data.json.encrypted +
+    "\nPDF permission    : " + evt.data.json.permission +
+    "\nPDF page size     : " + evt.data.json.size +
+    "\nPage count        : " + evt.data.json.pagecount +
+    "\nAnnotation count  : " + evt.data.json.annotationcount +
+    "\nBookmark count    : " + evt.data.json.bookmarkcount +
+    "\nAttachment count  : " + evt.data.json.attachmentcount +
+    "\nMetadata count    : " + evt.data.json.metadatacount +
+    "\nJavaScript count  : " + evt.data.json.javascriptcount +
+    "\nImage count       : " + evt.data.json.imagecount +
+    "\nTable count       : " + evt.data.json.tablecount;
+
+  /*Event handler*/
+  const ffilePdfGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffilePdfGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Get info (metadata) from a PDF-file*/
+      const json = AsposePdfGetInfo(event.target.result, e.target.files[0].name);
+      /* JSON
+       Title             : json.title
+       Creator           : json.creator
+       Author            : json.author
+       Subject           : json.subject
+       Keywords          : json.keywords
+       Creation Date     : json.creation
+       Modify Date       : json.mod
+       PDF format        : json.format
+       PDF version       : json.version
+       PDF is PDF/A      : json.ispdfa
+       PDF is PDF/UA     : json.ispdfua
+       PDF is linearized : json.islinearized
+       PDF is encrypted  : json.isencrypted
+       PDF permission    : json.permission
+       PDF page size     : json.size
+       Page count        : json.pagecount
+       Annotation count  : json.annotationcount
+       Bookmark count    : json.bookmarkcount
+       Attachment count  : json.attachmentcount
+       Metadata count    : json.metadatacount
+       JavaScript count  : json.javascriptcount
+       Image count       : json.imagecount
+       Table count       : json.tablecount
+      */
+      if (json.errorCode == 0) document.getElementById('output').textContent = 
+          "Title               : " + json.title
+        + "\nCreator           : " + json.creator
+        + "\nAuthor            : " + json.author
+        + "\nSubject           : " + json.subject
+        + "\nKeywords          : " + json.keywords
+        + "\nCreation Date     : " + json.creation
+        + "\nModify Date       : " + json.mod
+        + "\nPDF format        : " + json.format
+        + "\nPDF version       : " + json.version
+        + "\nPDF is PDF/A      : " + json.ispdfa
+        + "\nPDF is PDF/UA     : " + json.ispdfua
+        + "\nPDF is linearized : " + json.islinearized
+        + "\nPDF is encrypted  : " + json.isencrypted
+        + "\nPDF permission    : " + json.permission
+        + "\nPDF page size     : " + json.size
+        + "\nPage count        : " + json.pagecount
+        + "\nAnnotation count  : " + json.annotationcount
+        + "\nBookmark count    : " + json.bookmarkcount
+        + "\nAttachment count  : " + json.attachmentcount
+        + "\nMetadata count    : " + json.metadatacount
+        + "\nJavaScript count  : " + json.javascriptcount
+        + "\nImage count       : " + json.imagecount
+        + "\nTable count       : " + json.tablecount
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/asposepdfgetpageslayers/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfgetpageslayers/_index.md
@@ -1,0 +1,63 @@
+---
+title: "AsposePdfGetPagesLayers"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta lista över lager från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfgetpageslayers/
+---
+
+_Hämta lista med lager från en PDF-fil._
+
+```js
+function AsposePdfGetPagesLayers(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **pagesLayers[][]** - list of pages with lists of layers on each page
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `first page layers:\n${JSON.stringify(evt.data.json.pagesLayers[0], null, 4)}` : `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffilePdfGetPagesLayers = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get list layers from a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfGetPagesLayers', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffilePdfGetPagesLayers = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Get list layers from a PDF-file*/
+      const json = AsposePdfGetPagesLayers(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) document.getElementById('output').textContent = "JSON:\n" + JSON.stringify(json, null, 4)
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
@@ -1,0 +1,63 @@
+---
+title: "AsposePdfGetWordsCharactersCount"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta antal ord och tecken i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfgetwordscharacterscount/
+---
+
+_Hämta antal ord och tecken i en PDF-fil._
+
+```js
+function AsposePdfGetWordsCharactersCount(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **words** - words count
+* **characters** - characters count
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `\nWords count:${evt.data.json.words}\nCharacters count:${evt.data.json.characters}` : `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffilePdfGetWordsCharactersCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get words and characters count in a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfGetWordsCharactersCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffilePdfGetWordsCharactersCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Get words and characters count in a PDF-file*/
+      const json = AsposePdfGetWordsCharactersCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) document.getElementById('output').textContent = "JSON:\n" + JSON.stringify(json, null, 4)
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/asposepdfremovemetadata/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfremovemetadata/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfRemoveMetadata"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort metadata från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfremovemetadata/
+---
+
+_Ta bort metadata från en PDF-fil._
+
+```js
+function AsposePdfRemoveMetadata(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfRemoveMetadata = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfRemoveMetadata', "params": [event.target.result, e.target.files[0].name, "ResultPdfRemoveMetadata.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfRemoveMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+      const json = AsposePdfRemoveMetadata(event.target.result, e.target.files[0].name, "ResultPdfRemoveMetadata.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/metadata/asposepdfsetinfo/_index.md
+++ b/swedish/javascript-cpp/metadata/asposepdfsetinfo/_index.md
@@ -1,0 +1,111 @@
+---
+title: "AsposePdfSetInfo"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ställ in information (metadata) i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposepdfsetinfo/
+---
+
+_Ställ in information (metadata) i en PDF-fil._
+
+```js
+function AsposePdfSetInfo(
+    fileBlob,
+    fileName,
+    title, 
+    creator, 
+    author,
+    subject,
+    keywords,
+    creation,
+    mod,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **title** title
+* **creator** creator
+* **author** author
+* **subject** subject
+* **keywords** list keywords
+* **creation** creation date
+* **mod** modify date
+* **fileNameResult** result file name
+
+För 'title', 'creator', 'author', 'subject', 'keywords', 'creation' och 'mod', om du inte behöver ange ett värde, använd undefined eller "" (tom sträng)
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+      const title = 'Setting PDF Document Information';
+      const creator = ''; /*if not need to set value, use: undefined or ""/'' (empty string)*/
+      const author = 'Aspose';
+      const subject = undefined;
+      const keywords = 'Aspose.Pdf, DOM, API';
+      const creation = undefined; /*create date*/
+      const mod = '2008/12/21 12:15:12'; /*modify date*/
+      /*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfSetInfo',
+          "params": [event.target.result, e.target.files[0].name, title, creator, author, subject, keywords, creation, mod, "ResultSetInfo.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+      /*If not need to set value, use undefined or "" (empty string)*/
+      /*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+      const json = AsposePdfSetInfo(event.target.result, e.target.files[0].name, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "2008/12/21 12:15:12", "ResultSetInfo.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/misc/_index.md
+++ b/swedish/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Övriga funktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Sekundära funktioner för att arbeta med PDF-filer."
+type: docs
+url: /sv/javascript-cpp/misc/
+---
+## Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfAbout](./asposepdfabout/) | Hämta information om Product. |
+| [DownloadFile](./downloadfile/) | Skapa en länk i HTML för att ladda ner filen. |
+| [DownloadFileAuto](./downloadfileauto/) | Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```

--- a/swedish/javascript-cpp/misc/asposepdfabout/_index.md
+++ b/swedish/javascript-cpp/misc/asposepdfabout/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfAbout"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta information om Product."
+type: docs
+url: /sv/javascript-cpp/misc/asposepdfabout/
+---
+
+_Hämta information om produkten._
+
+```js
+function AsposePdfAbout()
+```
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **product** - Product name
+* **family** - Product family
+* **version** - Product version
+* **releasedate** - Date release
+* **producer** - Full name/producer
+* **islicensed** - Product is licensed
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nFamily       : " + evt.data.json.family
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nRelease date : " + evt.data.json.releasedate
+                    + "\nProducer     : " + evt.data.json.producer
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePdfAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePdfAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePdfAbout();
+    /* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+    */
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nFamily       : " + json.family
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nRelease date : " + json.releasedate
+                                                                         + "\nProducer     : " + json.producer
+                                                                         + "\nIs licensed  : " + json.islicensed
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/swedish/javascript-cpp/misc/downloadfile/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfile/
+---
+
+_Skapa en länk i HTML för att ladda ner filen._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/swedish/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfileauto/
+---
+
+_Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder._
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/swedish/javascript-cpp/organize/_index.md
+++ b/swedish/javascript-cpp/organize/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Organisera PDF-funktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Funktioner för att organisera PDF-filer."
+type: docs
+url: /sv/javascript-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfOptimize](./asposepdfoptimize/) | Optimera en PDF-fil. |
+| [AsposePdfMerge2Files](./asposepdfmerge2files/) | Slå ihop två PDF-filer. |
+| [AsposePdfSplit2Files](./asposepdfsplit2files/) | Dela upp i två PDF-filer. |
+| [AsposePdfRotateAllPages](./asposepdfrotateallpages/) | Rotera PDF-sidor. |
+| [AsposePdfDeletePages](./asposepdfdeletepages/) | Ta bort sidor från en PDF-fil. |
+| [AsposePdfAddStamp](./asposepdfaddstamp/) | Lägg till stämpel i en PDF-fil. |
+| [AsposePdfAddStampPages](./asposepdfaddstamppages/) | Lägg till stämpel på specifika sidor i en PDF-fil. |
+| [AsposePdfAddImage](./asposepdfaddimage/) | Lägg till en bild i slutet av en PDF-fil. |
+| [AsposePdfAddPageNum](./asposepdfaddpagenum/) | Lägg till sidnummer i en PDF-fil. |
+| [AsposePdfAddBackgroundImage](./asposepdfaddbackgroundimage/) | Lägg till bakgrundsbild i en PDF-fil. |
+| [AsposePdfAddTextHeaderFooter](./asposepdfaddtextheaderfooter/) | Lägg till text i sidhuvud/sidfot i en PDF-fil. |
+| [AsposePdfRepair](./asposepdfrepair/) | Reparera en PDF-fil. |
+| [AsposePdfOptimizeResource](./asposepdfoptimizeresource/) | Optimera resurser i PDF-filen. |
+| [AsposePdfSetBackgroundColor](./asposepdfsetbackgroundcolor/) | Ställ in bakgrundsfärgen för PDF-filen. |
+| [AsposePdfDeleteAnnotations](./asposepdfdeleteannotations/) | Ta bort anteckningar från en PDF-fil. |
+| [AsposePdfDeleteBookmarks](./asposepdfdeletebookmarks/) | Ta bort bokmärken från en PDF-fil. |
+| [AsposePdfDeleteAttachments](./asposepdfdeleteattachments/) | Ta bort bilagor från en PDF-fil. |
+| [AsposePdfDeleteImages](./asposepdfdeleteimages/) | Ta bort bilder från en PDF-fil. |
+| [AsposePdfDeleteJavaScripts](./asposepdfdeletejavascripts/) | Ta bort JavaScript från en PDF-fil. |
+| [AsposePdfAddAttachment](./asposepdfaddattachment/) | Lägg till bilaga till en PDF-fil. |
+| [AsposePdfGetAttachment](./asposepdfgetattachment/) | Hämta bilaga från en PDF-fil. |
+| [AsposePdfReplaceText](./asposepdfreplacetext/) | Ersätt text i en PDF-fil. |
+| [AsposePdfReplaceTextPages](./asposepdfreplacetextpages/) | Ersätt text på sidor i en PDF-fil. |
+| [AsposePdfFindText](./asposepdffindtext/) | Hitta text i en PDF-fil. |
+| [AsposePdfReplaceFont](./asposepdfreplacefont/) | Ersätt teckensnitt i en PDF-fil. |
+| [AsposePdfValidatePDFA](./asposepdfvalidatepdfa/) | Validera PDF/A-kompatibilitet för en PDF-fil. |
+| [AsposePdfFindHiddenText](./asposepdffindhiddentext/) | Hitta dold text i en PDF-fil. |
+| [AsposePdfDeleteHiddenText](./asposepdfdeletehiddentext/) | Ta bort dold text från en PDF-fil. |
+| [AsposePdfAddWatermark](./asposepdfaddwatermark/) | Lägg till vattenstämpel till en PDF-fil. |
+| [AsposePdfDeleteWatermarks](./asposepdfdeletewatermarks/) | Ta bort vattenstämplar från en PDF-fil. |
+| [AsposePdfMergeLayers](./asposepdfmergelayers/) | Slå samman lager i en PDF-fil. |
+| [AsposePdfFlatten](./asposepdfflatten/) | Platta till en PDF-fil. |
+| [AsposePdfMakeBooklet](./asposepdfmakebooklet/) | Skapa häfte från en PDF-fil. |
+| [AsposePdfMakeNUp](./asposepdfmakenup/) | Skapa N-Up-dokument från en PDF-fil. |
+| [AsposePdfDeleteBlankPages](./asposepdfdeleteblankpages/) | Ta bort tomma sidor från en PDF-fil. |
+| [AsposePdfEmbedFonts](./asposepdfembedfonts/) | Bädda in teckensnitt i en PDF-fil. |
+| [AsposePdfUnembedFonts](./asposepdfunembedfonts/) | Ta bort inbäddade teckensnitt från en PDF-fil. |
+| [AsposePdfOptimizeFileSize](./asposepdfoptimizefilesize/) | Optimera storleken på PDF-filen med bildkomprimeringskvalitet. |
+| [AsposePdfDeleteTables](./asposepdfdeletetables/) | Ta bort tabeller från en PDF-fil. |
+| [AsposePdfCropPages](./asposepdfcroppages/) | Beskär PDF-sidor. |
+| [AsposePdfDeleteTextHeaders](./asposepdfdeletetextheaders/) | Ta bort textrubriker från en PDF-fil. |
+| [AsposePdfDeleteTextFooters](./asposepdfdeletetextfooters/) | Ta bort textfotnoter från en PDF-fil. |
+| [AsposePdfReplaceTextEx](./asposepdfreplacetextex/) | Ersätt flera textfragment i en PDF-fil med justeringskontroll. |
+| [AsposePdfRecover](./asposepdfrecover/) | Återskapa en PDF-filstruktur och rensa ogiltiga data. |
+| [AsposePdfRebuildXrefAndTrailer](./asposepdfrebuildxrefandtrailer/) | Bygg om en PDF-fils korsreferenstabell och trailer-strukturer. |
+| [AsposePdfReversePages](./asposepdfreversepages/) | Vänd på sidordningen i en PDF-fil. |
+
+
+## Detailed Description
+
+Funktioner för att organisera PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddattachment/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddattachment/_index.md
@@ -1,0 +1,107 @@
+---
+title: "AsposePdfAddAttachment"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till bilaga till en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddattachment/
+---
+
+_Lägg till bilaga till en PDF-fil._
+
+```js
+function AsposePdfAddAttachment(
+    fileBlob,
+    fileName,
+    fileAttachment,
+    fileDescription,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileAttachment** attachment file name
+* **fileDescription** attachment description
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ? 'attachment prepared!': DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  var fileAttachment;
+
+  /*Event handler*/
+  const ffileAddAttachment = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfAddAttachment', "params": [event.target.result, e.target.files[0].name, fileAttachment, 'Description', "ResultPdfAddAttachment.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileAttachment = e => {
+    const file_reader = new FileReader();
+    /*Set attachment's filename*/
+    fileAttachment = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var fileAttachment;
+
+  var ffileAttachment = function (e) {
+    const file_reader = new FileReader();
+    /*Set attachment's filename*/
+    fileAttachment = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileAttachment);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileAddAttachment = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+      const json = AsposePdfAddAttachment(event.target.result, e.target.files[0].name, fileAttachment, 'Description', "ResultPdfAddAttachment.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddbackgroundimage/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddbackgroundimage/_index.md
@@ -1,0 +1,120 @@
+---
+title: "AsposePdfAddBackgroundImage"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till bakgrundsbild i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddbackgroundimage/
+---
+
+_Lägg till bakgrundsbild i en PDF-fil._
+
+```js
+function AsposePdfAddBackgroundImage(
+    fileBlob,
+    fileName,
+    fileBackgroundImage,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileBackgroundImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ?
+          'image prepared!':
+          DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default image filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var fileBackgroundImage = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileAddBackgroundImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAddBackgroundImage',
+          "params": [event.target.result, e.target.files[0].name, fileBackgroundImage, "ResultBackgroundImage.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    fileBackgroundImage = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default image filename*/
+  var fileBackgroundImage = "/Aspose.jpg";
+
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    fileBackgroundImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileBackgroundImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileAddBackgroundImage = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+      const json = AsposePdfAddBackgroundImage(event.target.result, e.target.files[0].name, fileBackgroundImage, "ResultBackgroundImage.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddimage/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddimage/_index.md
@@ -1,0 +1,118 @@
+---
+title: "AsposePdfAddImage"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till en bild i slutet av en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddimage/
+---
+
+_Lägg till en bild i slutet av en PDF-fil._
+
+```js
+function AsposePdfAddImage(
+    fileBlob,
+    fileName,
+    fileImage,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ?
+          'image prepared!':
+          DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default image filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var fileImage = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileAddImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Add an image to end a PDF-file and save the "ResultImage.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAddImage',
+          "params": [event.target.result, e.target.files[0].name, fileImage, "ResultImage.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    fileImage = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default image filename*/
+  var fileImage = "/Aspose.jpg";
+
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileAddImage = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+      const json = AsposePdfAddImage(event.target.result, e.target.files[0].name, fileImage, "ResultImage.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddpagenum/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddpagenum/_index.md
@@ -1,0 +1,84 @@
+---
+title: "AsposePdfAddPageNum"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till sidnummer i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddpagenum/
+---
+
+_Lägg till sidnummer i en PDF-fil._
+
+```js
+function AsposePdfAddPageNum(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileAddPageNum = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Add page number to a PDF-file and save the "ResultAddPageNum.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAddPageNum', "params": [event.target.result, e.target.files[0].name, "ResultAddPageNum.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileAddPageNum = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add page number to a PDF-file and save the "ResultAddPageNum.pdf"*/
+      const json = AsposePdfAddPageNum(event.target.result, e.target.files[0].name, "ResultAddPageNum.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddstamp/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddstamp/_index.md
@@ -1,0 +1,146 @@
+---
+title: "AsposePdfAddStamp"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till stämpel i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddstamp/
+---
+
+_Lägg till en stämpel till en PDF-fil._
+
+```js
+function AsposePdfAddStamp(
+    fileBlob,
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileBlob** Blob object
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ?
+          'image prepared!':
+          DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default stamp filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var fileStamp = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileAddStamp = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const setBackground = 0;
+      const setXIndent_ = 5;
+      const setYIndent_ = 5;
+      const setHeight_ = 40;
+      const setWidth_ = 40;
+      const rotation_ = 'Module.Rotation.on270';
+      const setOpacity = 0.5;
+      /*Add stamp to a PDF-file and save the "ResultStamp.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAddStamp',
+          "params": [event.target.result, e.target.files[0].name, fileStamp, setBackground, setXIndent_, setYIndent_,
+                     setHeight_, setWidth_, rotation_, setOpacity, "ResultStamp.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileStamp = e => {
+    const file_reader = new FileReader();
+    /*Set the stamp filename*/
+    fileStamp = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+          { "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] },
+          [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default stamp filename*/
+  var fileStamp = "/Aspose.jpg";
+
+  var ffileStamp = function (e) {
+    const file_reader = new FileReader();
+    /*Set the stamp filename*/
+    fileStamp = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileStamp);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileAddStamp = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add stamp to a PDF-file and save the "ResultImage.pdf"*/
+      const json = AsposePdfAddStamp(event.target.result, e.target.files[0].name, fileStamp, 0, 5, 5, 40, 40, Module.Rotation.on270, 0.5, "ResultStamp.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddstamppages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddstamppages/_index.md
@@ -1,0 +1,140 @@
+---
+title: "AsposePdfAddStampPages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till stämpel på specifika sidor i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddstamppages/
+---
+
+_Lägg till stämpel på specifika sidor i en PDF-fil._
+
+```js
+function AsposePdfAddStampPages(
+    fileBlob,
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**:
+
+* **fileBlob** Blob object
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ? 'image prepared!': DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default stamp filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var fileStamp = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileAddStampPages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const setBackground = 0;
+      const setXIndent_ = 15;
+      const setYIndent_ = 15;
+      const setHeight_ = 50;
+      const setWidth_ = 50;
+      const rotation_ = 'Module.Rotation.on90';
+      const setOpacity = 0.7;
+      const numPage = 1;
+      /*Add stamp to a PDF-file on page #1 and save the "ResultStampPages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfAddStampPages', "params": [event.target.result, e.target.files[0].name, fileStamp, setBackground, setXIndent_, setYIndent_, setHeight_, setWidth_, rotation_, setOpacity, numPage, "ResultStampPages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileStamp = e => {
+    const file_reader = new FileReader();
+    /*Set the stamp filename*/
+    fileStamp = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPrepare', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default stamp filename*/
+  var fileStamp = "/Aspose.jpg";
+
+  var ffileStamp = function (e) {
+    const file_reader = new FileReader();
+    /*Set the stamp filename*/
+    fileStamp = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileStamp);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileAddStampPages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add stamp to a PDF-file on page #1 and save the "ResultStampPages.pdf"*/
+      const json = AsposePdfAddStampPages(event.target.result, e.target.files[0].name, fileStamp, 0, 15, 15, 50, 50, Module.Rotation.on90, 0.7, 1, "ResultStampPages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddtextheaderfooter/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddtextheaderfooter/_index.md
@@ -1,0 +1,91 @@
+---
+title: "AsposePdfAddTextHeaderFooter"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till text i sidhuvud/sidfot i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddtextheaderfooter/
+---
+
+_Lägg till text i sidhuvud/sidfot i en PDF-fil._
+
+```js
+function AsposePdfAddTextHeaderFooter(
+    fileBlob,
+    fileName,
+    header, 
+    footer,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **header** page header, if not need to set, use undefined or "" (empty string)
+* **footer** page footer, if not need to set, use undefined or "" (empty string)
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileAddTextHeaderFooter = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const header = 'Aspose.PDF for JavaScript via C++';
+      const footer = 'ASPOSE';
+      /*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfAddTextHeaderFooter',
+          "params": [event.target.result, e.target.files[0].name, header, footer, "ResultAddHeaderFooter.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileAddTextHeaderFooter = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add text in Header/Footer of a PDF-file and save the "ResultAddHeader.pdf"*/
+      const json = AsposePdfAddTextHeaderFooter(event.target.result, e.target.files[0].name, "Aspose.PDF for JavaScript via C++", "", "ResultAddHeader.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfaddwatermark/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfaddwatermark/_index.md
@@ -1,0 +1,106 @@
+---
+title: "AsposePdfAddWatermark"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Lägg till vattenstämpel till en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfaddwatermark/
+---
+
+_Lägg till vattenstämpel i en PDF-fil._
+
+```js
+function AsposePdfAddWatermark(
+    fileBlob,
+    fileName,
+    text,
+    fontName,
+    fontSize,
+    foregroundColor,
+    xPosition,
+    yPosition,
+    rotation,
+    isBackground,
+    opacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **text** watermark text
+* **fontName** font name
+* **fontSize** font size
+* **foregroundColor** text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **xPosition** x watermark position
+* **yPosition** y watermark position
+* **rotation** watermark rotation (0-360)
+* **isBackground** background (1 or 0)
+* **opacity** opacity (decimal)
+* **fileNameResult** result file name
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileAddWatermark = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const text = "Aspose PDF";
+      const fontName = "Arial";
+      const fontSize = 32;
+      const foregroundColor = "#010101";
+      const xPosition = 100;
+      const yPosition = 100;
+      const rotation = 45;
+      const isBackground = 1;
+      const opacity = 0.5;
+      /*Add watermark to a PDF-file and save the "ResultPdfAddWatermark.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfAddWatermark', "params": [event.target.result, e.target.files[0].name, text, fontName, fontSize, foregroundColor, xPosition, yPosition, rotation, isBackground, opacity, "ResultPdfAddWatermark.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileAddWatermark = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Add watermark to a PDF-file and save the "ResultPdfAddWatermark.pdf"*/
+      const json = AsposePdfAddWatermark(event.target.result, e.target.files[0].name, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultPdfAddWatermark.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfcroppages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfcroppages/_index.md
@@ -1,0 +1,80 @@
+---
+title: "AsposePdfCropPages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Beskär PDF-sidor."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfcroppages/
+---
+
+_Beskär PDF-sidor._
+
+```js
+function AsposePdfCropPages(
+    fileBlob,
+    fileName,
+    margin,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **margin** page margin
+* **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileCropPages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const margin = 0.5;
+      /*Crop PDF-pages and save the "ResultPdfCropPages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfCropPages', "params": [event.target.result, e.target.files[0].name, margin, "ResultPdfCropPages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileCropPages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Crop PDF-pages and save the "ResultRotation.pdf"*/
+      const json = AsposePdfCropPages(event.target.result, e.target.files[0].name, 0, "ResultPdfCropPages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeleteannotations/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeleteannotations/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteAnnotations"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort anteckningar från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeleteannotations/
+---
+
+_Ta bort annotationer från en PDF-fil._
+
+```js
+function AsposePdfDeleteAnnotations(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteAnnotations = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteAnnotations', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteAnnotations.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteAnnotations = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete annotations from s PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+      const json = AsposePdfDeleteAnnotations(event.target.result, e.target.files[0].name, "ResultPdfDeleteAnnotations.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeleteattachments/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeleteattachments/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteAttachments"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort bilagor från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeleteattachments/
+---
+
+_Ta bort bilagor från en PDF-fil._
+
+```js
+function AsposePdfDeleteAttachments(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteAttachments = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteAttachments', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteAttachments.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteAttachments = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+      const json = AsposePdfDeleteAttachments(event.target.result, e.target.files[0].name, "ResultPdfDeleteAttachments.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeleteblankpages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeleteblankpages/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePdfDeleteBlankPages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort tomma sidor från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeleteblankpages/
+---
+
+_Ta bort tomma sidor från en PDF-fil._
+
+```js
+function AsposePdfDeleteBlankPages(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileDeleteBlankPages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteBlankPages', "params": [event.target.result, e.target.files[0].name, "ResultDeleteBlankPages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileDeleteBlankPages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+      const json = AsposePdfDeleteBlankPages(event.target.result, e.target.files[0].name, "ResultDeleteBlankPages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletebookmarks/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletebookmarks/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteBookmarks"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort bokmärken från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletebookmarks/
+---
+
+_Ta bort bokmärken från en PDF-fil._
+
+```js
+function AsposePdfDeleteBookmarks(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteBookmarks = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteBookmarks', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteBookmarks.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteBookmarks = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+      const json = AsposePdfDeleteBookmarks(event.target.result, e.target.files[0].name, "ResultPdfDeleteBookmarks.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletehiddentext/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletehiddentext/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteHiddenText"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort dold text från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletehiddentext/
+---
+
+_Ta bort dold text från en PDF-fil._
+
+```js
+function AsposePdfDeleteHiddenText(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteHiddenText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteHiddenText', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteHiddenText.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteHiddenText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+      const json = AsposePdfDeleteHiddenText(event.target.result, e.target.files[0].name, "ResultPdfDeleteHiddenText.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeleteimages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeleteimages/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteImages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort bilder från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeleteimages/
+---
+
+_Ta bort bilder från en PDF-fil._
+
+```js
+function AsposePdfDeleteImages(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteImages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteImages', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteImages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteImages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+      const json = AsposePdfDeleteImages(event.target.result, e.target.files[0].name, "ResultPdfDeleteImages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletejavascripts/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletejavascripts/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteJavaScripts"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort JavaScript från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletejavascripts/
+---
+
+_Ta bort JavaScripts från en PDF-fil._
+
+```js
+function AsposePdfDeleteJavaScripts(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteJavaScripts = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteJavaScripts', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteJavaScripts.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteJavaScripts = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+      const json = AsposePdfDeleteJavaScripts(event.target.result, e.target.files[0].name, "ResultPdfDeleteJavaScripts.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletepages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletepages/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposePdfDeletePages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort sidor från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletepages/
+---
+
+_Ta bort sidor från en PDF-fil._
+
+```js
+function AsposePdfDeletePages(
+    fileBlob,
+    fileName,
+    fileNameResult,
+    numPages
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileDeletePages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+      const numPages = "1-3";
+      /*array, array of number pages*/
+      /*const numPages = [1,3];*/
+      /*number, number page*/
+      /*const numPages = 1;*/
+      /*Delete pages from a PDF-file and save the "ResultDeletePages.pdf - Ask Web Worker"*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfDeletePages',
+          "params": [event.target.result, e.target.files[0].name, "ResultDeletePages.pdf", numPages] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileDeletePages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete pages from a PDF-file and save the "ResultOptimize.pdf"*/
+      const json = AsposePdfDeletePages(event.target.result, e.target.files[0].name, "ResultDeletePages.pdf", "1-3");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletetables/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletetables/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteTables"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort tabeller från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletetables/
+---
+
+_Ta bort tabeller från en PDF-fil._
+
+```js
+function AsposePdfDeleteTables(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteTables = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteTables', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteTables.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteTables = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+      const json = AsposePdfDeleteTables(event.target.result, e.target.files[0].name, "ResultPdfDeleteTables.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletetextfooters/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletetextfooters/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteTextFooters"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort textfotnoter från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletetextfooters/
+---
+
+_Ta bort textfotnoter från en PDF-fil._
+
+```js
+function AsposePdfDeleteTextFooters(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteTextFooters = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteTextFooters', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteTextFooters.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteTextFooters = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+      const json = AsposePdfDeleteTextFooters(event.target.result, e.target.files[0].name, "ResultPdfDeleteTextFooters.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletetextheaders/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletetextheaders/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteTextHeaders"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort textrubriker från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletetextheaders/
+---
+
+_Ta bort textrubriker från en PDF-fil._
+
+```js
+function AsposePdfDeleteTextHeaders(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteTextHeaders = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteTextHeaders', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteTextHeaders.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteTextHeaders = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+      const json = AsposePdfDeleteTextHeaders(event.target.result, e.target.files[0].name, "ResultPdfDeleteTextHeaders.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfdeletewatermarks/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfdeletewatermarks/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfDeleteWatermarks"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort vattenstämplar från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfdeletewatermarks/
+---
+
+_Ta bort vattenstämplar från en PDF-fil._
+
+```js
+function AsposePdfDeleteWatermarks(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfDeleteWatermarks = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfDeleteWatermarks', "params": [event.target.result, e.target.files[0].name, "ResultPdfDeleteWatermarks.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfDeleteWatermarks = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+      const json = AsposePdfDeleteWatermarks(event.target.result, e.target.files[0].name, "ResultPdfDeleteWatermarks.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfembedfonts/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfembedfonts/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePdfEmbedFonts"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Bädda in teckensnitt i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfembedfonts/
+---
+
+_Bädda in teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfEmbedFonts(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileEmbedFonts = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfEmbedFonts', "params": [event.target.result, e.target.files[0].name, "ResultEmbedFonts.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileEmbedFonts = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+      const json = AsposePdfEmbedFonts(event.target.result, e.target.files[0].name, "ResultEmbedFonts.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdffindhiddentext/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdffindhiddentext/_index.md
@@ -1,0 +1,69 @@
+---
+title: "AsposePdfFindHiddenText"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hitta dold text i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdffindhiddentext/
+---
+
+_Hitta dold text i en PDF-fil._
+
+```js
+function AsposePdfFindHiddenText(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `textFragments:\n${JSON.stringify(evt.data.json.textFragments, null, 4)}` : `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffilePdfFindHiddenText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Find hidden text in a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfFindHiddenText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffilePdfFindHiddenText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Find hidden text in a PDF-file*/
+      const json = AsposePdfFindHiddenText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) document.getElementById('output').textContent = "JSON:\n" + JSON.stringify(json, null, 4)
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdffindtext/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdffindtext/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfFindText"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hitta text i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdffindtext/
+---
+
+_Hitta text i en PDF-fil._
+
+```js
+function AsposePdfFindText(
+    fileBlob,
+    fileName,
+    findText
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **findText** text fragment to search
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `textFragments:\n${JSON.stringify(evt.data.json.textFragments, null, 4)}` : `Error: ${evt.data.json.errorText}`; 
+
+  /*Event handler*/
+  const ffilePdfFindText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Find text in a PDF-file - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfFindText', "params": [event.target.result, e.target.files[0].name, "Aspose"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffilePdfFindText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Find text in a PDF-file*/
+      const json = AsposePdfFindText(event.target.result, e.target.files[0].name, "Aspose");
+      if (json.errorCode == 0) document.getElementById('output').textContent = "JSON:\n" + JSON.stringify(json, null, 4)
+      else document.getElementById('output').textContent = json.errorText;
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfflatten/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfflatten/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfFlatten"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Platta till en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfflatten/
+---
+
+_Platta till en PDF-fil._
+
+```js
+function AsposePdfFlatten(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFlatten = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Flatten a PDF-file and save the "ResultFlatten.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfFlatten', "params": [event.target.result, e.target.files[0].name, "ResultFlatten.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileFlatten = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+      const json = AsposePdfFlatten(event.target.result, e.target.files[0].name, "ResultFlatten.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfgetattachment/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfgetattachment/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfGetAttachment"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Hämta bilaga från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfgetattachment/
+---
+
+_Hämta bilaga från en PDF-fil._
+
+```js
+function AsposePdfGetAttachment(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileBlob** Blob object 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfGetAttachment_{0}" where {0} - name of attachment) 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - attachment files count
+  * **filesNameResult** - array of result filenames
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Files(attachment) count: ${evt.data.json.filesCount.toString()}\n${evt.data.params.forEach(
+          (element, index) => DownloadFile(evt.data.json.filesNameResult[index], "", element) ) ?? ""}` : 
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileGetAttachment = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get attachment from a PDF-file with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment) and save*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfGetAttachment', "params": [event.target.result, e.target.files[0].name, "ResultPdfGetAttachment_{0}"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileGetAttachment = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Get attachment from a PDF-file with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment) and save*/
+      const json = AsposePdfGetAttachment(event.target.result, e.target.files[0].name, "ResultPdfGetAttachment_{0}");
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(attachment) count: " + json.filesCount.toString();
+        /*Make links to result files*/
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "");
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/organize/asposepdfmakebooklet/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfmakebooklet/_index.md
@@ -1,0 +1,81 @@
+---
+title: "AsposePdfMakeBooklet"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Skapa häfte från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfmakebooklet/
+---
+
+_Skapa häfte från en PDF-fil._
+
+```js
+function AsposePdfMakeBooklet(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileMakeBooklet = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfMakeBooklet', "params": [event.target.result, e.target.files[0].name, "ResultMakeBooklet.pdf"] },
+        [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileMakeBooklet = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+      const json = AsposePdfMakeBooklet(event.target.result, e.target.files[0].name, "ResultMakeBooklet.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfmakenup/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfmakenup/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfMakeNUp"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Skapa N-Up-dokument från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfmakenup/
+---
+
+_Skapa N-Up-dokument från en PDF-fil._
+
+```js
+function AsposePdfMakeNUp(
+    fileBlob,
+    fileName,
+    columns,
+    rows,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **columns** count of columns
+* **rows** count of rows
+* **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileMakeNUp = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf" - Ask Web Worker*/
+      const columns = 2
+      const rows = 2
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfMakeNUp', "params": [event.target.result, e.target.files[0].name, columns, rows, "ResultMakeNUp.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileMakeNUp = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+      const columns = 2
+      const rows = 2
+      const json = AsposePdfMakeNUp(event.target.result, e.target.files[0].name, columns, rows, "ResultMakeNUp.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfmerge2files/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfmerge2files/_index.md
@@ -1,0 +1,109 @@
+---
+title: "AsposePdfMerge2Files"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Slå ihop två PDF-filer."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfmerge2files/
+---
+
+_Slå samman två PDF-filer._
+
+```js
+function AsposePdfMerge2Files(
+    fileBlob1,
+    fileBlob2,
+    fileName1,
+    fileName2,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+  * **fileBlob1** Blob object #1 
+  * **fileBlob2** Blob object #2 
+  * **fileName1** file name #1 
+  * **fileName2** file name #2 
+  * **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ? 
+                    fileProcess('AsposePdfMerge2Files', evt.data.json.optdata[0].file, {"fileName2": evt.data.json.fileNameResult}) ?? 'wait please...' : 
+                    DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0]) /*AsposePdfMerge2Files*/
+                   }` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler. Only two files are merged. If only one file is selected, then use it. For the second file you need to perform AsposePdfPrepare */
+  const ffileMerge = evt => fileProcess('AsposePdfPrepare',  evt.target.files[(evt.target.files.length == 1) ? 0 : 1],
+                                        [{"operation": 'AsposePdfMerge2Files', "file": evt.target.files[0]}])
+  /* Ask Web Worker */
+  const fileProcess = (operation, ffile, optdata) => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      if (operation == 'AsposePdfPrepare')
+        return AsposePDFWebWorker.postMessage(
+                 { "operation": operation, "params": [event.target.result, ffile.name, optdata] },
+                 [event.target.result]
+               );
+      else if (operation == 'AsposePdfMerge2Files')
+        return AsposePDFWebWorker.postMessage(
+                 { "operation": operation, 
+                   "params": [event.target.result, undefined, ffile.name, (optdata === undefined) ? ffile.name : optdata.fileName2,
+                              `Result${operation}.pdf`] },
+                 [event.target.result]
+               );
+    }
+    file_reader.readAsArrayBuffer(ffile);
+  }
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileMerge = function (e) {
+    const file_reader = new FileReader();
+    function readFile(index) {
+      /*Only two files*/
+      if (index >= e.target.files.length || index >= 2) {
+        /*Merge two PDF-files and save the "ResultMerge.pdf"*/
+        const json = AsposePdfMerge2Files(undefined, undefined, e.target.files[0].name, e.target.files[1].name, "ResultMerge.pdf");
+        if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+        else document.getElementById('output').textContent = json.errorText;
+        /*Make a link to download the result file*/
+        DownloadFile(json.fileNameResult, "application/pdf");
+        return;
+      }
+      const file = e.target.files[index];
+      file_reader.onload = function (event) {
+        /*Save the BLOB in the Memory FS for processing*/
+        AsposePdfPrepare(event.target.result, file.name);
+        readFile(index + 1)
+      }
+      file_reader.readAsArrayBuffer(file);
+    }
+    readFile(0);
+  }
+```

--- a/swedish/javascript-cpp/organize/asposepdfmergelayers/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfmergelayers/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePdfMergeLayers"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Slå samman lager i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfmergelayers/
+---
+
+_Sammanfoga lager i en PDF-fil._
+
+```js
+function AsposePdfMergeLayers(
+    fileBlob,
+    fileName,
+    newLayerName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **newLayerName** merged layer name for each page
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfMergeLayers = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfMergeLayers', "params": [event.target.result, e.target.files[0].name, "MergedLayer", "ResultPdfMergeLayers.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfMergeLayers = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+      const json = AsposePdfMergeLayers(event.target.result, e.target.files[0].name, "MergedLayer", "ResultPdfMergeLayers.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfoptimize/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfoptimize/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfOptimize"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Optimera en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfoptimize/
+---
+
+_Optimera en PDF-fil._
+
+```js
+function AsposePdfOptimize(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileOptimize = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Optimize a PDF-file and save the "ResultOptimize.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfOptimize', "params": [event.target.result, e.target.files[0].name, "ResultOptimize.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileOptimize = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+      const json = AsposePdfOptimize(event.target.result, e.target.files[0].name, "ResultOptimize.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfoptimizefilesize/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfoptimizefilesize/_index.md
@@ -1,0 +1,81 @@
+---
+title: "AsposePdfOptimizeFileSize"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Optimera storleken på PDF-filen med bildkomprimeringskvalitet."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfoptimizefilesize/
+---
+
+_Optimera storleken på PDF-filen med bildkomprimeringskvalitet._
+
+```js
+function AsposePdfOptimizeFileSize(
+    fileBlob,
+    fileName,
+    imageQuality,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **imageQuality** image compression quality
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfOptimizeFileSize = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const imageQuality = 50;
+      /*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfOptimizeFileSize', "params": [event.target.result, e.target.files[0].name, imageQuality, "ResultPdfOptimizeFileSize.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfOptimizeFileSize = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const imageQuality = 50;
+      /*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+      const json = AsposePdfOptimizeFileSize(event.target.result, e.target.files[0].name, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfoptimizeresource/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfoptimizeresource/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfOptimizeResource"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Optimera resurser i PDF-filen."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfoptimizeresource/
+---
+
+_Optimera resurser i en PDF-fil._
+
+```js
+function AsposePdfOptimizeResource(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfOptimizeResource = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfOptimizeResource', "params": [event.target.result, e.target.files[0].name, "ResultPdfOptimizeResource.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfOptimizeResource = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+      const json = AsposePdfOptimizeResource(event.target.result, e.target.files[0].name, "ResultPdfOptimizeResource.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfRebuildXrefAndTrailer"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Bygg om en PDF-fils korsreferenstabell och trailer-strukturer."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfrebuildxrefandtrailer/
+---
+
+_Bygg om en PDF-fils korsreferenstabell och trailerstrukturer._
+
+```js
+function AsposePdfRebuildXrefAndTrailer(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent =.
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileRebuildXrefAndTrailer = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultRebuildXrefAndTrailer.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfRebuildXrefAndTrailer', "params": [event.target.result, e.target.files[0].name, "ResultRebuildXrefAndTrailer.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileRebuildXrefAndTrailer = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultRebuildXrefAndTrailer.pdf"*/
+      const json = AsposePdfRebuildXrefAndTrailer(event.target.result, e.target.files[0].name, "ResultRebuildXrefAndTrailer.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfrecover/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfrecover/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfRecover"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Återskapa en PDF-filstruktur och rensa ogiltiga data."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfrecover/
+---
+
+_Återställ en PDF-filstruktur och trimma ogiltig data._
+
+```js
+function AsposePdfRecover(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileRecover = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Recover a PDF-file structure and trims invalid data and save the "ResultRecover.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfRecover', "params": [event.target.result, e.target.files[0].name, "ResultRecover.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileRecover = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Recover a PDF-file structure and trims invalid data and save the "ResultRecover.pdf"*/
+      const json = AsposePdfRecover(event.target.result, e.target.files[0].name, "ResultRecover.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfrepair/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfrepair/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfRepair"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Reparera en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfrepair/
+---
+
+_Reparera en PDF-fil._
+
+```js
+function AsposePdfRepair(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfRepair = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Repair a PDF-file and save the "ResultPdfRepair.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfRepair', "params": [event.target.result, e.target.files[0].name, "ResultPdfRepair.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfRepair = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+      const json = AsposePdfRepair(event.target.result, e.target.files[0].name, "ResultPdfRepair.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfreplacefont/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfreplacefont/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfReplaceFont"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ersätt teckensnitt i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfreplacefont/
+---
+
+_Ersätt teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfReplaceFont(
+    fileBlob,
+    fileName,
+    findFont,
+    replaceFont,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **findFont** name font to be replaced
+* **replaceFont** replacement font name
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileReplaceFont = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const findFont = 'Helvetica';
+      const replaceFont = 'Times';
+      /*Replace font Helvetica to Times in a PDF-file and save the "ResultReplaceFont.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfReplaceFont', "params": [event.target.result, e.target.files[0].name, findFont, replaceFont, "ResultReplaceFont.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileReplaceFont = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Replace font Helvetica to Times in a PDF-file and save the "ResultReplaceFont.pdf"*/
+      const json = AsposePdfReplaceFont(event.target.result, e.target.files[0].name, "Helvetica", "Times", "ResultReplaceFont.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfreplacetext/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfreplacetext/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfReplaceText"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ersätt text i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfreplacetext/
+---
+
+_Ersätt text i en PDF-fil._
+
+```js
+function AsposePdfReplaceText(
+    fileBlob,
+    fileName,
+    findText,
+    replaceText,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileReplaceText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const findText = 'Aspose';
+      const replaceText = 'ASPOSE';
+      /*Replace text in a PDF-file and save the "ResultReplaceText.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfReplaceText', "params": [event.target.result, e.target.files[0].name, findText, replaceText, "ResultReplaceText.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileReplaceText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Replace text in a PDF-file and save the "ResultReplaceText.pdf"*/
+      const json = AsposePdfReplaceText(event.target.result, e.target.files[0].name, "Aspose", "ASPOSE", "ResultReplaceText.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfreplacetextex/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfreplacetextex/_index.md
@@ -1,0 +1,116 @@
+---
+title: "AsposePdfReplaceTextEx"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ersätt flera textfragment i en PDF-fil med justeringskontroll."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfreplacetextex/
+---
+
+_Ersätt flera textfragment i en PDF-fil med justeringskontroll._
+
+```js
+function AsposePdfReplaceTextEx(
+    fileBlob,
+    fileName,
+    findReplaceSpec,
+    options,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **findReplaceSpec** Array, replacement specification:
+  * Array of objects describing replacements:
+    ```js
+    [
+      { findText: "text1", replaceText: "value1" },
+      { findText: "text2", replaceText: "value2" }
+    ]
+    ```
+  * Each object must contain `findText` and `replaceText` string properties
+* **options** object, settings for text replacement:
+  * `alignment` (string), text alignment (e.g., "left", "right", "auto")
+    * When `"auto"` is used, text direction is detected automatically.
+Riktning kan också tvingas explicit genom att prefixa `replaceText`
+med specialtecken i Unicode:
+`\u200F` (RTL) eller `\u200E` (LTR), helst som det första tecknet
+  * `numPages` (string|number|Array), target pages to process:
+    * number, page number as 2
+    * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+    * Array, array of page numbers, such as [1,3]
+  * empty object `{}` for default behavior
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileReplaceTextEx = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+      ];
+      const optionsText = {numPages: 1, alignment: "auto"};
+      /*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultReplaceTextEx.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfReplaceTextEx', "params": [event.target.result, e.target.files[0].name, findReplaceSpec, optionsText, "ResultReplaceTextEx.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileReplaceTextEx = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultReplaceTextEx.pdf"*/
+      const json = AsposePdfReplaceTextEx(event.target.result, e.target.files[0].name, [{findText: 'Aspose',replaceText: 'ASPOSE'}], {alignment: "left"}, "ResultReplaceTextEx.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfreplacetextpages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfreplacetextpages/_index.md
@@ -1,0 +1,108 @@
+---
+title: "AsposePdfReplaceTextPages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ersätt text på sidor i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfreplacetextpages/
+---
+
+_Ersätt text på sidor i en PDF-fil._
+
+```js
+function AsposePdfReplaceTextPages(
+    fileBlob,
+    fileName,
+    findText,
+    replaceText,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileReplaceTextPages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const findText = 'Aspose';
+      const replaceText = 'ASPOSE';
+
+      /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+      const numPages = "1-3";
+      /*array, array of number pages*/
+      /*const numPages = [1,3];*/
+      /*number, number page*/
+      /*const numPages = 1;*/
+      /*if numPages == 0 then all pages*/
+
+      /*Replace text on 1-3 pages in a PDF-file and save the "ResultReplaceTextPages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfReplaceTextPages', "params": [event.target.result, e.target.files[0].name, findText, replaceText, numPages, "ResultReplaceTextPages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileReplaceTextPages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+      const numPages = "1-3";
+      /*array, array of number pages*/
+      /*const numPages = [1,3];*/
+      /*number, number page*/
+      /*const numPages = 1;*/
+      /*if numPages == 0 then all pages*/
+
+      /*Replace text on 1-3 pages in a PDF-file and save the "ResultReplaceTextPages.pdf"*/
+      const json = AsposePdfReplaceTextPages(event.target.result, e.target.files[0].name, "Aspose", "ASPOSE", numPages, "ResultReplaceTextPages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfreversepages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfreversepages/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposePdfReversePages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Vänd på sidordningen i en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfreversepages/
+---
+
+_Vänd på sidordningen i en PDF-fil._
+
+```js
+function AsposePdfReversePages(
+    fileBlob,
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileReversePages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Reverse the page order of a PDF-file and save the "ResultReversePages.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfReversePages', "params": [event.target.result, e.target.files[0].name, "ResultReversePages.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileReversePages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Reverse the page order of a PDF-file and save the "ResultReversePages.pdf"*/
+      const json = AsposePdfReversePages(event.target.result, e.target.files[0].name, "ResultReversePages.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfrotateallpages/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfrotateallpages/_index.md
@@ -1,0 +1,90 @@
+---
+title: "AsposePdfRotateAllPages"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Rotera PDF-sidor."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfrotateallpages/
+---
+
+_Rotera PDF-sidor._
+
+```js
+function AsposePdfRotateAllPages(
+    fileBlob,
+    fileName,
+    rotation,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **rotation** pages rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileRotateAllPages = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const rotation = 'Module.Rotation.on270';
+      /*Rotate PDF-pages and save the "ResultRotation.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfRotateAllPages',
+          "params": [event.target.result, e.target.files[0].name, rotation, "ResultRotation.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileRotateAllPages = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Rotate PDF-pages PDF-file and save the "ResultRotation.pdf"*/
+      const json = AsposePdfRotateAllPages(event.target.result, e.target.files[0].name, Module.Rotation.on270, "ResultRotation.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfsetbackgroundcolor/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfsetbackgroundcolor/_index.md
@@ -1,0 +1,80 @@
+---
+title: "AsposePdfSetBackgroundColor"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ställ in bakgrundsfärgen för PDF-filen."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfsetbackgroundcolor/
+---
+
+_Ställ in bakgrundsfärgen för PDF-filen._
+
+```js
+function AsposePdfSetBackgroundColor(
+    fileBlob,
+    fileName,
+    backgroundColor,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **backgroundColor** PDF background color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfSetBackgroundColor = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const backgroundColor= "#426bf4";
+      /*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfSetBackgroundColor', "params": [event.target.result, e.target.files[0].name, backgroundColor, "ResultPdfSetBackgroundColor.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfSetBackgroundColor = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+      const json = AsposePdfSetBackgroundColor(event.target.result, e.target.files[0].name, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfsplit2files/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfsplit2files/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposePdfSplit2Files"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Dela upp i två PDF-filer."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfsplit2files/
+---
+
+_Dela upp i två PDF-filer._
+
+```js
+function AsposePdfSplit2Files(
+    fileBlob,
+    fileName,
+    pageToSplit,
+    fileNameResult1,
+    fileNameResult2 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **pageToSplit** number page for split 
+* **fileNameResult1** result file name #1 
+* **fileNameResult2** result file name #2 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult1** - result file name #1
+* **fileNameResult2** - result file name #2
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult1, "application/pdf", evt.data.params[0])}
+                \n${DownloadFile(evt.data.json.fileNameResult2, "application/pdf", evt.data.params[1])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileSplit = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Set number a page to split*/
+      const pageToSplit = 1;
+      /*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfSplit2Files',
+          "params": [event.target.result, e.target.files[0].name, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileSplit = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Set number a page to split*/
+      const pageToSplit = 1;
+      /*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+      const json = AsposePdfSplit2Files(event.target.result, e.target.files[0].name, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = e.target.files[0].name + " split: " + json.fileNameResult1 + ", " + json.fileNameResult2
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the first result file*/
+      DownloadFile(json.fileNameResult1, "application/pdf");
+      /*Make a link to download the second result file*/
+      DownloadFile(json.fileNameResult2, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfunembedfonts/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfunembedfonts/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePdfUnembedFonts"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ta bort inbäddade teckensnitt från en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfunembedfonts/
+---
+
+_Ta bort inbäddning av teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfUnembedFonts(
+    fileBlob,
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileUnembedFonts = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfUnembedFonts', "params": [event.target.result, e.target.files[0].name, "ResultUnembedFonts.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileUnembedFonts = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+      const json = AsposePdfUnembedFonts(event.target.result, e.target.files[0].name, "ResultUnembedFonts.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/organize/asposepdfvalidatepdfa/_index.md
+++ b/swedish/javascript-cpp/organize/asposepdfvalidatepdfa/_index.md
@@ -1,0 +1,91 @@
+---
+title: "AsposePdfValidatePDFA"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Validera PDF/A-kompatibilitet för en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/organize/asposepdfvalidatepdfa/
+---
+
+_Validera PDF/A-kompatibilitet för en PDF-fil._
+
+```js
+function AsposePdfValidatePDFA(
+    fileBlob,
+    fileName,
+    pdfFormat,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object
+* **fileName** file name
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name where verification comments will be stored (xml format)
+
+**Return**: 
+
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/xml", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfValidatePDFA = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const pdfFormat = 'Module.PdfFormat.PDF_A_1A';
+      /*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfValidatePDFA', "params": [event.target.result, e.target.files[0].name, pdfFormat, "ResultPdfValidatePDFA.xml"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+
+**Simple example**:
+
+```js
+var ffilePdfValidatePDFA = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+      const json = AsposePdfValidatePDFA(event.target.result, e.target.files[0].name, Module.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/xml");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/security/_index.md
+++ b/swedish/javascript-cpp/security/_index.md
@@ -1,0 +1,31 @@
+---
+title: "PDF-säkerhetsfunktioner"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Funktioner för att arbeta med säkerhetsfunktioner i PDF-filer."
+type: docs
+url: /sv/javascript-cpp/security/
+---
+
+## Security PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfEncrypt](./asposepdfencrypt/) | Kryptera en PDF-fil. |
+| [AsposePdfDecrypt](./asposepdfdecrypt/) | Dekryptera en PDF-fil. |
+| [AsposePdfSignPKCS7](./asposepdfsignpkcs7/) | Signera en PDF-fil med digitala signaturer. |
+| [AsposePdfSignPKCS7Detached](./asposepdfsignpkcs7detached/) | Signera en PDF-fil med fristående digitala signaturer. |
+| [AsposePdfChangePassword](./asposepdfchangepassword/) | Ändra lösenord för PDF-filen. |
+
+## Detailed Description
+
+Funktioner för att arbeta med säkerhetsfunktioner i PDF-filer.
+
+```js
+/* Web Worker*/
+const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.PDF for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePDFforJS.js"></script>
+```

--- a/swedish/javascript-cpp/security/asposepdfchangepassword/_index.md
+++ b/swedish/javascript-cpp/security/asposepdfchangepassword/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposePdfChangePassword"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Ändra lösenord för PDF-filen."
+type: docs
+url: /sv/javascript-cpp/security/asposepdfchangepassword/
+---
+
+_Ändra lösenord för PDF-filen._
+
+```js
+function AsposePdfChangePassword(
+    fileBlob,
+    fileName,
+    ownerPassword,
+    newUserPassword,
+    newOwnerPassword,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **ownerPassword** owner password
+* **newUserPassword** new user password
+* **newOwnerPassword** new owner password
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffilePdfChangePassword = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const ownerPassword = 'owner'; /*Owner password*/
+      const newUserPassword = "newuser"; /*New user password*/
+      const newOwnerPassword = "newowner"; /*New owner password*/
+      /*Change passwords of the PDF file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfChangePassword',
+          "params": [event.target.result, e.target.files[0].name, ownerPassword, newUserPassword, newOwnerPassword,
+                     "ResultPdfChangePassword.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffilePdfChangePassword = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Change passwords of the PDF file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+      const json = AsposePdfChangePassword(event.target.result, e.target.files[0].name, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/security/asposepdfdecrypt/_index.md
+++ b/swedish/javascript-cpp/security/asposepdfdecrypt/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposePdfDecrypt"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Dekryptera en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/security/asposepdfdecrypt/
+---
+
+_Dekryptera en PDF-fil._
+
+```js
+function AsposePdfDecrypt(
+    fileBlob,
+    fileName,
+    password,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **password** user password 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileDecrypt = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const password = 'owner';
+      /*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfDecrypt',
+          "params": [event.target.result, e.target.files[0].name, password, "ResultDecrypt.pdf"] }, 
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileDecrypt = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+      const json = AsposePdfDecrypt(event.target.result, e.target.files[0].name, "owner", "ResultDecrypt.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/security/asposepdfencrypt/_index.md
+++ b/swedish/javascript-cpp/security/asposepdfencrypt/_index.md
@@ -1,0 +1,110 @@
+---
+title: "AsposePdfEncrypt"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Kryptera en PDF-fil."
+type: docs
+url: /sv/javascript-cpp/security/asposepdfencrypt/
+---
+
+_Kryptera en PDF-fil._
+
+```js
+function AsposePdfEncrypt(
+    fileBlob,
+    fileName,
+    passwordUser,
+    passwordOwner,
+    permissions,
+    cryptoAlgorithm,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+* **passwordUser** user password 
+* **passwordOwner** owner password 
+* **permissions** encrypt permissions:
+  * Module.Permissions.PrintDocument
+  * Module.Permissions.ModifyContent
+  * Module.Permissions.ExtractContent
+  * Module.Permissions.ModifyTextAnnotations
+  * Module.Permissions.FillForm
+  * Module.Permissions.ExtractContentWithDisabilities
+  * Module.Permissions.AssembleDocument
+  * Module.Permissions.PrintingQuality 
+* **cryptoAlgorithm** encrypt algorithm:
+  * Module.CryptoAlgorithm.RC4x40
+  * Module.CryptoAlgorithm.RC4x128
+  * Module.CryptoAlgorithm.AESx128
+  * Module.CryptoAlgorithm.AESx256 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileEncrypt = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const password_user = 'user';
+      const password_owner = 'owner';
+      const permissions = 'Module.Permissions.PrintDocument';
+      const algorithm = 'Module.CryptoAlgorithm.RC4x40';
+      /*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfEncrypt',
+          "params": [event.target.result, e.target.files[0].name, password_user, password_owner,
+                     permissions, algorithm, "ResultEncrypt.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  var ffileEncrypt = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      /*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultDecrypt.pdf"*/
+      const json = AsposePdfEncrypt(event.target.result, e.target.files[0].name, "user", "owner", Module.Permissions.PrintDocument, Module.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/security/asposepdfsignpkcs7/_index.md
+++ b/swedish/javascript-cpp/security/asposepdfsignpkcs7/_index.md
@@ -1,0 +1,184 @@
+---
+title: "AsposePdfSignPKCS7"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Signera en PDF-fil med digitala signaturer."
+type: docs
+url: /sv/javascript-cpp/security/asposepdfsignpkcs7/
+---
+
+_Signera en PDF-fil med digitala signaturer._
+
+```js
+function AsposePdfSignPKCS7(
+    fileBlob,
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileBlob** Blob object
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ?
+          'file prepared!':
+          DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default PKCS7 key filename*/
+  var fileSign = "test.pfx";
+  /*Set the default image (Signature Appearance) filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var signatureAppearance = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileSignPKCS7 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const pageNum = 1;
+      const pswSign = document.getElementById("passwordSign").value;
+      const setXIndent = 100;
+      const setYIndent = 100;
+      const setHeight = 200;
+      const setWidth = 100;
+      const reason = 'Reason';
+      const contact = 'contact@test.com';
+      const location = 'Location';
+      const isVisible = 1;
+      /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfSignPKCS7',
+          "params": [event.target.result, e.target.files[0].name, pageNum, fileSign, pswSign, setXIndent, setYIndent,
+                     setHeight, setWidth, reason, contact, location, isVisible, signatureAppearance, "ResultSignPKCS7.pdf"] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileSign = e => {
+    const file_reader = new FileReader();
+    /*Set the PKCS7 key filename*/
+    fileSign = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPrepare', "params": [event.target.result, fileSign] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    signatureAppearance = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage(
+        { "operation": 'AsposePdfPrepare', "params": [event.target.result, signatureAppearance] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default PKCS7 key filename*/
+  var fileSign = "/test.pfx";
+
+  var ffileSign = function (e) {
+    const file_reader = new FileReader();
+    /*Set the PKCS7 key filename*/
+    fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileSign);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Set the default image (Signature Appearance) filename*/
+  var signatureAppearance = "/Aspose.jpg";
+
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    signatureAppearance = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, signatureAppearance);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileSignPKCS7 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      let pswSign = document.getElementById("passwordSign").value;
+      /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+      const json = AsposePdfSignPKCS7(event.target.result, e.target.files[0].name, 1, fileSign, pswSign, 200, 200, 200, 100, "TEST", "test@test.com", "EU", 1, signatureAppearance,"ResultSignPKCS7.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/security/asposepdfsignpkcs7detached/_index.md
+++ b/swedish/javascript-cpp/security/asposepdfsignpkcs7detached/_index.md
@@ -1,0 +1,169 @@
+---
+title: "AsposePdfSignPKCS7Detached"
+second_title: "Aspose.PDF för JavaScript via C++"
+description: "Signera en PDF-fil med fristående digitala signaturer."
+type: docs
+url: /sv/javascript-cpp/security/asposepdfsignpkcs7detached/
+---
+
+_Signera en PDF-fil med fristående digitala signaturer._
+
+```js
+function AsposePdfSignPKCS7Detached(
+    fileBlob,
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileBlob** Blob object
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePDFWebWorker = new Worker("AsposePDFforJS.js");
+  AsposePDFWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePDFWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${(evt.data.operation == 'AsposePdfPrepare') ? 'file prepared!': DownloadFile(evt.data.json.fileNameResult, "application/pdf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Set the default PKCS7 key filename*/
+  var fileSign = "test.pfx";
+  /*Set the default image (Signature Appearance) filename: 'Aspose.jpg' already loaded, see settings in 'settings.json'*/
+  var signatureAppearance = "Aspose.jpg";
+
+  /*Event handler*/
+  const ffileSignPKCS7Detached = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const pageNum = 1;
+      const pswSign = document.getElementById("passwordSign").value;
+      const setXIndent = 100;
+      const setYIndent = 100;
+      const setHeight = 200;
+      const setWidth = 100;
+      const reason = 'Reason';
+      const contact = 'contact@test.com';
+      const location = 'Location';
+      const isVisible = 1;
+      /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7Detached.pdf" - Ask Web Worker*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfSignPKCS7Detached', "params": [event.target.result, e.target.files[0].name, pageNum, fileSign, pswSign, setXIndent, setYIndent, setHeight, setWidth, reason, contact, location, isVisible, signatureAppearance, "ResultSignPKCS7Detached.pdf"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileSign = e => {
+    const file_reader = new FileReader();
+    /*Set the PKCS7 key filename*/
+    fileSign = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPrepare', "params": [event.target.result, fileSign] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    signatureAppearance = e.target.files[0].name;
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePDFWebWorker.postMessage({ "operation": 'AsposePdfPrepare', "params": [event.target.result, signatureAppearance] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = (filename, mime, content) => {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.innerHTML = "Click here to download the file " + filename;
+      document.body.appendChild(link); 
+      document.body.appendChild(document.createElement("br"));
+      return filename;
+    }
+```
+**Simple example**:
+```js
+  /*Set the default PKCS7 key filename*/
+  var fileSign = "/test.pfx";
+
+  var ffileSign = function (e) {
+    const file_reader = new FileReader();
+    /*Set the PKCS7 key filename*/
+    fileSign = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, fileSign);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Set the default image (Signature Appearance) filename*/
+  var signatureAppearance = "/Aspose.jpg";
+
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    signatureAppearance = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePdfPrepare(event.target.result, signatureAppearance);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  var ffileSignPKCS7Detached = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      let pswSign = document.getElementById("passwordSign").value;
+      /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+      const json = AsposePdfSignPKCS7Detached(event.target.result, e.target.files[0].name, 1, fileSign, pswSign, 200, 200, 200, 100, "TEST", "test@test.com", "EU", 1, signatureAppearance,"ResultSignPKCS7Detached.pdf");
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult
+      else document.getElementById('output').textContent = json.errorText;
+      /*Make a link to download the result file*/
+      DownloadFile(json.fileNameResult, "application/pdf");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 99/99
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `swedish/javascript-cpp`

🤖 Generated by RDA