### PR TITLE
[draft] Translate NET API Reference to German

### DIFF
--- a/german/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AICopilotFactory.CreateOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AICopilotFactory-Methode. Erstellt einen OCR‑Copilot basierend auf dem Client und den Optionen"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/
+---
+## AICopilotFactory.CreateOcrCopilot&lt;TOptions&gt; method
+
+Erstellt einen OCR‑Copilot basierend auf dem Client und den Optionen.
+
+```csharp
+public static IOcrCopilot CreateOcrCopilot<TOptions>(IOcrClient<TOptions> client, 
+    IOcrCopilotOptions<TOptions> options)
+```
+
+### Siehe auch
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrClient&lt;TOptions&gt;](../../iocrclient-1/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [AICopilotFactory](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Klasse ChatMessageResponse"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.ChatMessageResponse Klasse. Eine vom Modell erzeugte Chat-Vervollständigungsnachricht"
+type: docs
+weight: 200
+url: /de/net/aspose.pdf.ai/chatmessageresponse/
+---
+## ChatMessageResponse class
+
+Eine vom Modell erzeugte Chat-Vervollständigungsnachricht.
+
+```csharp
+public class ChatMessageResponse
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [ChatMessageResponse](chatmessageresponse/#constructor)() | Initialisiert eine neue Instanz der `ChatMessageResponse`-Klasse. |
+| [ChatMessageResponse](chatmessageresponse/#constructor_1)(string, string) | Initialisiert eine neue Instanz der `ChatMessageResponse`-Klasse. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Content](../../aspose.pdf.ai/chatmessageresponse/content/) { get; set; } | Liest oder setzt den Inhalt der Nachricht. |
+| [Id](../../aspose.pdf.ai/chatmessageresponse/id/) { get; set; } | Liest oder setzt die ID der Nachricht. |
+| [Name](../../aspose.pdf.ai/chatmessageresponse/name/) { get; set; } | Liest oder setzt einen optionalen Namen für den Teilnehmer. Liefert dem Modell Informationen, um Teilnehmer mit derselben Rolle zu unterscheiden. |
+| [Refusal](../../aspose.pdf.ai/chatmessageresponse/refusal/) { get; set; } | Liest oder setzt die Ablehnungsnachricht, die vom Modell erzeugt wird. |
+| [Role](../../aspose.pdf.ai/chatmessageresponse/role/) { get; set; } | Liest oder setzt die Rolle des Autors der Nachricht. |
+| [ToolCalls](../../aspose.pdf.ai/chatmessageresponse/toolcalls/) { get; set; } | Liest oder setzt die vom Modell erzeugten Werkzeugaufrufe, wie Funktionsaufrufe. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/_index.md
@@ -1,0 +1,44 @@
+---
+title: "ChatMessageResponse.ChatMessageResponse"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Konstruktor. Initialisiert eine neue Instanz der ChatMessageResponse-Klasse."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/
+---
+## ChatMessageResponse() {#constructor}
+
+Initialisiert eine neue Instanz der [`ChatMessageResponse`](../)-Klasse.
+
+```csharp
+public ChatMessageResponse()
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## ChatMessageResponse(string, string) {#constructor_1}
+
+Initialisiert eine neue Instanz der [`ChatMessageResponse`](../)-Klasse.
+
+```csharp
+public ChatMessageResponse(string role, string content)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| role | String | Die Rolle des Autors dieser Nachricht. |
+| content | String | Der Inhalt der Nachricht. |
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/content/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/content/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Content"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt den Inhalt der Nachricht zurück oder legt ihn fest."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.ai/chatmessageresponse/content/
+---
+## ChatMessageResponse.Content property
+
+Liest oder setzt den Inhalt der Nachricht.
+
+```csharp
+public string Content { get; set; }
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/id/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/id/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Id"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt die ID der Nachricht zurück oder legt sie fest."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/chatmessageresponse/id/
+---
+## ChatMessageResponse.Id property
+
+Liest oder setzt die ID der Nachricht.
+
+```csharp
+public string Id { get; set; }
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/name/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/name/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Name"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt einen optionalen Namen für den Teilnehmer zurück oder legt ihn fest. Liefert Modellinformationen, um zwischen Teilnehmern derselben Rolle zu unterscheiden."
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.ai/chatmessageresponse/name/
+---
+## ChatMessageResponse.Name property
+
+Liest oder setzt einen optionalen Namen für den Teilnehmer. Liefert dem Modell Informationen, um Teilnehmer mit derselben Rolle zu unterscheiden.
+
+```csharp
+public string Name { get; set; }
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/refusal/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/refusal/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Refusal"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt die vom Modell erzeugte Ablehnungsnachricht zurück oder legt sie fest."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/chatmessageresponse/refusal/
+---
+## ChatMessageResponse.Refusal property
+
+Liest oder setzt die Ablehnungsnachricht, die vom Modell erzeugt wird.
+
+```csharp
+public string Refusal { get; set; }
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/role/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/role/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Role"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt die Rolle des Nachrichtenautors zurück oder legt sie fest"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.ai/chatmessageresponse/role/
+---
+## ChatMessageResponse.Role property
+
+Liest oder setzt die Rolle des Autors der Nachricht.
+
+```csharp
+public string Role { get; set; }
+```
+
+### Siehe auch
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/chatmessageresponse/toolcalls/_index.md
+++ b/german/net/aspose.pdf.ai/chatmessageresponse/toolcalls/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ChatMessageResponse.ToolCalls"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ChatMessageResponse-Eigenschaft. Gibt die vom Modell erzeugten Werkzeugaufrufe zurück oder legt sie fest, z. B. Funktionsaufrufe."
+type: docs
+weight: 70
+url: /de/net/aspose.pdf.ai/chatmessageresponse/toolcalls/
+---
+## ChatMessageResponse.ToolCalls property
+
+Liest oder setzt die vom Modell erzeugten Werkzeugaufrufe, wie Funktionsaufrufe.
+
+```csharp
+public List<ToolCall> ToolCalls { get; set; }
+```
+
+### Siehe auch
+
+* class [ToolCall](../../toolcall/)
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/_index.md
+++ b/german/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "CompletionCreateRequest.MaxCompletionTokens"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "CompletionCreateRequest-Eigenschaft. Ruft die maximale Anzahl von Tokens ab, die bei der Vervollständigung generiert werden, oder legt sie fest."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/
+---
+## CompletionCreateRequest.MaxCompletionTokens property
+
+Ruft die maximale Anzahl von Tokens ab, die bei der Vervollständigung generiert werden, oder legt sie fest.
+
+```csharp
+public int? MaxCompletionTokens { get; set; }
+```
+
+### Siehe auch
+
+* class [CompletionCreateRequest](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/detail/_index.md
+++ b/german/net/aspose.pdf.ai/detail/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Enum Detail"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.Detail-Enum. Gibt das Detaillierungsniveau für die Bildanalyse an."
+type: docs
+weight: 330
+url: /de/net/aspose.pdf.ai/detail/
+---
+## Detail enumeration
+
+Gibt das Detaillierungsniveau für die Bildanalyse an.
+
+```csharp
+public enum Detail
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| Auto | `0` | Das Detaillierungsniveau wird automatisch von der API basierend auf Eingabe und Kontext bestimmt. |
+| Low | `1` | Niedriges Detaillierungsniveau, das eine allgemeinere und schnellere Analyse ermöglicht. |
+| High | `2` | Hohes Detaillierungsniveau, das eine gründlichere und präzisere Analyse bietet. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrclient-1/_index.md
+++ b/german/net/aspose.pdf.ai/iocrclient-1/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Schnittstelle IOcrClientTOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.IOcrClient1TOptions Schnittstelle. Stellt eine Schnittstelle für einen OCR-Client mit spezifischen Optionen dar"
+type: docs
+weight: 560
+url: /de/net/aspose.pdf.ai/iocrclient-1/
+---
+## IOcrClient&lt;TOptions&gt; interface
+
+Stellt eine Schnittstelle für einen OCR-Client mit spezifischen Optionen dar.
+
+```csharp
+public interface IOcrClient<in TOptions> : IAIClient
+```
+
+| Parameter | Beschreibung |
+| --- | --- |
+| TOptions | Der Typ der Optionen für den OCR-Client. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [GetOcrCopilot](../../aspose.pdf.ai/iocrclient-1/getocrcopilot/)(IOcrCopilotOptions&lt;TOptions&gt;) | Ruft eine Instanz von [`IOcrCopilot`](../iocrcopilot/) mit den angegebenen Optionen ab. |
+
+### Siehe auch
+
+* interface [IAIClient](../iaiclient/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IOcrClient1.GetOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "IOcrClient-Methode. Liefert eine Instanz von IOcrCopilot mit den angegebenen Optionen."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/
+---
+## IOcrClient&lt;TOptions&gt;.GetOcrCopilot method
+
+Liefert eine Instanz von [`IOcrCopilot`](../../iocrcopilot/) mit den angegebenen Optionen.
+
+```csharp
+public IOcrCopilot GetOcrCopilot(IOcrCopilotOptions<TOptions> options)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Optionen | IOcrCopilotOptions`1 | Die Optionen für den OCR‑Copiloten. |
+
+### Rückgabewert
+
+Eine Instanz von [`IOcrCopilot`](../../iocrcopilot/).
+
+### Siehe auch
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* interface [IOcrClient&lt;TOptions&gt;](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/iocrcopilot/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Schnittstelle IOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.IOcrCopilot Schnittstelle. Stellt einen OCR‑Copilot für die Verarbeitung gescannter PDFs und Bilder über KI‑Modelle dar"
+type: docs
+weight: 570
+url: /de/net/aspose.pdf.ai/iocrcopilot/
+---
+## IOcrCopilot interface
+
+Stellt einen OCR‑Copilot für die Verarbeitung gescannter PDFs und Bilder über KI‑Modelle dar.
+
+```csharp
+public interface IOcrCopilot : IAICopilot
+```
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [GetTextRecognitionResultAsync](../../aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/)(CancellationToken?) | Ruft asynchron die Texterkennungsergebnisse für die PDF Document und Bilddateien ab. Unterstützte Bildtypen: PNG (.png), JPEG (.jpeg und .jpg), WEBP (.webp), nicht‑animiertes GIF (.gif). |
+
+### Siehe auch
+
+* interface [IAICopilot](../iaicopilot/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/_index.md
+++ b/german/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IOcrCopilot.GetTextRecognitionResultAsync"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "IOcrCopilot-Methode. Ruft Text-Erkennungsergebnisse für PDF-Dokumente und Bilddateien asynchron ab. Unterstützte Bildtypen: PNG .png, JPEG .jpeg und .jpg, WEBP .webp, nicht animiertes GIF .gif"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/
+---
+## IOcrCopilot.GetTextRecognitionResultAsync method
+
+Ruft asynchron die Texterkennungsergebnisse für die PDF Document und Bilddateien ab. Unterstützte Bildtypen: PNG (.png), JPEG (.jpeg und .jpg), WEBP (.webp), nicht‑animiertes GIF (.gif).
+
+```csharp
+public Task<List<TextRecognitionResult>> GetTextRecognitionResultAsync(
+    CancellationToken? cancellationToken = default)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| cancellationToken | Nullable`1 | Ein optionales Cancellation-Token, um den Vorgang abzubrechen. |
+
+### Rückgabewert
+
+Ein Task, der die asynchrone Operation darstellt. Das Task-Ergebnis enthält eine Liste von [`TextRecognitionResult`](../../textrecognitionresult/).
+
+### Siehe auch
+
+* class [TextRecognitionResult](../../textrecognitionresult/)
+* interface [IOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrcopilotoptions-1/_index.md
+++ b/german/net/aspose.pdf.ai/iocrcopilotoptions-1/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Schnittstelle IOcrCopilotOptionsTOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.IOcrCopilotOptions1TOptions Schnittstelle. Stellt eine Schnittstelle für Chat-Copilot-Optionen mit einem spezifischen Typ dar"
+type: docs
+weight: 580
+url: /de/net/aspose.pdf.ai/iocrcopilotoptions-1/
+---
+## IOcrCopilotOptions&lt;TOptions&gt; interface
+
+Stellt eine Schnittstelle für Chat-Copilot-Optionen mit einem spezifischen Typ dar.
+
+```csharp
+public interface IOcrCopilotOptions<out TOptions>
+```
+
+| Parameter | Beschreibung |
+| --- | --- |
+| TOptions | Der Typ der Optionen für den Chat-Copilot. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [GetOptions](../../aspose.pdf.ai/iocrcopilotoptions-1/getoptions/)() | Ruft die Optionen vom Typ *TOptions* ab. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/_index.md
+++ b/german/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IOcrCopilotOptions1.GetOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "IOcrCopilotOptions-Methode. Ruft die Optionen vom Typ TOptions ab"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/
+---
+## IOcrCopilotOptions&lt;TOptions&gt;.GetOptions method
+
+Ruft die Optionen vom Typ *TOptions* ab.
+
+```csharp
+public TOptions GetOptions()
+```
+
+### Rückgabewert
+
+Die Optionen vom Typ *TOptions*.
+
+### Siehe auch
+
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Klasse OcrDetail"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.OcrDetail Klasse. Stellt das OCR-Ergebnis für eine einzelne Seite eines Dokuments oder einer einzelnen Bilddatei dar"
+type: docs
+weight: 860
+url: /de/net/aspose.pdf.ai/ocrdetail/
+---
+## OcrDetail class
+
+Stellt das OCR-Ergebnis für eine einzelne Seite eines Dokuments oder einer einzelnen Bilddatei dar.
+
+```csharp
+public class OcrDetail : IComparable<OcrDetail>
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [OcrDetail](ocrdetail/)() | Der Standardkonstruktor. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [ErrorMessage](../../aspose.pdf.ai/ocrdetail/errormessage/) { get; set; } | Eine Fehlermeldung, die beschreibt, warum OCR für diese Seite fehlgeschlagen ist, wenn Success false ist. Andernfalls Null. |
+| [ExtractedText](../../aspose.pdf.ai/ocrdetail/extractedtext/) { get; set; } | Der extrahierte Textinhalt der Seite. Null, wenn Success false ist oder kein Text gefunden wurde. |
+| [PageNumber](../../aspose.pdf.ai/ocrdetail/pagenumber/) { get; set; } | Die 1-basierte Page-Nummer im Quell-Dokument. Bei einseitigen Bildern ist sie immer 1. |
+| [Success](../../aspose.pdf.ai/ocrdetail/success/) { get; set; } | Gibt an, ob die OCR-Extraktion für diese spezifische Page erfolgreich war. |
+| [Usage](../../aspose.pdf.ai/ocrdetail/usage/) { get; set; } | Liest oder legt die Nutzungsstatistiken fest. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [CompareTo](../../aspose.pdf.ai/ocrdetail/compareto/)(OcrDetail) | Vergleicht die aktuelle OcrDetail-Instanz mit einem anderen OcrDetail-Objekt anhand ihrer PageNumber-Eigenschaft. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/compareto/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/compareto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.CompareTo"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Methode. Vergleicht die aktuelle OcrDetail-Instanz mit einem anderen OcrDetail-Objekt anhand ihrer PageNumber-Eigenschaft."
+type: docs
+weight: 70
+url: /de/net/aspose.pdf.ai/ocrdetail/compareto/
+---
+## OcrDetail.CompareTo method
+
+Vergleicht die aktuelle OcrDetail-Instanz mit einem anderen OcrDetail-Objekt anhand ihrer PageNumber-Eigenschaft.
+
+```csharp
+public int CompareTo(OcrDetail other)
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/errormessage/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/errormessage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.ErrorMessage"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Eigenschaft. Eine Fehlermeldung, die beschreibt, warum OCR für diese Seite fehlgeschlagen ist, wenn Success false ist. Andernfalls null."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.ai/ocrdetail/errormessage/
+---
+## OcrDetail.ErrorMessage property
+
+Eine Fehlermeldung, die beschreibt, warum OCR für diese Seite fehlgeschlagen ist, wenn Success false ist. Andernfalls Null.
+
+```csharp
+public string ErrorMessage { get; set; }
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/extractedtext/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/extractedtext/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.ExtractedText"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Eigenschaft. Der extrahierte Textinhalt der Seite. Null, wenn Success false ist oder kein Text gefunden wurde."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/ocrdetail/extractedtext/
+---
+## OcrDetail.ExtractedText property
+
+Der extrahierte Textinhalt der Seite. Null, wenn Success false ist oder kein Text gefunden wurde.
+
+```csharp
+public string ExtractedText { get; set; }
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/ocrdetail/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/ocrdetail/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.OcrDetail"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Konstruktor. Der Standardkonstruktor."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/ocrdetail/ocrdetail/
+---
+## OcrDetail constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public OcrDetail()
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/pagenumber/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/pagenumber/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.PageNumber"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Eigenschaft. Die 1-basierte Seitennummer im Quelldokument. Für einseitige Bilder ist dies immer 1."
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.ai/ocrdetail/pagenumber/
+---
+## OcrDetail.PageNumber property
+
+Die 1-basierte Page-Nummer im Quell-Dokument. Bei einseitigen Bildern ist sie immer 1.
+
+```csharp
+public int PageNumber { get; set; }
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/success/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/success/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.Success"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Eigenschaft. Gibt an, ob die OCR-Extraktion für diese bestimmte Seite erfolgreich war."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/ocrdetail/success/
+---
+## OcrDetail.Success property
+
+Gibt an, ob die OCR-Extraktion für diese spezifische Page erfolgreich war.
+
+```csharp
+public bool Success { get; set; }
+```
+
+### Siehe auch
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/ocrdetail/usage/_index.md
+++ b/german/net/aspose.pdf.ai/ocrdetail/usage/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OcrDetail.Usage"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OcrDetail-Eigenschaft. Ruft die Nutzungsstatistiken ab oder legt sie fest."
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.ai/ocrdetail/usage/
+---
+## OcrDetail.Usage property
+
+Liest oder legt die Nutzungsstatistiken fest.
+
+```csharp
+public Usage Usage { get; set; }
+```
+
+### Siehe auch
+
+* class [Usage](../../usage/)
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/_index.md
+++ b/german/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIChatCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIChatCopilotOptions-Eigenschaft. Gibt den maximalen Wert der Prompt-Token zurück oder legt ihn fest, der im Verlauf des Laufs verwendet werden kann."
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/
+---
+## OpenAIChatCopilotOptions.MaxPromptTokens property
+
+Gibt die maximale Anzahl von Prompt-Token zurück oder legt sie fest, die während des Laufs verwendet werden können.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Siehe auch
+
+* class [OpenAIChatCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiclient/getocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/openaiclient/getocrcopilot/_index.md
@@ -1,0 +1,34 @@
+---
+title: "OpenAIClient.GetOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIClient-Methode. Liefert eine Instanz von IOcrCopilot mit den angegebenen Optionen."
+type: docs
+weight: 250
+url: /de/net/aspose.pdf.ai/openaiclient/getocrcopilot/
+---
+## OpenAIClient.GetOcrCopilot method
+
+Liefert eine Instanz von [`IOcrCopilot`](../../iocrcopilot/) mit den angegebenen Optionen.
+
+```csharp
+public IOcrCopilot GetOcrCopilot(IOcrCopilotOptions<OpenAIOcrCopilotOptions> options)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Optionen | IOcrCopilotOptions`1 | Die Optionen für den OCR‑Copiloten. |
+
+### Rückgabewert
+
+Eine Instanz von [`IOcrCopilot`](../../iocrcopilot/).
+
+### Siehe auch
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [OpenAIOcrCopilotOptions](../../openaiocrcopilotoptions/)
+* class [OpenAIClient](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/_index.md
+++ b/german/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIImageDescriptionCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIImageDescriptionCopilotOptions-Eigenschaft. Gibt die maximale Anzahl von Prompt-Token zurück, die während des Laufs verwendet werden können, oder legt sie fest"
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/
+---
+## OpenAIImageDescriptionCopilotOptions.MaxPromptTokens property
+
+Gibt die maximale Anzahl von Prompt-Token zurück oder legt sie fest, die während des Laufs verwendet werden können.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Siehe auch
+
+* class [OpenAIImageDescriptionCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaimodels/gpt4omini/_index.md
+++ b/german/net/aspose.pdf.ai/openaimodels/gpt4omini/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIModels.Gpt4OMini"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIModels-Eigenschaft. Gibt die Kennung für das GPT4omini-Modell zurück"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.ai/openaimodels/gpt4omini/
+---
+## OpenAIModels.Gpt4OMini property
+
+Gibt die Kennung für das GPT-4o-mini-Modell zurück.
+
+```csharp
+public static string Gpt4OMini { get; }
+```
+
+### Siehe auch
+
+* class [OpenAIModels](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilot/_index.md
@@ -1,0 +1,64 @@
+---
+title: "Klasse OpenAIOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.OpenAIOcrCopilot‑Klasse. Bietet OCR‑Funktionen zum Extrahieren von Text aus PDF‑Dokumenten und Bildern. Unterstützte Bildtypen: PNG .png, JPEG .jpeg und .jpg, WEBP .webp, nicht animiertes GIF .gif. Beispielhafte Verwendung zum Erstellen eines OpenAI‑Clients, Konfigurieren von Optionen und Verwenden des OCR‑Copiloten."
+type: docs
+weight: 980
+url: /de/net/aspose.pdf.ai/openaiocrcopilot/
+---
+## OpenAIOcrCopilot class
+
+Bietet OCR‑Funktionen zum Extrahieren von Text aus PDF‑Dokumenten und Bildern. Unterstützte Bildtypen: PNG (.png), JPEG (.jpeg und .jpg), WEBP (.webp), nicht animiertes GIF (.gif). Beispielhafte Verwendung zum Erstellen eines OpenAI‑Clients, Konfigurieren von Optionen und Verwenden des OCR‑Copiloten.
+
+```csharp
+// Erstelle AI‑Client.
+var openAiClient = OpenAIClient
+    .CreateWithApiKey(ApiKey) // Create OpenAI client with the API key.
+    //.WithOrganization("org_123") // Optionale Parameter konfigurieren.
+    .Build(); // Build
+
+// Erstelle Copilot‑Optionen.
+var options = OpenAIOcrCopilotOptions
+    .Create() // Create options like this, or...
+    //.Create(options => { options.Model = OpenAIModels.Gpt4O; }) // ...mit Delegat erstellen.
+    .WithDocument("DocumentInputPath"); // .WithDocument methods allows to add Document objects and paths to PDF documents and images.
+
+// Erstelle Zusammenfassungs‑Copilot.
+IOcrCopilot ocrCopilot = AICopilotFactory.CreateOcrCopilot(openAiClient, options);
+
+// Hole Texterkennungen.
+List<TextRecognitionResult> textRecognitions = await ocrCopilot.GetTextRecognitionResultAsync();
+
+// Zugriff auf den extrahierten Text.
+string text = textRecognitions[0].OcrDetails[0].ExtractedText;
+```
+
+```csharp
+public class OpenAIOcrCopilot : IOcrCopilot
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [OpenAIOcrCopilot](openaiocrcopilot/)(IOpenAIClient, IOcrCopilotOptions&lt;OpenAIOcrCopilotOptions&gt;) | Initialisiert eine neue Instanz der `OpenAIOcrCopilot`-Klasse. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [HasContext](../../aspose.pdf.ai/openaiocrcopilot/hascontext/) { get; } |  |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [GetTextRecognitionResultAsync](../../aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/)(CancellationToken?) |  |
+
+### Siehe auch
+
+* interface [IOcrCopilot](../iocrcopilot/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilot.GetTextRecognitionResultAsync"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilot-Methode."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/
+---
+## OpenAIOcrCopilot.GetTextRecognitionResultAsync method
+
+```csharp
+public Task<List<TextRecognitionResult>> GetTextRecognitionResultAsync(
+    CancellationToken? cancellationToken = default)
+```
+
+### Siehe auch
+
+* class [TextRecognitionResult](../../textrecognitionresult/)
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilot/hascontext/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilot/hascontext/_index.md
@@ -1,0 +1,21 @@
+---
+title: "OpenAIOcrCopilot.HasContext"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilot-Eigenschaft."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.ai/openaiocrcopilot/hascontext/
+---
+## OpenAIOcrCopilot.HasContext property
+
+```csharp
+public bool HasContext { get; }
+```
+
+### Siehe auch
+
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilot.OpenAIOcrCopilot"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilot-Konstruktor. Initialisiert eine neue Instanz der OpenAIOcrCopilot-Klasse"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/
+---
+## OpenAIOcrCopilot constructor
+
+Initialisiert eine neue Instanz der [`OpenAIOcrCopilot`](../)-Klasse.
+
+```csharp
+public OpenAIOcrCopilot(IOpenAIClient client, IOcrCopilotOptions<OpenAIOcrCopilotOptions> options)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| client | IOpenAIClient | Der OpenAI-Client, der für OCR-Operationen verwendet wird. |
+| Optionen | IOcrCopilotOptions`1 | Die Optionen, die zum Konfigurieren des OCR-Copiloten verwendet werden. |
+
+### Siehe auch
+
+* interface [IOpenAIClient](../../iopenaiclient/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [OpenAIOcrCopilotOptions](../../openaiocrcopilotoptions/)
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Klasse OpenAIOcrCopilotOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.OpenAIOcrCopilotOptions-Klasse. Stellt die Optionen zur Konfiguration des OpenAIOcrCopilot dar."
+type: docs
+weight: 990
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/
+---
+## OpenAIOcrCopilotOptions class
+
+Stellt die Optionen zur Konfiguration des OpenAIOcrCopilot dar.
+
+```csharp
+public class OpenAIOcrCopilotOptions : OpenAIAssistantCopilotOptionsBase, 
+    IOcrCopilotOptions<OpenAIOcrCopilotOptions>
+```
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Detail](../../aspose.pdf.ai/openaiocrcopilotoptions/detail/) { get; set; } | Liest oder legt das Detaillierungsniveau für die Bildanalyse fest. |
+| [DocumentCollection](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/documentcollection/) { get; set; } | Liest oder legt die Sammlung von documents fest, die verarbeitet werden sollen. |
+| [MaxCompletionTokens](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/maxcompletiontokens/) { get; set; } | Liest oder legt die maximale Anzahl von Completion-Token fest, die während des Laufs verwendet werden können. |
+| [Model](../../aspose.pdf.ai/openaicopilotoptionsbase/model/) { get; set; } | Liest oder legt das Modell fest, das für den Assistenten verwendet wird. |
+| [Resolution](../../aspose.pdf.ai/openaiocrcopilotoptions/resolution/) { get; set; } | Liest oder legt die Auflösung fest, die zum Konvertieren von PDF-Seiten in Bilder verwendet wird. Der Standardwert ist 300 dpi. |
+| [SystemInstructions](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/systeminstructions/) { get; set; } | Liest oder legt den Dateipfad für die Textdatei fest, die die Systemanweisungen des Assistenten enthält. |
+| [Temperature](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/temperature/) { get; set; } | Liest oder legt die Sampling-Temperatur fest, die für das Modell verwendet wird. |
+| [TopP](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/topp/) { get; set; } | Liest oder legt den top-p-Wert für das Nucleus-Sampling fest. |
+| [UserInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/) { get; set; } | Liest oder legt die Benutzeraufforderung fest. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| static [Create](../../aspose.pdf.ai/openaiocrcopilotoptions/create/#create)() | Erstellt eine neue Instanz von `OpenAIOcrCopilotOptions`. |
+| static [Create](../../aspose.pdf.ai/openaiocrcopilotoptions/create/#create_1)(Action&lt;OpenAIOcrCopilotOptions&gt;) | Erstellt eine Instanz von `OpenAIOcrCopilotOptions` und konfiguriert sie mit dem bereitgestellten Delegaten. |
+| [GetOptions](../../aspose.pdf.ai/openaiocrcopilotoptions/getoptions/)() | Ruft die aktuelle `OpenAIOcrCopilotOptions` ab. |
+| [WithDetail](../../aspose.pdf.ai/openaiocrcopilotoptions/withdetail/)(Detail) | Legt den Detaillierungsgrad für die Bildanalyse fest. |
+| [WithDocument](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocument/#withdocument)(PdfDocument) | Fügt ein PDF-Dokument zur Dokumentensammlung hinzu. |
+| [WithDocument](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocument/#withdocument_1)(string) | Fügt einen Dokumentpfad zur Dokumentensammlung hinzu. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments)(DocumentCollection) | Setzt die Dokumentensammlung. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments_1)(List&lt;PdfDocument&gt;) | Fügt mehrere PDF-Dokumente zur Dokumentensammlung hinzu. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments_2)(List&lt;string&gt;) | Fügt mehrere Dokumentpfade zur Dokumentensammlung hinzu. |
+| [WithMaxCompletionTokens](../../aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/)(int?) | Legt die maximale Anzahl an Completion-Token fest. |
+| [WithModel](../../aspose.pdf.ai/openaiocrcopilotoptions/withmodel/)(string) | Legt das Modell fest. |
+| [WithResolution](../../aspose.pdf.ai/openaiocrcopilotoptions/withresolution/)(int) | Legt die Auflösung fest, die zum Konvertieren von PDF-Seiten in Bilder verwendet wird. Der Standardwert beträgt 300 dpi. |
+| [WithSystemInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/)(string) | Legt die Anweisungen für die OCR‑Copilot‑Optionen fest. |
+| [WithTemperature](../../aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/)(double?) | Legt die Temperatur fest. |
+| [WithTopP](../../aspose.pdf.ai/openaiocrcopilotoptions/withtopp/)(double?) | Legt den Top‑P‑Wert fest. |
+| [WithUserInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/)(string) | Legt die Benutzereingabe fest. |
+
+### Siehe auch
+
+* class [OpenAIAssistantCopilotOptionsBase](../openaiassistantcopilotoptionsbase/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../iocrcopilotoptions-1/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/create/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/create/_index.md
@@ -1,0 +1,51 @@
+---
+title: "OpenAIOcrCopilotOptions.Create"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions method. Erstellt eine neue Instanz von OpenAIOcrCopilotOptions"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/create/
+---
+## Create() {#create}
+
+Erstellt eine neue Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+```csharp
+public static OpenAIOcrCopilotOptions Create()
+```
+
+### Rückgabewert
+
+Eine neue Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## Create(Action&lt;OpenAIOcrCopilotOptions&gt;) {#create_1}
+
+Erstellt eine Instanz von [`OpenAIOcrCopilotOptions`](../) und konfiguriert sie mithilfe des bereitgestellten Delegaten.
+
+```csharp
+public static OpenAIOcrCopilotOptions Create(Action<OpenAIOcrCopilotOptions> config)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| config | Action`1 | Der Delegat zum Konfigurieren der Optionen. |
+
+### Rückgabewert
+
+Die konfigurierte Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OpenAIOcrCopilotOptions.Detail"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions property. Liest oder setzt den Detaillierungsgrad für die Bildanalyse."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/
+---
+## OpenAIOcrCopilotOptions.Detail property
+
+Liest oder legt das Detaillierungsniveau für die Bildanalyse fest.
+
+```csharp
+public Detail Detail { get; set; }
+```
+
+### Siehe auch
+
+* enum [Detail](../../detail/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "OpenAIOcrCopilotOptions.GetOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Ruft die aktuelle OpenAIOcrCopilotOptions ab."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/
+---
+## OpenAIOcrCopilotOptions.GetOptions method
+
+Ruft die aktuelle [`OpenAIOcrCopilotOptions`](../) ab.
+
+```csharp
+public OpenAIOcrCopilotOptions GetOptions()
+```
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilotOptions.Resolution"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions property. Ruft die Auflösung ab, die zum Konvertieren von PDF‑Seiten in Bilder verwendet wird, oder setzt sie. Der Standardwert ist 300 dpi"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/
+---
+## OpenAIOcrCopilotOptions.Resolution property
+
+Liest oder legt die Auflösung fest, die zum Konvertieren von PDF-Seiten in Bilder verwendet wird. Der Standardwert ist 300 dpi.
+
+```csharp
+public int Resolution { get; set; }
+```
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilotOptions.UserInstructions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions property. Ruft die Benutzereingabe ab oder setzt sie"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/
+---
+## OpenAIOcrCopilotOptions.UserInstructions property
+
+Liest oder legt die Benutzeraufforderung fest.
+
+```csharp
+public string UserInstructions { get; set; }
+```
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/_index.md
@@ -1,0 +1,32 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDetail"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt das Detaillierungsniveau für die Bildanalyse fest"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/
+---
+## OpenAIOcrCopilotOptions.WithDetail method
+
+Legt den Detaillierungsgrad für die Bildanalyse fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDetail(Detail detail)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Detail | Detail | Das Detaillierungsniveau. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* enum [Detail](../../detail/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/_index.md
@@ -1,0 +1,56 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDocument"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Fügt ein PDF Document zur Document collection hinzu"
+type: docs
+weight: 70
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/
+---
+## WithDocument(PdfDocument) {#withdocument}
+
+Fügt ein PDF-Dokument zur Dokumentensammlung hinzu.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocument(PdfDocument pdfDocument)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pdfDocument | PdfDocument | Das PDF Document zum Hinzufügen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [PdfDocument](../../pdfdocument/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocument(string) {#withdocument_1}
+
+Fügt einen Dokumentpfad zur Dokumentensammlung hinzu.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocument(string filePath)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePath | String | Der Dateipfad des Document zum Hinzufügen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/_index.md
@@ -1,0 +1,81 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDocuments"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt die Document collection fest"
+type: docs
+weight: 80
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/
+---
+## WithDocuments(DocumentCollection) {#withdocuments}
+
+Setzt die Dokumentensammlung.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(DocumentCollection documentCollection)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| documentCollection | DocumentCollection | Die Document collection zum Festlegen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [DocumentCollection](../../documentcollection/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocuments(List&lt;PdfDocument&gt;) {#withdocuments_1}
+
+Fügt mehrere PDF-Dokumente zur Dokumentensammlung hinzu.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(List<PdfDocument> pdfDocuments)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pdfDocuments | List`1 | Die Liste der PDF documents zum Hinzufügen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [PdfDocument](../../pdfdocument/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocuments(List&lt;string&gt;) {#withdocuments_2}
+
+Fügt mehrere Dokumentpfade zur Dokumentensammlung hinzu.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(List<string> filePaths)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePaths | List`1 | Die Liste der Dateipfade zum Hinzufügen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithMaxCompletionTokens"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt die maximalen Completion-Token fest"
+type: docs
+weight: 90
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/
+---
+## OpenAIOcrCopilotOptions.WithMaxCompletionTokens method
+
+Legt die maximale Anzahl an Completion-Token fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithMaxCompletionTokens(int? maxCompletionTokens)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| maxCompletionTokens | Nullable`1 | Die maximalen Completion-Token zum Festlegen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithModel"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions method. Setzt das Modell"
+type: docs
+weight: 100
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/
+---
+## OpenAIOcrCopilotOptions.WithModel method
+
+Legt das Modell fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithModel(string model)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| model | String | Das zu setzende Modell. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithResolution"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt die Auflösung fest, die zum Konvertieren von PDF-Seiten in Bilder verwendet wird. Der Standardwert ist 300 dpi."
+type: docs
+weight: 110
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/
+---
+## OpenAIOcrCopilotOptions.WithResolution method
+
+Legt die Auflösung fest, die zum Konvertieren von PDF-Seiten in Bilder verwendet wird. Der Standardwert beträgt 300 dpi.
+
+```csharp
+public OpenAIOcrCopilotOptions WithResolution(int resolution)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| resolution | Int32 | Die Auflösung in dpi. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithSystemInstructions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions method. Setzt die Anweisungen für die ocr copilot‑Optionen"
+type: docs
+weight: 120
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/
+---
+## OpenAIOcrCopilotOptions.WithSystemInstructions method
+
+Legt die Anweisungen für die OCR‑Copilot‑Optionen fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithSystemInstructions(string text)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Text | String | Die festzulegenden Anweisungen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithTemperature"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt die Temperatur fest."
+type: docs
+weight: 130
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/
+---
+## OpenAIOcrCopilotOptions.WithTemperature method
+
+Legt die Temperatur fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithTemperature(double? temperature)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Temperatur | Nullable`1 | Die einzustellende Temperatur. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithTopP"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt den Top‑P‑Wert fest"
+type: docs
+weight: 140
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/
+---
+## OpenAIOcrCopilotOptions.WithTopP method
+
+Legt den Top‑P‑Wert fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithTopP(double? topP)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| topP | Nullable`1 | Der Top‑P‑Wert zum Festlegen. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/_index.md
+++ b/german/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithUserInstructions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAIOcrCopilotOptions-Methode. Legt die Benutzeraufforderung fest"
+type: docs
+weight: 150
+url: /de/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/
+---
+## OpenAIOcrCopilotOptions.WithUserInstructions method
+
+Legt die Benutzereingabe fest.
+
+```csharp
+public OpenAIOcrCopilotOptions WithUserInstructions(string text)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Text | String | Der Eingabetext. |
+
+### Rückgabewert
+
+Die aktuelle Instanz von [`OpenAIOcrCopilotOptions`](../).
+
+### Siehe auch
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/_index.md
+++ b/german/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAISummaryCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OpenAISummaryCopilotOptions-Eigenschaft. Gibt die maximale Anzahl von Prompt-Token zurück oder legt sie fest, die während des Laufs verwendet werden können"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/
+---
+## OpenAISummaryCopilotOptions.MaxPromptTokens property
+
+Gibt die maximale Anzahl von Prompt-Token zurück oder legt sie fest, die während des Laufs verwendet werden können.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Siehe auch
+
+* class [OpenAISummaryCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/_index.md
@@ -1,0 +1,38 @@
+---
+title: "Klasse TextRecognitionResult"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AI.TextRecognitionResult Klasse. Stellt die aggregierten OCR-Ergebnisse für ein einzelnes Document dar"
+type: docs
+weight: 1180
+url: /de/net/aspose.pdf.ai/textrecognitionresult/
+---
+## TextRecognitionResult class
+
+Stellt die aggregierten OCR-Ergebnisse für ein einzelnes Document dar.
+
+```csharp
+public class TextRecognitionResult
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [TextRecognitionResult](textrecognitionresult/)() | Der Standardkonstruktor. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [OcrDetails](../../aspose.pdf.ai/textrecognitionresult/ocrdetails/) { get; set; } | Eine Liste, die die detaillierten OCR-Ergebnisse für jede Page des Document enthält. Bei Einzelbilddateien enthält diese Liste typischerweise einen OcrDetail‑Eintrag mit PageNumber = 1. |
+| [OverallSuccess](../../aspose.pdf.ai/textrecognitionresult/overallsuccess/) { get; set; } | Gibt an, ob OCR für ALLE Pages dieses Document erfolgreich war. False, wenn irgendein OcrDetail in OcrDetails Success = false hat. |
+| [SourceIdentifier](../../aspose.pdf.ai/textrecognitionresult/sourceidentifier/) { get; set; } | Bezeichner für die Quelldatei (z. B. der vollständige Pfad oder ein eindeutiger Name). |
+| [SummaryErrorMessage](../../aspose.pdf.ai/textrecognitionresult/summaryerrormessage/) { get; set; } | Eine konsolidierte Fehlermeldung, wenn OverallSuccess false ist, oder eine Zusammenfassung, wenn eine Seite fehlgeschlagen ist. Null, wenn OverallSuccess true ist. |
+| [TotalUsage](../../aspose.pdf.ai/textrecognitionresult/totalusage/) { get; set; } | Liest oder setzt die Gesamtnutzungsstatistiken für die Verarbeitung dieses Document (alle Pages). |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextRecognitionResult.OcrDetails"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Eigenschaft. Eine Liste, die die detaillierten OCR-Ergebnisse für jede Seite des Dokuments enthält. Für Einzelbilddateien wird diese Liste typischerweise einen OcrDetail-Eintrag mit PageNumber 1 enthalten"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/
+---
+## TextRecognitionResult.OcrDetails property
+
+Eine Liste, die die detaillierten OCR-Ergebnisse für jede Page des Document enthält. Bei Einzelbilddateien enthält diese Liste typischerweise einen OcrDetail‑Eintrag mit PageNumber = 1.
+
+```csharp
+public List<OcrDetail> OcrDetails { get; set; }
+```
+
+### Siehe auch
+
+* class [OcrDetail](../../ocrdetail/)
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.OverallSuccess"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Eigenschaft. Gibt an, ob OCR für ALLE Seiten dieses Dokuments erfolgreich war. False, wenn irgendein OcrDetail in OcrDetails Success false ist"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/
+---
+## TextRecognitionResult.OverallSuccess property
+
+Gibt an, ob OCR für ALLE Pages dieses Document erfolgreich war. False, wenn irgendein OcrDetail in OcrDetails Success = false hat.
+
+```csharp
+public bool OverallSuccess { get; set; }
+```
+
+### Siehe auch
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.SourceIdentifier"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Eigenschaft. Kennung für die Quelldatei, z. B. der vollständige Pfad oder ein eindeutiger Name"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/
+---
+## TextRecognitionResult.SourceIdentifier property
+
+Bezeichner für die Quelldatei (z. B. der vollständige Pfad oder ein eindeutiger Name).
+
+```csharp
+public string SourceIdentifier { get; set; }
+```
+
+### Siehe auch
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.SummaryErrorMessage"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Eigenschaft. Eine konsolidierte Fehlermeldung, wenn OverallSuccess false ist, oder eine Zusammenfassung, falls eine Seite fehlgeschlagen ist. Null, wenn OverallSuccess true ist"
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/
+---
+## TextRecognitionResult.SummaryErrorMessage property
+
+Eine konsolidierte Fehlermeldung, wenn OverallSuccess false ist, oder eine Zusammenfassung, wenn eine Seite fehlgeschlagen ist. Null, wenn OverallSuccess true ist.
+
+```csharp
+public string SummaryErrorMessage { get; set; }
+```
+
+### Siehe auch
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.TextRecognitionResult"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Konstruktor. Der Standardkonstruktor"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/
+---
+## TextRecognitionResult constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public TextRecognitionResult()
+```
+
+### Siehe auch
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.ai/textrecognitionresult/totalusage/_index.md
+++ b/german/net/aspose.pdf.ai/textrecognitionresult/totalusage/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextRecognitionResult.TotalUsage"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextRecognitionResult-Eigenschaft. Gibt die Gesamtnutzungsstatistiken für die Verarbeitung dieses Dokuments (alle Seiten) zurück oder legt sie fest"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.ai/textrecognitionresult/totalusage/
+---
+## TextRecognitionResult.TotalUsage property
+
+Liest oder setzt die Gesamtnutzungsstatistiken für die Verarbeitung dieses Document (alle Pages).
+
+```csharp
+public Usage TotalUsage { get; set; }
+```
+
+### Siehe auch
+
+* class [Usage](../../usage/)
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.annotations/freetextannotation/settextstyle/_index.md
+++ b/german/net/aspose.pdf.annotations/freetextannotation/settextstyle/_index.md
@@ -1,0 +1,55 @@
+---
+title: "FreeTextAnnotation.SetTextStyle"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "FreeTextAnnotation method. Legt die Formatierung fest, die durch den Parameter textStyle für gesamten Anmerkungstext bestimmt wird"
+type: docs
+weight: 150
+url: /de/net/aspose.pdf.annotations/freetextannotation/settextstyle/
+---
+## SetTextStyle(RichTextFontStyles, string, double, Color) {#settextstyle}
+
+Legt die Formatierung fest, die durch den Parameter textStyle für gesamten Anmerkungstext bestimmt wird.
+
+```csharp
+public void SetTextStyle(RichTextFontStyles textStyles, string fontName, double fontSize, 
+    Color fontColor)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| textStyles | RichTextFontStyles | Stil(e) für Anmerkungstext angewendet. |
+| fontName | String | Schriftname, der für Anmerkungstext verwendet wird. |
+| fontSize | Double | Schriftgröße, die für Anmerkungstext verwendet wird. |
+| fontColor | Color | Schriftfarbe, die für Anmerkungstext verwendet wird. |
+
+### Siehe auch
+
+* enum [RichTextFontStyles](../../richtextfontstyles/)
+* class [FreeTextAnnotation](../)
+* namespace [Aspose.Pdf.Annotations](../../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## SetTextStyle(int, int, RichTextFontStyles) {#settextstyle_1}
+
+Legt die Formatierung fest, die durch den Parameter textStyle für ein Textfragment vom Index fromInd bis zum Index toInd bestimmt wird.
+
+```csharp
+public void SetTextStyle(int fromInd, int toInd, RichTextFontStyles textStyles)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fromInd | Int32 | Startindex des Textfragmentes (ab 0). |
+| toInd | Int32 | Endindex des Textfragmentes (gezählt ab 0, dieser nicht enthalten). |
+| textStyles | RichTextFontStyles | Stil(e), die auf das Textfragment angewendet werden. |
+
+### Siehe auch
+
+* enum [RichTextFontStyles](../../richtextfontstyles/)
+* class [FreeTextAnnotation](../)
+* namespace [Aspose.Pdf.Annotations](../../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.annotations/richtextfontstyles/_index.md
+++ b/german/net/aspose.pdf.annotations/richtextfontstyles/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum RichTextFontStyles"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Annotations.RichTextFontStyles enum. Optionen für die Formatierung von Textfragmenten in RichText"
+type: docs
+weight: 2600
+url: /de/net/aspose.pdf.annotations/richtextfontstyles/
+---
+## RichTextFontStyles enumeration
+
+Optionen für die Formatierung von Textfragmenten in RichText.
+
+```csharp
+[Flags]
+public enum RichTextFontStyles
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| ClearExisting | `1` | Wenn gesetzt, werden alle vorhandenen Stile gelöscht, bevor weitere angewendet werden. In Kombination mit anderen Stil‑Flags (z. B. Bold) werden zunächst die Stile zurückgesetzt und anschließend die angegebenen angewendet. Ohne dieses Flag werden neue Stile zu den bestehenden hinzugefügt. |
+| Bold | `2` | Option, die Fett angibt. |
+| Italic | `4` | Option, die Kursiv angibt. |
+| Underline | `8` | Option, die Unterstreichung angibt. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.Annotations](../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.devices/imagedevice/getbitmap/_index.md
+++ b/german/net/aspose.pdf.devices/imagedevice/getbitmap/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ImageDevice.GetBitmap"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ImageDevice-Methode. Konvertiert die Seite in ein Bitmap"
+type: docs
+weight: 80
+url: /de/net/aspose.pdf.devices/imagedevice/getbitmap/
+---
+## ImageDevice.GetBitmap method
+
+Konvertiert die Seite in ein Bitmap.
+
+```csharp
+public Bitmap GetBitmap(Page page)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Seite | Page | Die Page zum Konvertieren. |
+
+### Siehe auch
+
+* class [Page](../../../aspose.pdf/page/)
+* class [ImageDevice](../)
+* namespace [Aspose.Pdf.Devices](../../../aspose.pdf.devices/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/_index.md
+++ b/german/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/_index.md
@@ -1,0 +1,59 @@
+---
+title: "PdfFileSignature.TryExtractCertificate"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "PdfFileSignature-Methode. Extrahiert das einzelne X.509-Zertifikat einer Signatur"
+type: docs
+weight: 310
+url: /de/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/
+---
+## TryExtractCertificate(SignatureName, out X509Certificate2) {#tryextractcertificate_1}
+
+Extrahiert das einzelne X.509-Zertifikat der Signatur.
+
+```csharp
+public bool TryExtractCertificate(SignatureName signName, out X509Certificate2 certificate)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| signName | SignatureName | Der Name der Signatur. |
+| certificate | X509Certificate2& | Wenn ein Zertifikat gefunden wurde, wird das einzelne X.509-Zertifikatsobjekt zurückgegeben; andernfalls null. |
+
+### Rückgabewert
+
+Ein gültiges Zertifikat wurde gefunden.
+
+### Siehe auch
+
+* class [SignatureName](../../signaturename/)
+* class [PdfFileSignature](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## TryExtractCertificate(SignatureName, out Stream) {#tryextractcertificate}
+
+Extrahiert das einzelne X.509-Zertifikat der Signatur als Stream.
+
+```csharp
+public bool TryExtractCertificate(SignatureName signName, out Stream stream)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| signName | SignatureName | Der Name der Signatur. |
+| Strom | Stream& | Wenn ein Zertifikat gefunden wurde, gibt es den X.509 Einzelzertifikat‑Stream zurück; andernfalls null. |
+
+### Rückgabewert
+
+Ein gültiges Zertifikat wurde gefunden.
+
+### Siehe auch
+
+* class [SignatureName](../../signaturename/)
+* class [PdfFileSignature](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.facades/pdfviewer/printdocuments/_index.md
+++ b/german/net/aspose.pdf.facades/pdfviewer/printdocuments/_index.md
@@ -1,0 +1,487 @@
+---
+title: "PdfViewer.PrintDocuments"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "PdfViewer-Methode. Druckt mehrere PDF-Dokumente mit den Standarddrucker- und Seiteneinstellungen."
+type: docs
+weight: 370
+url: /de/net/aspose.pdf.facades/pdfviewer/printdocuments/
+---
+## PrintDocuments(params Document[]) {#printdocuments}
+
+Druckt mehrere PDF-Dokumente mit den Standarddrucker- und Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(params Document[] documents)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| documents | Document[] | Ein Array von [`Document`](../../../aspose.pdf/document/)‑Objekten, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Druckauftrag.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(document1, document2, document3)
+End Using
+```
+
+### Siehe auch
+
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(params string[]) {#printdocuments_8}
+
+Druckt mehrere PDF-Dokumente mit den Standarddrucker- und Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(params string[] filePaths)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePaths | String[] | Ein Array von Dateipfaden, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Druckauftrag. Stellen Sie sicher, dass die angegebenen Dateipfade gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(path1, path2, path3)
+```
+
+### Siehe auch
+
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(params Stream[]) {#printdocuments_7}
+
+Druckt mehrere PDF-Dokumente aus den bereitgestellten Streams mit den Standarddrucker- und Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(params Stream[] documentStreams)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| documentStreams | Stream[] | Ein Array von Streams, die die zu druckenden PDF-Dokumente enthalten. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Vorgang. Stellen Sie sicher, dass die bereitgestellten Streams während des Druckvorgangs gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(stream1, stream2, stream3)
+End Using
+```
+
+### Siehe auch
+
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params Document[]) {#printdocuments_1}
+
+Druckt mehrere PDF-Dokumente mit den angegebenen Druckereinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params Document[] documents)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Das [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/)‑Objekt, das die für den Druck zu verwendenden Druckereinstellungen angibt. |
+| documents | Document[] | Ein Array von [`Document`](../../../aspose.pdf/document/)‑Objekten, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente mit benutzerdefinierten Druckereinstellungen.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Dim printDocument As New PrintDocument()
+     Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+     printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, document1, document2, document3)
+End Using
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params string[]) {#printdocuments_6}
+
+Druckt mehrere PDF-Dokumente mit den angegebenen Druckereinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params string[] filePaths)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Das [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) Objekt, das Druckerkonfigurationsdetails enthält. |
+| filePaths | String[] | Ein Array von Dateipfaden, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Druckauftrag. Stellen Sie sicher, dass die angegebenen Dateipfade gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+var printDocument = new PrintDocument();
+Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Dim printDocument As New PrintDocument()
+Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, path1, path2, path3)
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params Stream[]) {#printdocuments_5}
+
+Druckt mehrere PDF-Dokumente aus den bereitgestellten Streams unter Verwendung der angegebenen Druckereinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params Stream[] documentStreams)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Die Druckereinstellungen, die während des Druckvorgangs angewendet werden. |
+| documentStreams | Stream[] | Ein Array von Streams, die die zu druckenden PDF-Dokumente enthalten. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Vorgang. Stellen Sie sicher, dass die bereitgestellten Streams während des Druckvorgangs gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Dim printDocument As New PrintDocument()
+    Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, stream1, stream2, stream3)
+End Using
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params Document[]) {#printdocuments_2}
+
+Druckt mehrere PDF-Dokumente unter Verwendung des angegebenen Druckers und der Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params Document[] documents)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Das [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/)‑Objekt, das die für den Druck zu verwendenden Druckereinstellungen angibt. |
+| pageSettings | PageSettings | Das [`PageSettings`](../../../aspose.pdf.printing/pagesettings/) Objekt, das die für den Druck zu verwendenden Seiteneinstellungen angibt. |
+| documents | Document[] | Ein Array von [`Document`](../../../aspose.pdf/document/)‑Objekten, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente mit benutzerdefinierten Drucker- und Seiteneinstellungen.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+    pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Dim printDocument As New PrintDocument()
+     Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+     printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+     Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+     pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+     pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, document1, document2, document3)
+End Using
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params string[]) {#printdocuments_4}
+
+Druckt mehrere PDF-Dokumente unter Verwendung des angegebenen Druckers und der Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params string[] filePaths)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Das [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) Objekt, das Druckerkonfigurationsdetails enthält. |
+| pageSettings | PageSettings | Das [`PageSettings`](../../../aspose.pdf.printing/pagesettings/) Objekt, das Seitenlayout und -einstellungen spezifiziert. |
+| filePaths | String[] | Ein Array von Dateipfaden, die die zu druckenden PDF-Dokumente darstellen. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Druckauftrag. Stellen Sie sicher, dass die angegebenen Dateipfade gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+var printDocument = new PrintDocument();
+Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Dim printDocument As New PrintDocument()
+Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, path1, path2, path3)
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params Stream[]) {#printdocuments_3}
+
+Druckt mehrere PDF-Dokumente aus den bereitgestellten Streams unter Verwendung des angegebenen Druckers und der Seiteneinstellungen.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params Stream[] documentStreams)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | Die Druckereinstellungen, die während des Druckvorgangs angewendet werden. |
+| pageSettings | PageSettings | Die Seiteneinstellungen, die jedem Dokument während des Druckens angewendet werden. |
+| documentStreams | Stream[] | Ein Array von Streams, die die zu druckenden PDF-Dokumente enthalten. |
+
+## Hinweise
+
+Diese Methode ermöglicht das Drucken mehrerer PDF-Dokumente in einem einzigen Vorgang. Stellen Sie sicher, dass die bereitgestellten Streams während des Druckvorgangs gültig und zugänglich sind.
+
+## Beispiele
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+    pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Dim printDocument As New PrintDocument()
+    Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+    Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+    pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, stream1, stream2, stream3)
+End Using
+```
+
+### Siehe auch
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.forms/form/hasxfa/_index.md
+++ b/german/net/aspose.pdf.forms/form/hasxfa/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Form.HasXfa"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Form-Eigenschaft. Gibt einen Wert zurück, der angibt, ob das Dokument ein XFA-Formular enthält. Diese Eigenschaft wurde eingeführt, um zu bestimmen, ob IgnoreNeedsRendering verwendet werden soll, um das XFA-Formular zu entfernen, wenn das XFA-Formular vorhanden ist und NeedsRendering false ist."
+type: docs
+weight: 90
+url: /de/net/aspose.pdf.forms/form/hasxfa/
+---
+## Form.HasXfa property
+
+Gibt einen Wert zurück, der angibt, ob das Dokument ein XFA-Formular enthält. Diese Eigenschaft wurde eingeführt, um zu bestimmen, ob [`IgnoreNeedsRendering`](../ignoreneedsrendering/) verwendet werden soll, um das XFA-Formular zu entfernen, wenn das XFA-Formular vorhanden ist und [`NeedsRendering`](../needsrendering/) false ist.
+
+```csharp
+public bool HasXfa { get; }
+```
+
+### Siehe auch
+
+* class [Form](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.forms/form/needsrendering/_index.md
+++ b/german/net/aspose.pdf.forms/form/needsrendering/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Form.NeedsRendering"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Form-Eigenschaft. Gibt einen Wert zurück, der angibt, ob das Dokument die Entfernung des dynamischen XFA-Formulars erfordert. Diese Eigenschaft wurde eingeführt, um zu bestimmen, ob IgnoreNeedsRendering verwendet werden soll, um das XFA-Formular zu entfernen, wenn das XFA-Formular vorhanden ist und NeedsRendering false ist."
+type: docs
+weight: 130
+url: /de/net/aspose.pdf.forms/form/needsrendering/
+---
+## Form.NeedsRendering property
+
+Gibt einen Wert zurück, der angibt, ob das Dokument die Entfernung des dynamischen XFA-Formulars erfordert. Diese Eigenschaft wurde eingeführt, um zu bestimmen, ob [`IgnoreNeedsRendering`](../ignoreneedsrendering/) verwendet werden soll, um das XFA-Formular zu entfernen, wenn das XFA-Formular vorhanden ist und `NeedsRendering` false ist.
+
+```csharp
+public bool NeedsRendering { get; }
+```
+
+### Siehe auch
+
+* class [Form](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/_index.md
+++ b/german/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "SignatureCustomAppearance.IsForegroundImage"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "SignatureCustomAppearance-Eigenschaft. Gibt einen Wert zurück oder legt ihn fest, der angibt, ob das Bild in der Signaturdarstellung als Vordergrundbild gezeichnet wird. Standardwert false."
+type: docs
+weight: 130
+url: /de/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/
+---
+## SignatureCustomAppearance.IsForegroundImage property
+
+Gibt einen Wert zurück oder legt ihn fest, der angibt, ob das Bild in der Signaturdarstellung als Vordergrundbild gezeichnet wird. Standardwert: false.
+
+```csharp
+public bool IsForegroundImage { get; set; }
+```
+
+### Siehe auch
+
+* class [SignatureCustomAppearance](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.forms/signaturefield/extractcertificateobject/_index.md
+++ b/german/net/aspose.pdf.forms/signaturefield/extractcertificateobject/_index.md
@@ -1,0 +1,27 @@
+---
+title: "SignatureField.ExtractCertificateObject"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "SignatureField-Methode. Extrahiert das einzelne X.509-Zertifikatsobjekt"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.forms/signaturefield/extractcertificateobject/
+---
+## SignatureField.ExtractCertificateObject method
+
+Extrahiert das einzelne X.509-Zertifikatsobjekt.
+
+```csharp
+public X509Certificate2 ExtractCertificateObject()
+```
+
+### Rückgabewert
+
+Wenn das Zertifikat gefunden wurde, wird das einzelne X.509-Zertifikat zurückgegeben; andernfalls null.
+
+### Siehe auch
+
+* class [SignatureField](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofd/_index.md
+++ b/german/net/aspose.pdf.plugins/ofd/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Klasse Ofd"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Plugins.Ofd Klasse. Stellt das Ofd‑Plugin dar"
+type: docs
+weight: 9090
+url: /de/net/aspose.pdf.plugins/ofd/
+---
+## Ofd class
+
+Stellt das `Ofd`‑Plugin dar.
+
+```csharp
+public sealed class Ofd : IDisposable, IPlugin
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [Ofd](ofd/)() | Der Standardkonstruktor. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [Dispose](../../aspose.pdf.plugins/ofd/dispose/)() | Implementierung von IDisposable. |
+| [Process](../../aspose.pdf.plugins/ofd/process/)(IPluginOptions) | Startet die `Ofd`‑Verarbeitung mit den angegebenen Parametern. |
+
+### Siehe auch
+
+* interface [IPlugin](../iplugin/)
+* namespace [Aspose.Pdf.Plugins](../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofd/dispose/_index.md
+++ b/german/net/aspose.pdf.plugins/ofd/dispose/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ofd.Dispose"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Ofd-Methode. Implementierung von IDisposable"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.plugins/ofd/dispose/
+---
+## Ofd.Dispose method
+
+Implementierung von IDisposable.
+
+```csharp
+public void Dispose()
+```
+
+### Siehe auch
+
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofd/ofd/_index.md
+++ b/german/net/aspose.pdf.plugins/ofd/ofd/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ofd.Ofd"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Ofd-Konstruktor. Der Standardkonstruktor"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.plugins/ofd/ofd/
+---
+## Ofd constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public Ofd()
+```
+
+### Siehe auch
+
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofd/process/_index.md
+++ b/german/net/aspose.pdf.plugins/ofd/process/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Ofd.Process"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Ofd-Methode. Startet die Ofd-Verarbeitung mit den angegebenen Parametern"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.plugins/ofd/process/
+---
+## Ofd.Process method
+
+Startet die [`Ofd`](../)-Verarbeitung mit den angegebenen Parametern.
+
+```csharp
+public ResultContainer Process(IPluginOptions options)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| options | IPluginOptions | Ein Optionsobjekt, das Anweisungen für das [`Ofd`](../) enthält. |
+
+### Rückgabewert
+
+Ein [`ResultContainer`](../../resultcontainer/)-Objekt, das das Ergebnis der Operation enthält.
+
+### Siehe auch
+
+* class [ResultContainer](../../resultcontainer/)
+* interface [IPluginOptions](../../ipluginoptions/)
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofdtopdfoptions/_index.md
+++ b/german/net/aspose.pdf.plugins/ofdtopdfoptions/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Klasse OfdToPdfOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Plugins.OfdToPdfOptions Klasse. Stellt Optionen für die Konvertierung von OFD zu PDF dar"
+type: docs
+weight: 9100
+url: /de/net/aspose.pdf.plugins/ofdtopdfoptions/
+---
+## OfdToPdfOptions class
+
+Stellt Optionen für die Konvertierung von OFD zu PDF dar.
+
+```csharp
+public class OfdToPdfOptions : PdfConverterOptions
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [OfdToPdfOptions](ofdtopdfoptions/)() | Der Standardkonstruktor. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Inputs](../../aspose.pdf.plugins/pdfconverteroptions/inputs/) { get; } | Gibt die Datenkollektion des PdfConverterOptions‑Plugins zurück. |
+| [OfdLoadOptions](../../aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/) { get; set; } | Liest oder setzt die OFD-Ladeoptionen. |
+| override [OperationName](../../aspose.pdf.plugins/ofdtopdfoptions/operationname/) { get; } | Liest den Namen der Operation. |
+| [Outputs](../../aspose.pdf.plugins/pdfconverteroptions/outputs/) { get; } | Liest die Sammlung hinzugefügter Ziele zum Speichern von Operationsergebnissen. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [AddInput](../../aspose.pdf.plugins/pdfconverteroptions/addinput/)(IDataSource) | Fügt der Datenkollektion des PdfConverter‑Plugins eine neue Datenquelle hinzu. |
+| [AddOutput](../../aspose.pdf.plugins/pdfconverteroptions/addoutput/)(IDataSource) | Fügt der Datenkollektion des PdfToXLSXConverterOptions‑Plugins eine neue Datenquelle hinzu. |
+
+### Siehe auch
+
+* class [PdfConverterOptions](../pdfconverteroptions/)
+* namespace [Aspose.Pdf.Plugins](../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/_index.md
+++ b/german/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OfdToPdfOptions.OfdLoadOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OfdToPdfOptions-Eigenschaft. Liest oder setzt die OFD-Ladeoptionen"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/
+---
+## OfdToPdfOptions.OfdLoadOptions property
+
+Liest oder setzt die OFD-Ladeoptionen.
+
+```csharp
+public OfdLoadOptions OfdLoadOptions { get; set; }
+```
+
+### Siehe auch
+
+* class [OfdLoadOptions](../../../aspose.pdf/ofdloadoptions/)
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/_index.md
+++ b/german/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OfdToPdfOptions.OfdToPdfOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OfdToPdfOptions-Konstruktor. Der Standardkonstruktor"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/
+---
+## OfdToPdfOptions constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public OfdToPdfOptions()
+```
+
+### Siehe auch
+
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/_index.md
+++ b/german/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OfdToPdfOptions.OperationName"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "OfdToPdfOptions-Eigenschaft. Gibt den Namen der Operation zurück"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/
+---
+## OfdToPdfOptions.OperationName property
+
+Liest den Namen der Operation.
+
+```csharp
+public override string OperationName { get; }
+```
+
+### Siehe auch
+
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/certificateencryptionoptions/_index.md
+++ b/german/net/aspose.pdf.security/certificateencryptionoptions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Klasse CertificateEncryptionOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Security.CertificateEncryptionOptions Klasse. Stellt eine Klasse für die Verschlüsselungsoptionen eines PDF Document mittels zertifikatsbasierter Verschlüsselungsmethode dar. Wird verwendet, um verschlüsselte PDF Document zu öffnen."
+type: docs
+weight: 10100
+url: /de/net/aspose.pdf.security/certificateencryptionoptions/
+---
+## CertificateEncryptionOptions class
+
+Stellt eine Klasse für die Verschlüsselungsoptionen eines PDF-Dokuments mithilfe einer zertifikatbasierten Verschlüsselungsmethode dar. Wird verwendet, um verschlüsselte PDF-Dokumente zu öffnen.
+
+```csharp
+public class CertificateEncryptionOptions
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_2)(string, StoreName, StoreLocation) | Erstellt eine Instanz der Klasse `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_3)(string, string, string) | Erstellt eine Instanz der Klasse `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor)(X509Certificate2, StoreName, StoreLocation) | Erstellt eine Instanz der Klasse `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_1)(X509Certificate2, string, string) | Erstellt eine Instanz der Klasse `CertificateEncryptionOptions`. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/_index.md
+++ b/german/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/_index.md
@@ -1,0 +1,99 @@
+---
+title: "CertificateEncryptionOptions.CertificateEncryptionOptions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "CertificateEncryptionOptions-Konstruktor. Erstellt eine Instanz der Klasse CertificateEncryptionOptions"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/
+---
+## CertificateEncryptionOptions(string, string, string) {#constructor_3}
+
+Erstellt eine Instanz der Klasse [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(string publicCertificatePath, string pfxPath, 
+    string pfxPassword)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicCertificatePath | String | Der Pfad zur öffentlichen Zertifikatsdatei. |
+| pfxPath | String | Der Pfad zur p12-Archivdatei. |
+| pfxPassword | String | Das Passwort der p12-Archivdatei. |
+
+### Siehe auch
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(string, StoreName, StoreLocation) {#constructor_2}
+
+Erstellt eine Instanz der Klasse [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(string publicCertificatePath, 
+    StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicCertificatePath | String | Der Pfad zur öffentlichen Zertifikatsdatei. |
+| storeName | StoreName | Der Store-Name, um ein Zertifikat mit privatem Schlüssel zu erhalten. |
+| storeLocation | StoreLocation | Der Speicherort, um ein Zertifikat mit privatem Schlüssel zu erhalten. |
+
+### Siehe auch
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(X509Certificate2, StoreName, StoreLocation) {#constructor}
+
+Erstellt eine Instanz der Klasse [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(X509Certificate2 publicCertificate, 
+    StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicCertificate | X509Certificate2 | Das öffentliche Zertifikat. |
+| storeName | StoreName | Der Store-Name, um ein Zertifikat mit privatem Schlüssel zu erhalten. |
+| storeLocation | StoreLocation | Der Speicherort, um ein Zertifikat mit privatem Schlüssel zu erhalten. |
+
+### Siehe auch
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(X509Certificate2, string, string) {#constructor_1}
+
+Erstellt eine Instanz der Klasse [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(X509Certificate2 publicCertificate, string pfxPath, 
+    string pfxPassword)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicCertificate | X509Certificate2 | Das öffentliche Zertifikat. |
+| pfxPath | String | Der Pfad zur p12-Archivdatei. |
+| pfxPassword | String | Das Passwort der p12-Archivdatei. |
+
+### Siehe auch
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Klasse EncryptionParameters"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Security.EncryptionParameters Klasse. Stellt eine Verschlüsselungsparameter‑Klasse dar"
+type: docs
+weight: 10140
+url: /de/net/aspose.pdf.security/encryptionparameters/
+---
+## EncryptionParameters class
+
+Stellt eine Verschlüsselungsparameter‑Klasse dar.
+
+```csharp
+public class EncryptionParameters
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [EncryptionParameters](encryptionparameters/)() | Der Standardkonstruktor. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Filter](../../aspose.pdf.security/encryptionparameters/filter/) { get; } | Liefert den Filternamen. |
+| [KeyLength](../../aspose.pdf.security/encryptionparameters/keylength/) { get; } | Liefert die Schlüssellänge. |
+| [OwnerKey](../../aspose.pdf.security/encryptionparameters/ownerkey/) { get; } | Liefert den Besitzer‑Schlüssel (das "O"‑Feld des Verschlüsselungswörterbuchs.) |
+| [Password](../../aspose.pdf.security/encryptionparameters/password/) { get; } | Liefert das Passwort aus der Eingabe. |
+| [Permissions](../../aspose.pdf.security/encryptionparameters/permissions/) { get; } | Die Dokumentberechtigungen. |
+| [PermissionsInt](../../aspose.pdf.security/encryptionparameters/permissionsint/) { get; } | Die ganzzahlige Darstellung der Dokumentberechtigungen. |
+| [Perms](../../aspose.pdf.security/encryptionparameters/perms/) { get; } | Liest die Perms-Felddaten. Es handelt sich um verschlüsselte Berechtigungen. |
+| [Revision](../../aspose.pdf.security/encryptionparameters/revision/) { get; } | Liefert die Revision des Handlers oder des Verschlüsselungsalgorithmus. |
+| [SubFilter](../../aspose.pdf.security/encryptionparameters/subfilter/) { get; } | Liefert den Subfilter-Namen. |
+| [UserKey](../../aspose.pdf.security/encryptionparameters/userkey/) { get; } | Liest den Benutzerschlüssel (das "U"-Feld des Verschlüsselungswörterbuchs.) |
+| [Version](../../aspose.pdf.security/encryptionparameters/version/) { get; } | Liefert die Version des Handlers oder des Verschlüsselungsalgorithmus. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/encryptionparameters/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/encryptionparameters/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.EncryptionParameters"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Konstruktor. Der Standardkonstruktor"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.security/encryptionparameters/encryptionparameters/
+---
+## EncryptionParameters constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public EncryptionParameters()
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/filter/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/filter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Filter"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt den Namen des Filters zurück"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.security/encryptionparameters/filter/
+---
+## EncryptionParameters.Filter property
+
+Liefert den Filternamen.
+
+```csharp
+public string Filter { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/keylength/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/keylength/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.KeyLength"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt die Schlüssellänge zurück"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.security/encryptionparameters/keylength/
+---
+## EncryptionParameters.KeyLength property
+
+Liefert die Schlüssellänge.
+
+```csharp
+public int KeyLength { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/ownerkey/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/ownerkey/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.OwnerKey"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt den owner key zurück. Das O-Feld des Verschlüsselungswörterbuchs"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.security/encryptionparameters/ownerkey/
+---
+## EncryptionParameters.OwnerKey property
+
+Liefert den Besitzer‑Schlüssel (das "O"‑Feld des Verschlüsselungswörterbuchs.)
+
+```csharp
+public byte[] OwnerKey { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/password/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/password/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Password"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt das Passwort aus der Eingabe zurück"
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.security/encryptionparameters/password/
+---
+## EncryptionParameters.Password property
+
+Liefert das Passwort aus der Eingabe.
+
+```csharp
+public string Password { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/permissions/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/permissions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "EncryptionParameters.Permissions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Die Dokumentberechtigungen"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.security/encryptionparameters/permissions/
+---
+## EncryptionParameters.Permissions property
+
+Die Dokumentberechtigungen.
+
+```csharp
+public Permissions Permissions { get; }
+```
+
+### Siehe auch
+
+* enum [Permissions](../../../aspose.pdf/permissions/)
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/permissionsint/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/permissionsint/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.PermissionsInt"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Die ganzzahlige Darstellung der Dokumentberechtigungen"
+type: docs
+weight: 70
+url: /de/net/aspose.pdf.security/encryptionparameters/permissionsint/
+---
+## EncryptionParameters.PermissionsInt property
+
+Die ganzzahlige Darstellung der Dokumentberechtigungen.
+
+```csharp
+public int PermissionsInt { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/perms/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/perms/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Perms"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt die Perms-Felddaten zurück. Es handelt sich um verschlüsselte Berechtigungen"
+type: docs
+weight: 80
+url: /de/net/aspose.pdf.security/encryptionparameters/perms/
+---
+## EncryptionParameters.Perms property
+
+Liest die Perms-Felddaten. Es handelt sich um verschlüsselte Berechtigungen.
+
+```csharp
+public byte[] Perms { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/revision/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/revision/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Revision"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt die Revision des Handlers oder des Verschlüsselungsalgorithmus zurück"
+type: docs
+weight: 90
+url: /de/net/aspose.pdf.security/encryptionparameters/revision/
+---
+## EncryptionParameters.Revision property
+
+Liefert die Revision des Handlers oder des Verschlüsselungsalgorithmus.
+
+```csharp
+public int Revision { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/subfilter/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/subfilter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.SubFilter"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt den Subfilter-Namen zurück"
+type: docs
+weight: 100
+url: /de/net/aspose.pdf.security/encryptionparameters/subfilter/
+---
+## EncryptionParameters.SubFilter property
+
+Liefert den Subfilter-Namen.
+
+```csharp
+public string SubFilter { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/userkey/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/userkey/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.UserKey"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt den user key zurück. Das U-Feld des Verschlüsselungswörterbuchs"
+type: docs
+weight: 110
+url: /de/net/aspose.pdf.security/encryptionparameters/userkey/
+---
+## EncryptionParameters.UserKey property
+
+Liest den Benutzerschlüssel (das "U"-Feld des Verschlüsselungswörterbuchs.)
+
+```csharp
+public byte[] UserKey { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/encryptionparameters/version/_index.md
+++ b/german/net/aspose.pdf.security/encryptionparameters/version/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Version"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "EncryptionParameters-Eigenschaft. Gibt die Version des Handlers oder des Verschlüsselungsalgorithmus zurück"
+type: docs
+weight: 120
+url: /de/net/aspose.pdf.security/encryptionparameters/version/
+---
+## EncryptionParameters.Version property
+
+Liefert die Version des Handlers oder des Verschlüsselungsalgorithmus.
+
+```csharp
+public int Version { get; }
+```
+
+### Siehe auch
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Schnittstelle ICustomSecurityHandler"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Security.ICustomSecurityHandler Schnittstelle. Die benutzerdefinierte Sicherheits-Handler-Schnittstelle"
+type: docs
+weight: 10150
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/
+---
+## ICustomSecurityHandler interface
+
+Die benutzerdefinierte Sicherheits-Handler-Schnittstelle.
+
+```csharp
+public interface ICustomSecurityHandler
+```
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [Filter](../../aspose.pdf.security/icustomsecurityhandler/filter/) { get; } | Liefert den Filternamen. |
+| [KeyLength](../../aspose.pdf.security/icustomsecurityhandler/keylength/) { get; } | Liefert die Schlüssellänge. |
+| [Revision](../../aspose.pdf.security/icustomsecurityhandler/revision/) { get; } | Liefert die Revision des Handlers oder des Verschlüsselungsalgorithmus. |
+| [SubFilter](../../aspose.pdf.security/icustomsecurityhandler/subfilter/) { get; } | Liefert den Subfilter-Namen. |
+| [Version](../../aspose.pdf.security/icustomsecurityhandler/version/) { get; } | Liefert die Version des Handlers oder des Verschlüsselungsalgorithmus. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [CalculateEncryptionKey](../../aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/)(string) | Berechnet den EncryptionKey. Im Allgemeinen wird der Schlüssel basierend auf dem UserKey berechnet. Sie können Werte aus EncryptionParams verwenden, die die zum Zeitpunkt des Aufrufs aktuellen Parameter enthalten. Dieser Wert wird als Schlüsselargument in [`Encrypt`](./encrypt/) und [`Decrypt`](./decrypt/) übergeben. |
+| [Decrypt](../../aspose.pdf.security/icustomsecurityhandler/decrypt/)(byte[], int, int, byte[]) | Entschlüsselt das Datenarray. |
+| [Encrypt](../../aspose.pdf.security/icustomsecurityhandler/encrypt/)(byte[], int, int, byte[]) | Verschlüsselt das Datenarray. |
+| [EncryptPermissions](../../aspose.pdf.security/icustomsecurityhandler/encryptpermissions/)(int) | Verschlüsselt das Berechtigungsfeld des Dokuments. Das Ergebnis wird in das Perms-Feld des Verschlüsselungswörterbuchs geschrieben. Beim Öffnen eines Dokuments kann der Wert in [`EncryptionParameters`](../encryptionparameters/) über das Perms-Feld abgerufen werden. Ermöglicht es, zu prüfen, ob sich die Dokumentberechtigungen geändert haben. |
+| [GetOwnerKey](../../aspose.pdf.security/icustomsecurityhandler/getownerkey/)(string, string) | Erstellt ein codiertes Array basierend auf Passwörtern, das in das O-Feld des Verschlüsselungswörterbuchs geschrieben wird. Sollte sich ausschließlich auf die übergebenen Argumente stützen. Das Benutzerpasswort kann aus diesem Feld mithilfe des Besitzerpassworts berechnet werden. Wird während der Verschlüsselung aufgerufen, um es vorzubereiten und das Verschlüsselungswörterbuch zu füllen. Der Wert ist in [`CalculateEncryptionKey`](./calculateencryptionkey/) verfügbar, um den Schlüssel aus dem UserKey zu erhalten. Die vom Benutzer beim Aufruf der Dokumentenverschlüsselung angegebenen Passwörter werden übergeben. Passwörter können nicht angegeben werden oder es kann nur eines angegeben werden. |
+| [GetUserKey](../../aspose.pdf.security/icustomsecurityhandler/getuserkey/)(string) | Erstellt ein codiertes Array basierend auf dem Passwort des Benutzers. Dieser Wert wird typischerweise verwendet, um zu prüfen, ob das Passwort zum Benutzer oder zum Besitzer gehört, und um den Verschlüsselungsschlüssel zu erhalten. Wird während der Verschlüsselung aufgerufen, um es vorzubereiten und das Verschlüsselungs‑Wörterbuch zu füllen. Das vom Benutzer angegebene Passwort wird als Argument beim Aufruf der Dokumentenverschlüsselung übergeben. |
+| [Initialize](../../aspose.pdf.security/icustomsecurityhandler/initialize/)(EncryptionParameters) | Wird aufgerufen, um die aktuelle Instanz für die Verschlüsselung zu initialisieren. Beachten Sie, dass beim Verschlüsseln die Daten der übertragenen Eigenschaften `ICustomSecurityHandler` eingefügt werden und beim Öffnen des Dokuments aus dem Verschlüsselungswörterbuch. Wenn die Methode während einer neuen Verschlüsselung aufgerufen wird, sind [`UserKey`](../encryptionparameters/userkey/) und [`OwnerKey`](../encryptionparameters/ownerkey/) null. |
+| [IsOwnerPassword](../../aspose.pdf.security/icustomsecurityhandler/isownerpassword/)(string) | Prüft, ob das Passwort das Passwort des Dokumentenbesitzers ist. Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF‑API verwendet. |
+| [IsUserPassword](../../aspose.pdf.security/icustomsecurityhandler/isuserpassword/)(string) | Prüft, ob das Passwort zum Benutzer gehört (Passwort zum Öffnen des Dokuments). Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF‑API verwendet. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.CalculateEncryptionKey"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Berechnet den EncryptionKey. Im Allgemeinen wird der Schlüssel basierend auf dem UserKey berechnet. Sie können Werte aus EncryptionParams verwenden, die die aktuellen Parameter zum Zeitpunkt des Aufrufs enthalten. Dieser Wert wird als Schlüsselargument in Encrypt und Decrypt übergeben."
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/
+---
+## ICustomSecurityHandler.CalculateEncryptionKey method
+
+Berechnet den EncryptionKey. Im Allgemeinen wird der Schlüssel basierend auf dem UserKey berechnet. Sie können Werte aus EncryptionParams verwenden, die die aktuellen Parameter zum Zeitpunkt des Aufrufs enthalten. Dieser Wert wird als Schlüsselargument in [`Encrypt`](../encrypt/) und [`Decrypt`](../decrypt/) übergeben.
+
+```csharp
+public byte[] CalculateEncryptionKey(string password)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| password | String | Vom Benutzer eingegebenes Passwort. |
+
+### Rückgabewert
+
+Das Array des Verschlüsselungsschlüssels.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/decrypt/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/decrypt/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ICustomSecurityHandler.Decrypt"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Entschlüsselt das Datenarray."
+type: docs
+weight: 70
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/decrypt/
+---
+## ICustomSecurityHandler.Decrypt method
+
+Entschlüsselt das Datenarray.
+
+```csharp
+public byte[] Decrypt(byte[] data, int objectNumber, int generation, byte[] key)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| data | Byte[] | Zu entschlüsselnde Daten. |
+| objectNumber | Int32 | Nummer des Objekts, das die verschlüsselten Daten enthält. |
+| generation | Int32 | Generation des Objekts. |
+| key | Byte[] | Schlüssel, der durch die Methode CalculateEncryptionKey erhalten wird. |
+
+### Rückgabewert
+
+Die entschlüsselten Daten.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/encrypt/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/encrypt/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ICustomSecurityHandler.Encrypt"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Verschlüsselt das Datenarray."
+type: docs
+weight: 80
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/encrypt/
+---
+## ICustomSecurityHandler.Encrypt method
+
+Verschlüsselt das Datenarray.
+
+```csharp
+public byte[] Encrypt(byte[] data, int objectNumber, int generation, byte[] key)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| data | Byte[] | Zu verschlüsselnde Daten. |
+| objectNumber | Int32 | Nummer des Objekts, das die verschlüsselten Daten enthält. |
+| generation | Int32 | Generation des Objekts. |
+| key | Byte[] | Schlüssel, der durch die Methode CalculateEncryptionKey erhalten wird. |
+
+### Rückgabewert
+
+Die verschlüsselten Daten.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.EncryptPermissions"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Verschlüsselt das Berechtigungsfeld des Document. Das Ergebnis wird in das Perms‑Feld des Verschlüsselungswörterbuchs geschrieben. Beim Öffnen eines Document kann der Wert in EncryptionParameters über das Perms‑Feld abgerufen werden. Ermöglicht die Überprüfung, ob sich die Document‑Berechtigungen geändert haben."
+type: docs
+weight: 90
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/
+---
+## ICustomSecurityHandler.EncryptPermissions method
+
+Verschlüsselt das Berechtigungsfeld des Document. Das Ergebnis wird in das Perms‑Verschlüsselungswörterbuchfeld geschrieben. Beim Öffnen eines Document kann der Wert über das Perms‑Feld in [`EncryptionParameters`](../../encryptionparameters/) abgerufen werden. Ermöglicht die Überprüfung, ob sich die Document‑Berechtigungen geändert haben.
+
+```csharp
+public byte[] EncryptPermissions(int permissions)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Berechtigungen | Int32 | Die Document‑Berechtigungen in ganzzahliger Darstellung. |
+
+### Rückgabewert
+
+Das verschlüsselte Array.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/filter/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/filter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Filter"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Eigenschaft. Gibt den Filternamen zurück."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/filter/
+---
+## ICustomSecurityHandler.Filter property
+
+Liefert den Filternamen.
+
+```csharp
+public string Filter { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/_index.md
@@ -1,0 +1,32 @@
+---
+title: "ICustomSecurityHandler.GetOwnerKey"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Erstellt ein codiertes Array basierend auf Passwörtern, das in das O-Feld des Verschlüsselungswörterbuchs geschrieben wird. Sollte sich nur auf die übergebenen Argumente verlassen. Das Benutzerpasswort kann aus diesem Feld mithilfe des Besitzerpassworts berechnet werden. Wird während der Verschlüsselung aufgerufen, um sie vorzubereiten und das Verschlüsselungswörterbuch zu füllen. Der Wert ist in CalculateEncryptionKey verfügbar, um den Schlüssel aus dem UserKey zu erhalten. Die vom Benutzer beim Aufrufen der Dokumentverschlüsselung angegebenen Passwörter werden übergeben. Passwörter müssen nicht angegeben werden oder es kann nur eines angegeben werden."
+type: docs
+weight: 100
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/
+---
+## ICustomSecurityHandler.GetOwnerKey method
+
+Erstellt ein codiertes Array basierend auf Passwörtern, das in das O-Feld des Verschlüsselungswörterbuchs geschrieben wird. Sollte sich nur auf die übergebenen Argumente verlassen. Das Benutzerpasswort kann aus diesem Feld mithilfe des Besitzerpassworts berechnet werden. Wird während der Verschlüsselung aufgerufen, um sie vorzubereiten und das Verschlüsselungswörterbuch zu füllen. Der Wert ist in [`CalculateEncryptionKey`](../calculateencryptionkey/) verfügbar, um den Schlüssel aus dem UserKey zu erhalten. Die vom Benutzer beim Aufrufen der Dokumentverschlüsselung angegebenen Passwörter werden übergeben. Passwörter müssen nicht angegeben werden oder es kann nur eines angegeben werden.
+
+```csharp
+public byte[] GetOwnerKey(string userPassword, string ownerPassword)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| userPassword | String | Das Benutzerpasswort. |
+| ownerPassword | String | Das Besitzerpasswort. |
+
+### Rückgabewert
+
+Das Array des owner key.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.GetUserKey"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Erstellt ein codiertes Array basierend auf dem Benutzerpasswort. Dieser Wert wird typischerweise verwendet, um zu prüfen, ob das Passwort zum Benutzer oder Eigentümer gehört und um den Verschlüsselungsschlüssel zu erhalten. Wird während der Verschlüsselung aufgerufen, um sie vorzubereiten und das Verschlüsselungswörterbuch zu füllen. Das benutzerdefinierte Passwort wird als Argument übergeben, wenn die Document-Verschlüsselung aufgerufen wird."
+type: docs
+weight: 110
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/
+---
+## ICustomSecurityHandler.GetUserKey method
+
+Erstellt ein codiertes Array basierend auf dem Passwort des Benutzers. Dieser Wert wird typischerweise verwendet, um zu prüfen, ob das Passwort zum Benutzer oder zum Besitzer gehört, und um den Verschlüsselungsschlüssel zu erhalten. Wird während der Verschlüsselung aufgerufen, um es vorzubereiten und das Verschlüsselungs‑Wörterbuch zu füllen. Das vom Benutzer angegebene Passwort wird als Argument beim Aufruf der Dokumentenverschlüsselung übergeben.
+
+```csharp
+public byte[] GetUserKey(string userPassword)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| userPassword | String | Das Benutzerpasswort. |
+
+### Rückgabewert
+
+Das Array des Benutzerschlüssels.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/initialize/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/initialize/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ICustomSecurityHandler.Initialize"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Wird aufgerufen, um die aktuelle Instanz für die Verschlüsselung zu initialisieren. Hinweis: Beim Verschlüsseln wird sie mit den Daten der übertragenen Eigenschaften ICustomSecurityHandler gefüllt und beim Öffnen des Dokuments aus dem Verschlüsselungswörterbuch. Wenn die Methode während einer neuen Verschlüsselung aufgerufen wird, sind UserKey und OwnerKey null."
+type: docs
+weight: 120
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/initialize/
+---
+## ICustomSecurityHandler.Initialize method
+
+Aufgerufen, um die aktuelle Instanz für die Verschlüsselung zu initialisieren. Beachten Sie, dass beim Verschlüsseln die Daten der übertragenen Eigenschaften [`ICustomSecurityHandler`](../) eingefüllt werden und beim Öffnen des Document aus dem Verschlüsselungswörterbuch. Wird die Methode während einer neuen Verschlüsselung aufgerufen, sind [`UserKey`](../../encryptionparameters/userkey/) und [`OwnerKey`](../../encryptionparameters/ownerkey/) null.
+
+```csharp
+public void Initialize(EncryptionParameters parameters)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Parameter | EncryptionParameters | Die Verschlüsselungsparameter. |
+
+### Siehe auch
+
+* class [EncryptionParameters](../../encryptionparameters/)
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.IsOwnerPassword"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Prüft, ob das Passwort das Besitzerpasswort des Dokuments ist. Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF-API verwendet."
+type: docs
+weight: 130
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/
+---
+## ICustomSecurityHandler.IsOwnerPassword method
+
+Prüft, ob das Passwort das Passwort des Dokumentenbesitzers ist. Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF‑API verwendet.
+
+```csharp
+public bool IsOwnerPassword(string password)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| password | String | Das Passwort. |
+
+### Rückgabewert
+
+True, wenn es ein Besitzerpasswort ist.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.IsUserPassword"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Methode. Prüft, ob das Passwort das Benutzerpasswort zum Öffnen des Dokuments ist. Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF-API verwendet."
+type: docs
+weight: 140
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/
+---
+## ICustomSecurityHandler.IsUserPassword method
+
+Prüft, ob das Passwort zum Benutzer gehört (Passwort zum Öffnen des Dokuments). Die Methode wird nach Initialize aufgerufen. Der Methodenaufruf wird in der PDF‑API verwendet.
+
+```csharp
+public bool IsUserPassword(string password)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| password | String | Das Passwort. |
+
+### Rückgabewert
+
+True, wenn es ein Passwort zum Öffnen des Dokuments ist.
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/keylength/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/keylength/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.KeyLength"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Eigenschaft. Gibt die Schlüssellänge zurück"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/keylength/
+---
+## ICustomSecurityHandler.KeyLength property
+
+Liefert die Schlüssellänge.
+
+```csharp
+public int KeyLength { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/revision/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/revision/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Revision"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Eigenschaft. Gibt die Revision des Handlers oder des Verschlüsselungsalgorithmus zurück"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/revision/
+---
+## ICustomSecurityHandler.Revision property
+
+Liefert die Revision des Handlers oder des Verschlüsselungsalgorithmus.
+
+```csharp
+public int Revision { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/subfilter/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/subfilter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.SubFilter"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Eigenschaft. Gibt den Namen des Subfilters zurück"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/subfilter/
+---
+## ICustomSecurityHandler.SubFilter property
+
+Liefert den Subfilter-Namen.
+
+```csharp
+public string SubFilter { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/icustomsecurityhandler/version/_index.md
+++ b/german/net/aspose.pdf.security/icustomsecurityhandler/version/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Version"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ICustomSecurityHandler-Eigenschaft. Gibt die Version des Handlers oder des Verschlüsselungsalgorithmus zurück."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf.security/icustomsecurityhandler/version/
+---
+## ICustomSecurityHandler.Version property
+
+Liefert die Version des Handlers oder des Verschlüsselungsalgorithmus.
+
+```csharp
+public int Version { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.security/validationoptions/checkcertificatechain/_index.md
+++ b/german/net/aspose.pdf.security/validationoptions/checkcertificatechain/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ValidationOptions.CheckCertificateChain"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ValidationOptions-Eigenschaft. Gibt einen Wert zurück oder legt ihn fest, der angibt, ob die Zertifikatskette während des Validierungsprozesses geprüft werden soll."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf.security/validationoptions/checkcertificatechain/
+---
+## ValidationOptions.CheckCertificateChain property
+
+Gibt einen Wert zurück oder legt ihn fest, der angibt, ob die Zertifikatskette während des Validierungsprozesses geprüft werden soll.
+
+```csharp
+public bool CheckCertificateChain { get; set; }
+```
+
+## Hinweise
+
+Wenn die Eigenschaft gesetzt ist, wird das Vorhandensein einer Zertifikatskette geprüft; ist sie nicht vorhanden, ist das Ergebnis der Überprüfung „Undefined“, was dem Verhalten von Adobe Acrobat entspricht. Wenn Sie nur den Widerrufsstatus online prüfen möchten, setzen Sie das Feld auf `false`. Der Standardwert ist `false`.
+
+### Siehe auch
+
+* class [ValidationOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/_index.md
+++ b/german/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLblElement"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ITaggedContent-Methode. Erstellt ListLblElement"
+type: docs
+weight: 180
+url: /de/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/
+---
+## ITaggedContent.CreateListLblElement method
+
+Erstellt [`ListLblElement`](../../../aspose.pdf.logicalstructure/listlblelement/).
+
+```csharp
+public ListLblElement CreateListLblElement()
+```
+
+### Rückgabewert
+
+Strukturelement erstellt.
+
+### Siehe auch
+
+* class [ListLblElement](../../../aspose.pdf.logicalstructure/listlblelement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/_index.md
+++ b/german/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLBodyElement"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ITaggedContent-Methode. Erstellt ListLBodyElement"
+type: docs
+weight: 190
+url: /de/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/
+---
+## ITaggedContent.CreateListLBodyElement method
+
+Erstellt [`ListLBodyElement`](../../../aspose.pdf.logicalstructure/listlbodyelement/).
+
+```csharp
+public ListLBodyElement CreateListLBodyElement()
+```
+
+### Rückgabewert
+
+Strukturelement erstellt.
+
+### Siehe auch
+
+* class [ListLBodyElement](../../../aspose.pdf.logicalstructure/listlbodyelement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/_index.md
+++ b/german/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLIElement"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ITaggedContent-Methode. Erstellt ListLIElement"
+type: docs
+weight: 200
+url: /de/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/
+---
+## ITaggedContent.CreateListLIElement method
+
+Erstellt [`ListLIElement`](../../../aspose.pdf.logicalstructure/listlielement/).
+
+```csharp
+public ListLIElement CreateListLIElement()
+```
+
+### Rückgabewert
+
+Strukturelement erstellt.
+
+### Siehe auch
+
+* class [ListLIElement](../../../aspose.pdf.logicalstructure/listlielement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.tagged/itaggedcontent/presave/_index.md
+++ b/german/net/aspose.pdf.tagged/itaggedcontent/presave/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ITaggedContent.PreSave"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ITaggedContent-Methode. Bereitet den getaggten Inhalt des Dokuments zum Speichern vor. Diese Methode führt notwendige Vorab-Speicheroperationen durch und stellt sicher, dass der Strukturbaum und andere getaggte Inhaltselemente korrekt konfiguriert sind, bevor das Dokument gespeichert wird"
+type: docs
+weight: 410
+url: /de/net/aspose.pdf.tagged/itaggedcontent/presave/
+---
+## ITaggedContent.PreSave method
+
+Bereitet den getaggten Inhalt des Dokuments zum Speichern vor. Diese Methode führt notwendige Vorab‑Speicheroperationen durch und stellt sicher, dass der Strukturbaum und andere getaggte Inhaltselemente korrekt konfiguriert sind, bevor das Dokument gespeichert wird.
+
+```csharp
+public void PreSave()
+```
+
+### Siehe auch
+
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.tagged/itaggedcontent/save/_index.md
+++ b/german/net/aspose.pdf.tagged/itaggedcontent/save/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ITaggedContent.Save"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ITaggedContent-Methode. Speichert den aktuellen Zustand des getaggten Inhalts im zugehörigen PDF-Dokument"
+type: docs
+weight: 420
+url: /de/net/aspose.pdf.tagged/itaggedcontent/save/
+---
+## ITaggedContent.Save method
+
+Speichert den aktuellen Zustand des getaggten Inhalts im zugehörigen PDF-Dokument.
+
+```csharp
+public void Save()
+```
+
+## Hinweise
+
+Diese Methode stellt sicher, dass alle getaggten Inhaltselemente im PDF-Dokument korrekt aktualisiert und gespeichert werden. Sie führt notwendige Vorgänge aus, wie das Aktualisieren von MCID für MCR-Elemente, das Setzen von BDC-Operatoren und die Gewährleistung der Konformität mit den PDF/UA-Standards.
+
+### Siehe auch
+
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/_index.md
+++ b/german/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Enum TextReplaceOptions.FontSizeAdjustment"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.Text.TextReplaceOptionsFontSizeAdjustment Enum. Gibt eine Richtlinie an, wie die Schriftgröße von Text angepasst werden soll, um in einen umgebenden Bereich zu passen"
+type: docs
+weight: 11200
+url: /de/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/
+---
+## TextReplaceOptions.FontSizeAdjustment enumeration
+
+Gibt eine Richtlinie an, wie die Schriftgröße von Text angepasst werden soll, um in einen umgebenden Bereich zu passen.
+
+```csharp
+public enum FontSizeAdjustment
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| None | `0` | Die Schriftgröße wird nicht geändert. |
+| ShrinkToFit | `1` | Die Schriftgröße wird reduziert, wenn der Text zu groß ist, um in die Grenzen zu passen. Die Schriftgröße wird niemals erhöht, wenn der Text kleiner als die Grenzen ist. |
+| ScaleToFill | `2` | Die Schriftgröße wird angepasst (sowohl verkleinert als auch vergrößert), um den Text so weit wie möglich die Grenzen des Rechtecks ausfüllen zu lassen. |
+
+### Siehe auch
+
+* class [TextReplaceOptions](../textreplaceoptions/)
+* namespace [Aspose.Pdf.Text](../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/_index.md
+++ b/german/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextReplaceOptions.FontSizeAdjustmentAction"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextReplaceOptions property. Liest oder setzt die Richtlinie zur Anpassung der Schriftgröße, damit sie innerhalb der durch das Rechteck definierten Grenzen passt"
+type: docs
+weight: 30
+url: /de/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/
+---
+## TextReplaceOptions.FontSizeAdjustmentAction property
+
+Liest oder setzt die Richtlinie zur Anpassung der Schriftgröße, damit sie innerhalb der durch das [`Rectangle`](../rectangle/) definierten Grenzen passt.
+
+```csharp
+public FontSizeAdjustment FontSizeAdjustmentAction { get; set; }
+```
+
+### Siehe auch
+
+* enum [FontSizeAdjustment](../../textreplaceoptions.fontsizeadjustment/)
+* class [TextReplaceOptions](../)
+* namespace [Aspose.Pdf.Text](../../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf.text/textreplaceoptions/rectangle/_index.md
+++ b/german/net/aspose.pdf.text/textreplaceoptions/rectangle/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextReplaceOptions.Rectangle"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "TextReplaceOptions property. Liest oder setzt das Rechteck, um den Text nach der Ersetzung anzupassen"
+type: docs
+weight: 60
+url: /de/net/aspose.pdf.text/textreplaceoptions/rectangle/
+---
+## TextReplaceOptions.Rectangle property
+
+Liest oder setzt das Rechteck, um den Text nach der Ersetzung anzupassen.
+
+```csharp
+public Rectangle Rectangle { get; set; }
+```
+
+### Siehe auch
+
+* class [Rectangle](../../../aspose.pdf/rectangle/)
+* class [TextReplaceOptions](../)
+* namespace [Aspose.Pdf.Text](../../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Klasse AutoTaggingSettings"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.AutoTaggingSettings‑Klasse. Stellt Einstellungen für die Autotagging‑Funktionalität in PDF‑Dokumenten bereit."
+type: docs
+weight: 2910
+url: /de/net/aspose.pdf/autotaggingsettings/
+---
+## AutoTaggingSettings class
+
+Stellt Einstellungen für die Auto‑Tagging‑Funktionalität in PDF‑Dokumenten bereit.
+
+```csharp
+public sealed class AutoTaggingSettings
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [AutoTaggingSettings](autotaggingsettings/)() | Der Standardkonstruktor. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| static [Default](../../aspose.pdf/autotaggingsettings/default/) { get; } | Liefert die Standardeinstellungen für die Auto‑Tagging‑Funktionalität in PDF‑Dokumenten. |
+| [EnableAutoTagging](../../aspose.pdf/autotaggingsettings/enableautotagging/) { get; set; } | Ruft den Wert ab oder legt ihn fest, der angibt, ob die Auto‑Tagging‑Funktionalität aktiviert ist. |
+| [HeadingLevels](../../aspose.pdf/autotaggingsettings/headinglevels/) { get; set; } | Ruft die Header‑Ebenen ab oder legt sie fest, die zur Bestimmung der Struktur von Überschriften in einem PDF‑Dokument verwendet werden. |
+| [HeadingRecognitionStrategy](../../aspose.pdf/autotaggingsettings/headingrecognitionstrategy/) { get; set; } | Ruft die Strategie ab oder legt sie fest, die zur Erkennung von Überschriften im Dokument während des Auto‑Taggings verwendet wird. |
+
+## Hinweise
+
+Die `AutoTaggingSettings`‑Klasse ermöglicht das Konfigurieren von Optionen für das automatische Tagging von PDF‑Inhalten. Sie enthält Eigenschaften, um das Auto‑Tagging zu aktivieren oder zu deaktivieren, eine Strategie zur Erkennung von Überschriften festzulegen und Header‑Ebenen basierend auf Schriftgrößen zu definieren.
+
+### Siehe auch
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/autotaggingsettings/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/autotaggingsettings/_index.md
@@ -1,0 +1,23 @@
+---
+title: "AutoTaggingSettings.AutoTaggingSettings"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AutoTaggingSettings-Konstruktor. Der Standardkonstruktor"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf/autotaggingsettings/autotaggingsettings/
+---
+## AutoTaggingSettings constructor
+
+Der Standardkonstruktor.
+
+```csharp
+public AutoTaggingSettings()
+```
+
+### Siehe auch
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/default/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/default/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AutoTaggingSettings.Default"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AutoTaggingSettings-Eigenschaft. Gibt die Standardeinstellungen für die Auto-Tagging-Funktionalität in PDF-Dokumenten zurück."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf/autotaggingsettings/default/
+---
+## AutoTaggingSettings.Default property
+
+Liefert die Standardeinstellungen für die Auto‑Tagging‑Funktionalität in PDF‑Dokumenten.
+
+```csharp
+public static AutoTaggingSettings Default { get; }
+```
+
+## Hinweise
+
+Die Standardeinstellungen aktivieren Auto-Tagging und verwenden die automatische Strategie zur Überschriften-Erkennung. Diese Einstellungen können als Basiskonfiguration für die PDF-Formatkonvertierung oder andere Vorgänge, die automatisches Tagging von PDF-Inhalten erfordern, verwendet werden.
+
+### Siehe auch
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/enableautotagging/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/enableautotagging/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AutoTaggingSettings.EnableAutoTagging"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AutoTaggingSettings-Eigenschaft. Ruft einen Wert ab oder legt ihn fest, der angibt, ob die Auto-Tagging‑Funktionalität aktiviert ist."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf/autotaggingsettings/enableautotagging/
+---
+## AutoTaggingSettings.EnableAutoTagging property
+
+Ruft den Wert ab oder legt ihn fest, der angibt, ob die Auto‑Tagging‑Funktionalität aktiviert ist.
+
+```csharp
+public bool EnableAutoTagging { get; set; }
+```
+
+## Hinweise
+
+Wenn aktiviert, erzeugt die Auto-Tagging‑Funktionalität automatisch getaggten Inhalt für das PDF‑Dokument, was die Barrierefreiheit und Struktur verbessern kann.
+
+### Siehe auch
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/headinglevels/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/headinglevels/_index.md
@@ -1,0 +1,28 @@
+---
+title: "AutoTaggingSettings.HeadingLevels"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AutoTaggingSettings-Eigenschaft. Gibt die Überschriftenebenen zurück oder legt sie fest, die zur Bestimmung der Struktur von Überschriften in einem PDF-Dokument verwendet werden."
+type: docs
+weight: 40
+url: /de/net/aspose.pdf/autotaggingsettings/headinglevels/
+---
+## AutoTaggingSettings.HeadingLevels property
+
+Ruft die Header‑Ebenen ab oder legt sie fest, die zur Bestimmung der Struktur von Überschriften in einem PDF‑Dokument verwendet werden.
+
+```csharp
+public HeadingLevels HeadingLevels { get; set; }
+```
+
+## Hinweise
+
+Die `HeadingLevels`-Eigenschaft ermöglicht die Konfiguration der Zuordnung von Schriftgrößen zu Überschriftenebenen. Sie wird während des Auto-Tagging-Prozesses verwendet, um anhand der Schriftgröße von Textelementen im Dokument geeignete Überschriftenebenen zu identifizieren und zuzuweisen.
+
+### Siehe auch
+
+* class [HeadingLevels](../../headinglevels/)
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/_index.md
+++ b/german/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/_index.md
@@ -1,0 +1,28 @@
+---
+title: "AutoTaggingSettings.HeadingRecognitionStrategy"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "AutoTaggingSettings-Eigenschaft. Ruft die Strategie ab oder legt sie fest, die beim Erkennen von Überschriften im Dokument während des Auto-Taggings verwendet wird."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/
+---
+## AutoTaggingSettings.HeadingRecognitionStrategy property
+
+Ruft die Strategie ab oder legt sie fest, die zur Erkennung von Überschriften im Dokument während des Auto‑Taggings verwendet wird.
+
+```csharp
+public HeadingRecognitionStrategy HeadingRecognitionStrategy { get; set; }
+```
+
+## Hinweise
+
+Die `HeadingRecognitionStrategy`-Eigenschaft bestimmt, wie Überschriften im Dokument identifiziert werden. Verfügbare Strategien umfassen das Erkennen von Überschriften anhand von Gliederungen, heuristischer Analyse oder automatischer Erkennung. Das Festlegen dieser Eigenschaft auf None deaktiviert die Überschriftenerkennung.
+
+### Siehe auch
+
+* enum [HeadingRecognitionStrategy](../../headingrecognitionstrategy/)
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/convertexception/_index.md
+++ b/german/net/aspose.pdf/convertexception/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Klasse ConvertException"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.ConvertException‑Klasse. Stellt Fehler dar, die bei der PDF_A-Konvertierung mit Hilfsobjekten auftreten."
+type: docs
+weight: 3480
+url: /de/net/aspose.pdf/convertexception/
+---
+## ConvertException class
+
+Stellt Fehler dar, die bei der PDF_A-Konvertierung mit Hilfsobjekten auftreten.
+
+```csharp
+public sealed class ConvertException : PdfException
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [ConvertException](convertexception/#constructor)(string) | Initialisiert eine neue Instanz der `ConvertException`‑Klasse. |
+| [ConvertException](convertexception/#constructor_1)(string, Exception) | Initialisiert eine neue Instanz der `ConvertException`‑Klasse. |
+
+### Siehe auch
+
+* class [PdfException](../pdfexception/)
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf/convertexception/convertexception/_index.md
+++ b/german/net/aspose.pdf/convertexception/convertexception/_index.md
@@ -1,0 +1,48 @@
+---
+title: "ConvertException.ConvertException"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "ConvertException-Konstruktor. Initialisiert eine neue Instanz der ConvertException-Klasse"
+type: docs
+weight: 10
+url: /de/net/aspose.pdf/convertexception/convertexception/
+---
+## ConvertException(string) {#constructor}
+
+Initialisiert eine neue Instanz der [`ConvertException`](../)-Klasse.
+
+```csharp
+public ConvertException(string message)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | String | Die Nachricht. |
+
+### Siehe auch
+
+* class [ConvertException](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## ConvertException(string, Exception) {#constructor_1}
+
+Initialisiert eine neue Instanz der [`ConvertException`](../)-Klasse.
+
+```csharp
+public ConvertException(string message, Exception innerException)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | String | Die Nachricht. |
+| innerException | Exception | Die Ausnahme, die die aktuelle Ausnahme verursacht, oder eine Nullreferenz (Nothing in Visual Basic), wenn keine innere Ausnahme angegeben ist. |
+
+### Siehe auch
+
+* class [ConvertException](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/document/customsecurityhandler/_index.md
+++ b/german/net/aspose.pdf/document/customsecurityhandler/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Document.CustomSecurityHandler"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Document-Eigenschaft. Gibt einen benutzerdefinierten Sicherheits-Handler zurück."
+type: docs
+weight: 90
+url: /de/net/aspose.pdf/document/customsecurityhandler/
+---
+## Document.CustomSecurityHandler property
+
+Gibt einen benutzerdefinierten Sicherheits-Handler zurück.
+
+```csharp
+public ICustomSecurityHandler CustomSecurityHandler { get; }
+```
+
+### Siehe auch
+
+* interface [ICustomSecurityHandler](../../../aspose.pdf.security/icustomsecurityhandler/)
+* class [Document](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/document/enablenotificationlogging/_index.md
+++ b/german/net/aspose.pdf/document/enablenotificationlogging/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Document.EnableNotificationLogging"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Document-Eigenschaft. Gibt einen Wert zurück oder legt ihn fest, der angibt, ob die Protokollierung von Benachrichtigungen aktiviert werden soll."
+type: docs
+weight: 170
+url: /de/net/aspose.pdf/document/enablenotificationlogging/
+---
+## Document.EnableNotificationLogging property
+
+Gibt einen Wert zurück oder legt ihn fest, der angibt, ob die Protokollierung von Benachrichtigungen aktiviert werden soll.
+
+```csharp
+public bool EnableNotificationLogging { get; set; }
+```
+
+### Siehe auch
+
+* class [Document](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/headinglevels/_index.md
+++ b/german/net/aspose.pdf/headinglevels/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Klasse HeadingLevels"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.HeadingLevels‑Klasse. Stellt eine Klasse dar, mit der Header‑Ebenen basierend auf der Schriftgröße verarbeitet werden können."
+type: docs
+weight: 5600
+url: /de/net/aspose.pdf/headinglevels/
+---
+## HeadingLevels class
+
+Stellt eine Klasse dar, mit der Header‑Ebenen basierend auf der Schriftgröße verarbeitet werden.
+
+```csharp
+public class HeadingLevels
+```
+
+## Konstruktoren
+
+| Name | Beschreibung |
+| --- | --- |
+| [HeadingLevels](headinglevels/#constructor)() | Erstellt eine neue Instanz der Klasse HeadingLevels. |
+| [HeadingLevels](headinglevels/#constructor_1)(double) | Erstellt eine neue Instanz der Klasse HeadingLevels. |
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [AllLevels](../../aspose.pdf/headinglevels/alllevels/) { get; } | Liefert alle Header‑Ebenen. |
+
+## Methoden
+
+| Name | Beschreibung |
+| --- | --- |
+| [AddLevels](../../aspose.pdf/headinglevels/addlevels/)(ICollection&lt;double&gt;) | Fügt Header‑Ebenen hinzu. Die Schriftgrößensammlung sollte absteigend sortiert sein. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf/headinglevels/addlevels/_index.md
+++ b/german/net/aspose.pdf/headinglevels/addlevels/_index.md
@@ -1,0 +1,33 @@
+---
+title: "HeadingLevels.AddLevels"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "HeadingLevels-Methode. Fügt Überschriftenebenen hinzu. Die Schriftgrößensammlung sollte nach absteigender Größe sortiert sein."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf/headinglevels/addlevels/
+---
+## HeadingLevels.AddLevels method
+
+Fügt Header‑Ebenen hinzu. Die Schriftgrößensammlung sollte absteigend sortiert sein.
+
+```csharp
+public void AddLevels(ICollection<double> fontSizes)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Schriftgrößen | ICollection`1 | Werte sollten in absteigender Reihenfolge sortiert werden. |
+
+### Ausnahmen
+
+| Ausnahme | Bedingung |
+| --- | --- |
+| ArgumentException | Wenn der Wert nicht sortiert ist oder der Wert kleiner als eins ist. |
+
+### Siehe auch
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/headinglevels/alllevels/_index.md
+++ b/german/net/aspose.pdf/headinglevels/alllevels/_index.md
@@ -1,0 +1,23 @@
+---
+title: "HeadingLevels.AllLevels"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "HeadingLevels-Eigenschaft. Gibt alle Überschriftenebenen zurück."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf/headinglevels/alllevels/
+---
+## HeadingLevels.AllLevels property
+
+Liefert alle Header‑Ebenen.
+
+```csharp
+public IList<double> AllLevels { get; }
+```
+
+### Siehe auch
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/headinglevels/headinglevels/_index.md
+++ b/german/net/aspose.pdf/headinglevels/headinglevels/_index.md
@@ -1,0 +1,43 @@
+---
+title: "HeadingLevels.HeadingLevels"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "HeadingLevels-Konstruktor. Erstellt eine neue Instanz der HeadingLevels-Klasse."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf/headinglevels/headinglevels/
+---
+## HeadingLevels() {#constructor}
+
+Erstellt eine neue Instanz der Klasse HeadingLevels.
+
+```csharp
+public HeadingLevels()
+```
+
+### Siehe auch
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## HeadingLevels(double) {#constructor_1}
+
+Erstellt eine neue Instanz der Klasse HeadingLevels.
+
+```csharp
+public HeadingLevels(double threshold)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| threshold | Double | Der Schwellenwert zum Vergleich von Schriftgrößen. Innerhalb des Schwellenwerts sind die Überschriftenebenen gleich. Der Standardwert des Schwellenwerts beträgt 0,01. |
+
+### Siehe auch
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/license/clearlicense/_index.md
+++ b/german/net/aspose.pdf/license/clearlicense/_index.md
@@ -1,0 +1,23 @@
+---
+title: "License.ClearLicense"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "License-Methode. Löscht die aktuelle Lizenz."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf/license/clearlicense/
+---
+## License.ClearLicense method
+
+Löscht die aktuelle Lizenz.
+
+```csharp
+public void ClearLicense()
+```
+
+### Siehe auch
+
+* class [License](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/license/licenseinfo/_index.md
+++ b/german/net/aspose.pdf/license/licenseinfo/_index.md
@@ -1,0 +1,24 @@
+---
+title: "License.LicenseInfo"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Lizenz-Eigenschaft. Gibt die aktuelle Lizenzinformation zurück"
+type: docs
+weight: 20
+url: /de/net/aspose.pdf/license/licenseinfo/
+---
+## License.LicenseInfo property
+
+Gibt die aktuelle Lizenzinformation zurück.
+
+```csharp
+public LicenseInfo LicenseInfo { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../../licenseinfo/)
+* class [License](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/_index.md
@@ -1,0 +1,35 @@
+---
+title: "Klasse LicenseInfo"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "Aspose.Pdf.LicenseInfo Klasse. Stellt Lizenzinformationen dar"
+type: docs
+weight: 6230
+url: /de/net/aspose.pdf/licenseinfo/
+---
+## LicenseInfo class
+
+Stellt Lizenzinformationen dar.
+
+```csharp
+public class LicenseInfo
+```
+
+## Eigenschaften
+
+| Name | Beschreibung |
+| --- | --- |
+| [EditionType](../../aspose.pdf/licenseinfo/editiontype/) { get; } | Ermittelt den Editionstyp der Lizenz. |
+| [EmailTo](../../aspose.pdf/licenseinfo/emailto/) { get; } | Ermittelt die für die Lizenzierung verwendete E‑Mail‑Adresse. |
+| [LicensedTo](../../aspose.pdf/licenseinfo/licensedto/) { get; } | Ermittelt die Informationen über den Lizenznehmer. |
+| [LicenseExpiry](../../aspose.pdf/licenseinfo/licenseexpiry/) { get; } | Ermittelt das Ablaufdatum der Lizenz. |
+| [LicenseNote](../../aspose.pdf/licenseinfo/licensenote/) { get; } | Ermittelt die Lizenznotiz. |
+| [LicenseType](../../aspose.pdf/licenseinfo/licensetype/) { get; } | Ermittelt den Lizenztyp. |
+| [Products](../../aspose.pdf/licenseinfo/products/) { get; } | Ermittelt die Liste der lizenzierten Produkte. |
+| [SubscriptionExpiry](../../aspose.pdf/licenseinfo/subscriptionexpiry/) { get; } | Ermittelt das Veröffentlichungsdatum der Assembly, für das Updates möglich sind. |
+
+### Siehe auch
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/editiontype/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/editiontype/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.EditionType"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft den Editionstyp der Lizenz ab."
+type: docs
+weight: 10
+url: /de/net/aspose.pdf/licenseinfo/editiontype/
+---
+## LicenseInfo.EditionType property
+
+Ermittelt den Editionstyp der Lizenz.
+
+```csharp
+public string EditionType { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/emailto/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/emailto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.EmailTo"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft die für die Lizenzierung verwendete E‑Mail‑Adresse ab."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf/licenseinfo/emailto/
+---
+## LicenseInfo.EmailTo property
+
+Ermittelt die für die Lizenzierung verwendete E‑Mail‑Adresse.
+
+```csharp
+public string EmailTo { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/licensedto/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/licensedto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicensedTo"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft die Informationen über den Lizenznehmer ab."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf/licenseinfo/licensedto/
+---
+## LicenseInfo.LicensedTo property
+
+Ermittelt die Informationen über den Lizenznehmer.
+
+```csharp
+public string LicensedTo { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/licenseexpiry/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/licenseexpiry/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseExpiry"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft das Ablaufdatum der Lizenz ab."
+type: docs
+weight: 40
+url: /de/net/aspose.pdf/licenseinfo/licenseexpiry/
+---
+## LicenseInfo.LicenseExpiry property
+
+Ermittelt das Ablaufdatum der Lizenz.
+
+```csharp
+public DateTime LicenseExpiry { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/licensenote/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/licensenote/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseNote"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft die Lizenznotiz ab."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf/licenseinfo/licensenote/
+---
+## LicenseInfo.LicenseNote property
+
+Ermittelt die Lizenznotiz.
+
+```csharp
+public string LicenseNote { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/licensetype/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/licensetype/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseType"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft den Lizenztyp ab."
+type: docs
+weight: 60
+url: /de/net/aspose.pdf/licenseinfo/licensetype/
+---
+## LicenseInfo.LicenseType property
+
+Ermittelt den Lizenztyp.
+
+```csharp
+public string LicenseType { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/products/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/products/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.Products"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft die Liste der lizenzierten Produkte ab."
+type: docs
+weight: 70
+url: /de/net/aspose.pdf/licenseinfo/products/
+---
+## LicenseInfo.Products property
+
+Ermittelt die Liste der lizenzierten Produkte.
+
+```csharp
+public List<string> Products { get; }
+```
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/licenseinfo/subscriptionexpiry/_index.md
+++ b/german/net/aspose.pdf/licenseinfo/subscriptionexpiry/_index.md
@@ -1,0 +1,27 @@
+---
+title: "LicenseInfo.SubscriptionExpiry"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "LicenseInfo-Eigenschaft. Ruft das Veröffentlichungsdatum der Assembly ab, für das Updates möglich sind."
+type: docs
+weight: 80
+url: /de/net/aspose.pdf/licenseinfo/subscriptionexpiry/
+---
+## LicenseInfo.SubscriptionExpiry property
+
+Ermittelt das Veröffentlichungsdatum der Assembly, für das Updates möglich sind.
+
+```csharp
+public DateTime SubscriptionExpiry { get; }
+```
+
+## Hinweise
+
+Sie können die Lizenz nicht für die Version der Assemblies mit den oben genannten Assembly-Daten verwenden.
+
+### Siehe auch
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/_index.md
+++ b/german/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PdfFormatConversionOptions.AutoTaggingSettings"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "PdfFormatConversionOptions-Eigenschaft. Liest oder legt die Einstellungen für automatisches Tagging während der PDF-Formatkonvertierung fest"
+type: docs
+weight: 40
+url: /de/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/
+---
+## PdfFormatConversionOptions.AutoTaggingSettings property
+
+Liest oder legt die Einstellungen für automatisches Tagging während der PDF-Formatkonvertierung fest.
+
+```csharp
+public AutoTaggingSettings AutoTaggingSettings { get; set; }
+```
+
+## Hinweise
+
+Automatische Tagging-Einstellungen werden verwendet, um das Verhalten des Auto-Tagging-Prozesses zu konfigurieren, der typischerweise eingesetzt wird, um die Barrierefreiheit und Struktur eines PDF-Dokuments während der Konvertierung in ein bestimmtes PDF-Format zu verbessern.
+
+### Siehe auch
+
+* class [AutoTaggingSettings](../../autotaggingsettings/)
+* class [PdfFormatConversionOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/psloadoptions/convertfontstottf/_index.md
+++ b/german/net/aspose.pdf/psloadoptions/convertfontstottf/_index.md
@@ -1,0 +1,23 @@
+---
+title: "PsLoadOptions.ConvertFontsToTTF"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "PsLoadOptions-Eigenschaft. Gibt an, ob nonTrueType-Schriften in TTF gespeichert werden sollen. Sie verringert das Volumen des resultierenden Dokuments bei der PS-zu-PDF-Konvertierung erheblich und erhöht die Konvertierungsgeschwindigkeit von PS-Dateien mit einer großen Menge Text in nonTrueType-Schriften für jedes Ausgabeformat. Allerdings gibt es eine leichte vertikale Verschiebung des Textes beim Konvertieren von PostSctipt-Datei in ein Bild."
+type: docs
+weight: 20
+url: /de/net/aspose.pdf/psloadoptions/convertfontstottf/
+---
+## PsLoadOptions.ConvertFontsToTTF property
+
+Gibt an, ob non-TrueType-Schriften in TTF gespeichert werden sollen. Sie verringert das Volumen des resultierenden Dokuments bei der PS-zu-PDF-Konvertierung erheblich und erhöht die Konvertierungsgeschwindigkeit von PS-Dateien mit einer großen Menge Text in non-TrueType-Schriften für jedes Ausgabeformat. Allerdings gibt es eine leichte vertikale Verschiebung des Textes beim Konvertieren von PostSctipt-Datei in ein Bild.
+
+```csharp
+public bool ConvertFontsToTTF { get; set; }
+```
+
+### Siehe auch
+
+* class [PsLoadOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/ximage/getalternativetext/_index.md
+++ b/german/net/aspose.pdf/ximage/getalternativetext/_index.md
@@ -1,0 +1,32 @@
+---
+title: "XImage.GetAlternativeText"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "XImage-Methode. Gibt eine Liste von Zeichenketten mit alternativem Text für ein XImage zurück"
+type: docs
+weight: 100
+url: /de/net/aspose.pdf/ximage/getalternativetext/
+---
+## XImage.GetAlternativeText method
+
+Gibt eine Liste von Zeichenketten mit alternativem Text für ein XImage zurück.
+
+```csharp
+public List<string> GetAlternativeText(Page page)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Seite | Page | Die Seite, auf der das XImage sich befindet. |
+
+### Rückgabewert
+
+Liste von Zeichenketten mit alternativem Text für ein XImage.
+
+### Siehe auch
+
+* class [Page](../../page/)
+* class [XImage](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/ximage/trysetalternativetext/_index.md
+++ b/german/net/aspose.pdf/ximage/trysetalternativetext/_index.md
@@ -1,0 +1,37 @@
+---
+title: "XImage.TrySetAlternativeText"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "XImage-Methode. Legt alternativen Text für ein XImage auf der Seite fest"
+type: docs
+weight: 180
+url: /de/net/aspose.pdf/ximage/trysetalternativetext/
+---
+## XImage.TrySetAlternativeText method
+
+Legt alternativen Text für ein XImage auf der Seite fest.
+
+```csharp
+public bool TrySetAlternativeText(string alternativeText, Page page)
+```
+
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| alternativeText | String | Der alternative Text, der angegeben werden soll. |
+| Seite | Page | Seite, auf der das XImage sich befindet. |
+
+### Rückgabewert
+
+Wahr, wenn alternativeText für XImage gesetzt ist. Falsch, wenn alternativeText für XImage nicht gesetzt ist.
+
+## Hinweise
+
+Die Methode gibt false zurück in den folgenden Fällen: - Das XImage wurde auf der angegebenen Seite nicht gefunden. - Das XImage erscheint mehrmals auf der Seite mit unterschiedlichen Strukturelementen, wodurch unklar ist, welche Instanz den alternativen Text erhalten soll.
+
+### Siehe auch
+
+* class [Page](../../page/)
+* class [XImage](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/xpssaveoptions/defaultfont/_index.md
+++ b/german/net/aspose.pdf/xpssaveoptions/defaultfont/_index.md
@@ -1,0 +1,23 @@
+---
+title: "XpsSaveOptions.DefaultFont"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "XpsSaveOptions-Eigenschaft. Gibt den Standard-Schriftartnamen zurück oder legt ihn fest. Wird verwendet, wenn der eingebettete Schriftartname im System nicht gefunden wird."
+type: docs
+weight: 30
+url: /de/net/aspose.pdf/xpssaveoptions/defaultfont/
+---
+## XpsSaveOptions.DefaultFont property
+
+Gibt den Standard-Schriftartnamen zurück oder legt ihn fest. Wird verwendet, wenn der eingebettete Schriftartname im System nicht gefunden wird.
+
+```csharp
+public string DefaultFont { get; set; }
+```
+
+### Siehe auch
+
+* class [XpsSaveOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/german/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/_index.md
+++ b/german/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/_index.md
@@ -1,0 +1,23 @@
+---
+title: "XpsSaveOptions.UseEmbeddedTrueTypeFonts"
+second_title: "Aspose.PDF für .NET API-Referenz"
+description: "XpsSaveOptions-Eigenschaft. Gibt das Flag zurück oder legt es fest, um eingebettete TrueType-Schriften zu verwenden. Das Vermeiden der Verwendung eingebetteter TrueType-Schriften kann die Konvertierungszeit reduzieren."
+type: docs
+weight: 50
+url: /de/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/
+---
+## XpsSaveOptions.UseEmbeddedTrueTypeFonts property
+
+Gibt das Flag zurück oder legt es fest, um eingebettete TrueType-Schriften zu verwenden. Das Vermeiden der Verwendung eingebetteter TrueType-Schriften kann die Konvertierungszeit reduzieren.
+
+```csharp
+public bool UseEmbeddedTrueTypeFonts { get; set; }
+```
+
+### Siehe auch
+
+* class [XpsSaveOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+


### PR DESCRIPTION
🔄 **In progress** — incremental translation of NET API Reference to **German** (`de`).

Updated at each cache checkpoint. Source: `english/net`

🤖 Generated by RDA