### PR TITLE
[draft] Translate NET API Reference to Spanish

### DIFF
--- a/spanish/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AICopilotFactory.CreateOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método AICopilotFactory. Crea un copiloto OCR basado en el cliente y las opciones."
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/aicopilotfactory/createocrcopilot/
+---
+## AICopilotFactory.CreateOcrCopilot&lt;TOptions&gt; method
+
+Crea un copiloto OCR basado en el cliente y las opciones.
+
+```csharp
+public static IOcrCopilot CreateOcrCopilot<TOptions>(IOcrClient<TOptions> client, 
+    IOcrCopilotOptions<TOptions> options)
+```
+
+### Ver también
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrClient&lt;TOptions&gt;](../../iocrclient-1/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [AICopilotFactory](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Clase ChatMessageResponse"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.AI.ChatMessageResponse. Un mensaje de finalización de chat generado por el modelo"
+type: docs
+weight: 200
+url: /es/net/aspose.pdf.ai/chatmessageresponse/
+---
+## ChatMessageResponse class
+
+Un mensaje de finalización de chat generado por el modelo.
+
+```csharp
+public class ChatMessageResponse
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [ChatMessageResponse](chatmessageresponse/#constructor)() | Inicializa una nueva instancia de la clase `ChatMessageResponse`. |
+| [ChatMessageResponse](chatmessageresponse/#constructor_1)(string, string) | Inicializa una nueva instancia de la clase `ChatMessageResponse`. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [Content](../../aspose.pdf.ai/chatmessageresponse/content/) { get; set; } | Obtiene o establece el contenido del mensaje. |
+| [Id](../../aspose.pdf.ai/chatmessageresponse/id/) { get; set; } | Obtiene o establece el ID del mensaje. |
+| [Name](../../aspose.pdf.ai/chatmessageresponse/name/) { get; set; } | Obtiene o establece un nombre opcional para el participante. Proporciona al modelo información para diferenciar entre participantes del mismo rol. |
+| [Refusal](../../aspose.pdf.ai/chatmessageresponse/refusal/) { get; set; } | Obtiene o establece el mensaje de rechazo generado por el modelo. |
+| [Role](../../aspose.pdf.ai/chatmessageresponse/role/) { get; set; } | Obtiene o establece el rol del autor del mensaje. |
+| [ToolCalls](../../aspose.pdf.ai/chatmessageresponse/toolcalls/) { get; set; } | Obtiene o establece las llamadas a herramientas generadas por el modelo, como llamadas a funciones. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/_index.md
@@ -1,0 +1,44 @@
+---
+title: "ChatMessageResponse.ChatMessageResponse"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor ChatMessageResponse. Inicializa una nueva instancia de la clase ChatMessageResponse."
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/chatmessageresponse/chatmessageresponse/
+---
+## ChatMessageResponse() {#constructor}
+
+Inicializa una nueva instancia de la clase [`ChatMessageResponse`](../).
+
+```csharp
+public ChatMessageResponse()
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## ChatMessageResponse(string, string) {#constructor_1}
+
+Inicializa una nueva instancia de la clase [`ChatMessageResponse`](../).
+
+```csharp
+public ChatMessageResponse(string role, string content)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| rol | Cadena | El rol del autor de este mensaje. |
+| contenido | Cadena | El contenido del mensaje. |
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/content/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/content/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Content"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece el contenido del mensaje."
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.ai/chatmessageresponse/content/
+---
+## ChatMessageResponse.Content property
+
+Obtiene o establece el contenido del mensaje.
+
+```csharp
+public string Content { get; set; }
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/id/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/id/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Id"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece el ID del mensaje."
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/chatmessageresponse/id/
+---
+## ChatMessageResponse.Id property
+
+Obtiene o establece el ID del mensaje.
+
+```csharp
+public string Id { get; set; }
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/name/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/name/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Name"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece un nombre opcional para el participante. Proporciona información del modelo para diferenciar entre participantes del mismo rol."
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.ai/chatmessageresponse/name/
+---
+## ChatMessageResponse.Name property
+
+Obtiene o establece un nombre opcional para el participante. Proporciona al modelo información para diferenciar entre participantes del mismo rol.
+
+```csharp
+public string Name { get; set; }
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/refusal/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/refusal/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Refusal"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece el mensaje de rechazo generado por el modelo."
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/chatmessageresponse/refusal/
+---
+## ChatMessageResponse.Refusal property
+
+Obtiene o establece el mensaje de rechazo generado por el modelo.
+
+```csharp
+public string Refusal { get; set; }
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/role/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/role/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ChatMessageResponse.Role"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece el rol del autor del mensaje."
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.ai/chatmessageresponse/role/
+---
+## ChatMessageResponse.Role property
+
+Obtiene o establece el rol del autor del mensaje.
+
+```csharp
+public string Role { get; set; }
+```
+
+### Ver también
+
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/chatmessageresponse/toolcalls/_index.md
+++ b/spanish/net/aspose.pdf.ai/chatmessageresponse/toolcalls/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ChatMessageResponse.ToolCalls"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ChatMessageResponse. Obtiene o establece las llamadas a herramientas generadas por el modelo, como llamadas a funciones."
+type: docs
+weight: 70
+url: /es/net/aspose.pdf.ai/chatmessageresponse/toolcalls/
+---
+## ChatMessageResponse.ToolCalls property
+
+Obtiene o establece las llamadas a herramientas generadas por el modelo, como llamadas a funciones.
+
+```csharp
+public List<ToolCall> ToolCalls { get; set; }
+```
+
+### Ver también
+
+* class [ToolCall](../../toolcall/)
+* class [ChatMessageResponse](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/_index.md
+++ b/spanish/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "CompletionCreateRequest.MaxCompletionTokens"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad CompletionCreateRequest. Obtiene o establece el número máximo de tokens a generar en la finalización"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/completioncreaterequest/maxcompletiontokens/
+---
+## CompletionCreateRequest.MaxCompletionTokens property
+
+Obtiene o establece el número máximo de tokens a generar en la finalización.
+
+```csharp
+public int? MaxCompletionTokens { get; set; }
+```
+
+### Ver también
+
+* class [CompletionCreateRequest](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/detail/_index.md
+++ b/spanish/net/aspose.pdf.ai/detail/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Enum Detalle"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.Detail enum. Especifica el nivel de detalle para el análisis de imágenes"
+type: docs
+weight: 330
+url: /es/net/aspose.pdf.ai/detail/
+---
+## Detail enumeration
+
+Especifica el nivel de detalle para el análisis de imágenes.
+
+```csharp
+public enum Detail
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| Auto | `0` | El nivel de detalle se determina automáticamente por la API en función de la entrada y el contexto. |
+| Low | `1` | Nivel de detalle bajo, que proporciona un análisis más general y rápido. |
+| High | `2` | Nivel de detalle alto, que ofrece un análisis más exhaustivo y preciso. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrclient-1/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrclient-1/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Interfaz IOcrClientTOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.IOcrClient1TOptions interface. Representa una interfaz para un cliente OCR con opciones específicas"
+type: docs
+weight: 560
+url: /es/net/aspose.pdf.ai/iocrclient-1/
+---
+## IOcrClient&lt;TOptions&gt; interface
+
+Representa una interfaz para un cliente OCR con opciones específicas.
+
+```csharp
+public interface IOcrClient<in TOptions> : IAIClient
+```
+
+| Parámetro | Descripción |
+| --- | --- |
+| TOptions | El tipo de opciones para el cliente OCR. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [GetOcrCopilot](../../aspose.pdf.ai/iocrclient-1/getocrcopilot/)(IOcrCopilotOptions&lt;TOptions&gt;) | Obtiene una instancia de [`IOcrCopilot`](../iocrcopilot/) con las opciones especificadas. |
+
+### Ver también
+
+* interface [IAIClient](../iaiclient/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IOcrClient1.GetOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método IOcrClient. Obtiene una instancia de IOcrCopilot con las opciones especificadas"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/iocrclient-1/getocrcopilot/
+---
+## IOcrClient&lt;TOptions&gt;.GetOcrCopilot method
+
+Obtiene una instancia de [`IOcrCopilot`](../../iocrcopilot/) con las opciones especificadas.
+
+```csharp
+public IOcrCopilot GetOcrCopilot(IOcrCopilotOptions<TOptions> options)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| opciones | IOcrCopilotOptions`1 | Las opciones para el copiloto OCR. |
+
+### Valor devuelto
+
+Una instancia de [`IOcrCopilot`](../../iocrcopilot/).
+
+### Ver también
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* interface [IOcrClient&lt;TOptions&gt;](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrcopilot/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Interfaz IOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Interfaz Aspose.Pdf.AI.IOcrCopilot. Representa un copiloto OCR para procesar PDFs escaneados e imágenes mediante modelos de IA"
+type: docs
+weight: 570
+url: /es/net/aspose.pdf.ai/iocrcopilot/
+---
+## IOcrCopilot interface
+
+Representa un copiloto OCR para procesar PDFs escaneados e imágenes mediante modelos de IA.
+
+```csharp
+public interface IOcrCopilot : IAICopilot
+```
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [GetTextRecognitionResultAsync](../../aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/)(CancellationToken?) | Recupera de forma asíncrona los resultados de reconocimiento de texto para los documentos PDF y archivos de imagen. Los tipos de imagen compatibles: PNG (.png), JPEG (.jpeg y .jpg), WEBP (.webp), GIF no animado (.gif). |
+
+### Ver también
+
+* interface [IAICopilot](../iaicopilot/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IOcrCopilot.GetTextRecognitionResultAsync"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "IOcrCopilot método. Recupera de forma asíncrona los resultados de reconocimiento de texto para los documentos PDF y archivos de imagen. Los tipos de imagen compatibles son PNG .png JPEG .jpeg y .jpg WEBP .webp GIF no animado .gif"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/iocrcopilot/gettextrecognitionresultasync/
+---
+## IOcrCopilot.GetTextRecognitionResultAsync method
+
+Recupera de forma asíncrona los resultados de reconocimiento de texto para los documentos PDF y archivos de imagen. Los tipos de imagen compatibles: PNG (.png), JPEG (.jpeg y .jpg), WEBP (.webp), GIF no animado (.gif).
+
+```csharp
+public Task<List<TextRecognitionResult>> GetTextRecognitionResultAsync(
+    CancellationToken? cancellationToken = default)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| cancellationToken | Nullable`1 | Un token de cancelación opcional para cancelar la operación. |
+
+### Valor devuelto
+
+Una tarea que representa la operación asíncrona. El resultado de la tarea contiene una lista de [`TextRecognitionResult`](../../textrecognitionresult/).
+
+### Ver también
+
+* class [TextRecognitionResult](../../textrecognitionresult/)
+* interface [IOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrcopilotoptions-1/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrcopilotoptions-1/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Interfaz IOcrCopilotOptionsTOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.IOcrCopilotOptions1TOptions interface. Representa una interfaz para opciones de copiloto de chat con un tipo específico"
+type: docs
+weight: 580
+url: /es/net/aspose.pdf.ai/iocrcopilotoptions-1/
+---
+## IOcrCopilotOptions&lt;TOptions&gt; interface
+
+Representa una interfaz para opciones de copiloto de chat con un tipo específico.
+
+```csharp
+public interface IOcrCopilotOptions<out TOptions>
+```
+
+| Parámetro | Descripción |
+| --- | --- |
+| TOptions | El tipo de opciones para el copiloto de chat. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [GetOptions](../../aspose.pdf.ai/iocrcopilotoptions-1/getoptions/)() | Obtiene las opciones del tipo *TOptions*. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/_index.md
+++ b/spanish/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IOcrCopilotOptions1.GetOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método IOcrCopilotOptions. Obtiene las opciones del tipo TOptions"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/iocrcopilotoptions-1/getoptions/
+---
+## IOcrCopilotOptions&lt;TOptions&gt;.GetOptions method
+
+Obtiene las opciones del tipo *TOptions*.
+
+```csharp
+public TOptions GetOptions()
+```
+
+### Valor devuelto
+
+Las opciones del tipo *TOptions*.
+
+### Ver también
+
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Clase OcrDetail"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.OcrDetail class. Representa el resultado OCR para una sola página de un documento o un solo archivo de imagen"
+type: docs
+weight: 860
+url: /es/net/aspose.pdf.ai/ocrdetail/
+---
+## OcrDetail class
+
+Representa el resultado OCR para una sola página de un documento o un solo archivo de imagen.
+
+```csharp
+public class OcrDetail : IComparable<OcrDetail>
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [OcrDetail](ocrdetail/)() | El constructor predeterminado. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [ErrorMessage](../../aspose.pdf.ai/ocrdetail/errormessage/) { get; set; } | Un mensaje de error que describe por qué OCR falló en esta página, si Success es false. Null de lo contrario. |
+| [ExtractedText](../../aspose.pdf.ai/ocrdetail/extractedtext/) { get; set; } | El contenido de texto extraído de la página. Null si Success es false o no se encontró texto. |
+| [PageNumber](../../aspose.pdf.ai/ocrdetail/pagenumber/) { get; set; } | El número de página basado en 1 dentro del documento fuente. Para imágenes de una sola página, siempre será 1. |
+| [Success](../../aspose.pdf.ai/ocrdetail/success/) { get; set; } | Indica si la extracción OCR para esta página específica fue exitosa. |
+| [Usage](../../aspose.pdf.ai/ocrdetail/usage/) { get; set; } | Obtiene o establece las estadísticas de uso. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [CompareTo](../../aspose.pdf.ai/ocrdetail/compareto/)(OcrDetail) | Compara la instancia actual de OcrDetail con otro objeto OcrDetail basado en su propiedad PageNumber. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/compareto/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/compareto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.CompareTo"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OcrDetail. Compara la instancia actual de OcrDetail con otro objeto OcrDetail basado en su propiedad PageNumber"
+type: docs
+weight: 70
+url: /es/net/aspose.pdf.ai/ocrdetail/compareto/
+---
+## OcrDetail.CompareTo method
+
+Compara la instancia actual de OcrDetail con otro objeto OcrDetail basado en su propiedad PageNumber.
+
+```csharp
+public int CompareTo(OcrDetail other)
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/errormessage/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/errormessage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.ErrorMessage"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OcrDetail. Un mensaje de error que describe por qué OCR falló en esta página si Success es false. Null de lo contrario"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.ai/ocrdetail/errormessage/
+---
+## OcrDetail.ErrorMessage property
+
+Un mensaje de error que describe por qué OCR falló en esta página, si Success es false. Null de lo contrario.
+
+```csharp
+public string ErrorMessage { get; set; }
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/extractedtext/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/extractedtext/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.ExtractedText"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OcrDetail. El contenido de texto extraído de la página. Null si Success es false o no se encontró texto"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/ocrdetail/extractedtext/
+---
+## OcrDetail.ExtractedText property
+
+El contenido de texto extraído de la página. Null si Success es false o no se encontró texto.
+
+```csharp
+public string ExtractedText { get; set; }
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/ocrdetail/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/ocrdetail/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.OcrDetail"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor OcrDetail. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/ocrdetail/ocrdetail/
+---
+## OcrDetail constructor
+
+El constructor predeterminado.
+
+```csharp
+public OcrDetail()
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/pagenumber/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/pagenumber/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.PageNumber"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OcrDetail. El número de página basado en 1 dentro del documento fuente. Para imágenes de una sola página siempre será 1"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.ai/ocrdetail/pagenumber/
+---
+## OcrDetail.PageNumber property
+
+El número de página basado en 1 dentro del documento fuente. Para imágenes de una sola página, siempre será 1.
+
+```csharp
+public int PageNumber { get; set; }
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/success/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/success/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OcrDetail.Success"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OcrDetail. Indica si la extracción OCR para esta página específica fue exitosa"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/ocrdetail/success/
+---
+## OcrDetail.Success property
+
+Indica si la extracción OCR para esta página específica fue exitosa.
+
+```csharp
+public bool Success { get; set; }
+```
+
+### Ver también
+
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/ocrdetail/usage/_index.md
+++ b/spanish/net/aspose.pdf.ai/ocrdetail/usage/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OcrDetail.Usage"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OcrDetail. Obtiene o establece las estadísticas de uso"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.ai/ocrdetail/usage/
+---
+## OcrDetail.Usage property
+
+Obtiene o establece las estadísticas de uso.
+
+```csharp
+public Usage Usage { get; set; }
+```
+
+### Ver también
+
+* class [Usage](../../usage/)
+* class [OcrDetail](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIChatCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OpenAIChatCopilotOptions. Obtiene o establece el número máximo de tokens de solicitud que pueden usarse durante la ejecución."
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.ai/openaichatcopilotoptions/maxprompttokens/
+---
+## OpenAIChatCopilotOptions.MaxPromptTokens property
+
+Obtiene o establece el número máximo de tokens de solicitud que pueden usarse a lo largo de la ejecución.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Ver también
+
+* class [OpenAIChatCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiclient/getocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiclient/getocrcopilot/_index.md
@@ -1,0 +1,34 @@
+---
+title: "OpenAIClient.GetOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIClient. Obtiene una instancia de IOcrCopilot con las opciones especificadas"
+type: docs
+weight: 250
+url: /es/net/aspose.pdf.ai/openaiclient/getocrcopilot/
+---
+## OpenAIClient.GetOcrCopilot method
+
+Obtiene una instancia de [`IOcrCopilot`](../../iocrcopilot/) con las opciones especificadas.
+
+```csharp
+public IOcrCopilot GetOcrCopilot(IOcrCopilotOptions<OpenAIOcrCopilotOptions> options)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| opciones | IOcrCopilotOptions`1 | Las opciones para el copiloto OCR. |
+
+### Valor devuelto
+
+Una instancia de [`IOcrCopilot`](../../iocrcopilot/).
+
+### Ver también
+
+* interface [IOcrCopilot](../../iocrcopilot/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [OpenAIOcrCopilotOptions](../../openaiocrcopilotoptions/)
+* class [OpenAIClient](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIImageDescriptionCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIImageDescriptionCopilotOptions propiedad. Obtiene o establece el número máximo de tokens de solicitud que pueden usarse durante la ejecución"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/openaiimagedescriptioncopilotoptions/maxprompttokens/
+---
+## OpenAIImageDescriptionCopilotOptions.MaxPromptTokens property
+
+Obtiene o establece el número máximo de tokens de solicitud que pueden usarse a lo largo de la ejecución.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Ver también
+
+* class [OpenAIImageDescriptionCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaimodels/gpt4omini/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaimodels/gpt4omini/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIModels.Gpt4OMini"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIModels propiedad. Obtiene el identificador del modelo GPT4omini"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.ai/openaimodels/gpt4omini/
+---
+## OpenAIModels.Gpt4OMini property
+
+Obtiene el identificador del modelo GPT-4o-mini.
+
+```csharp
+public static string Gpt4OMini { get; }
+```
+
+### Ver también
+
+* class [OpenAIModels](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilot/_index.md
@@ -1,0 +1,64 @@
+---
+title: "Clase OpenAIOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.OpenAIOcrCopilot class. Proporciona capacidades OCR para extraer texto de documentos PDF e imágenes. Los tipos de imagen compatibles PNG .png JPEG .jpeg y .jpg WEBP .webp GIF no animado .gif. Ejemplo de uso creando un cliente OpenAI, configurando opciones y usando el copilot OCR"
+type: docs
+weight: 980
+url: /es/net/aspose.pdf.ai/openaiocrcopilot/
+---
+## OpenAIOcrCopilot class
+
+Proporciona capacidades OCR para extraer texto de documentos PDF e imágenes. Los tipos de imagen compatibles: PNG (.png), JPEG (.jpeg y .jpg), WEBP (.webp), GIF no animado (.gif). Ejemplo de uso creando un cliente OpenAI, configurando opciones y usando el copilot OCR.
+
+```csharp
+// Crear cliente de IA.
+var openAiClient = OpenAIClient
+    .CreateWithApiKey(ApiKey) // Create OpenAI client with the API key.
+    //.WithOrganization("org_123") // Configura parámetros opcionales.
+    .Build(); // Build
+
+// Crear opciones del copilot.
+var options = OpenAIOcrCopilotOptions
+    .Create() // Create options like this, or...
+    //.Create(options => { options.Model = OpenAIModels.Gpt4O; }) // ...crea usando delegado.
+    .WithDocument("DocumentInputPath"); // .WithDocument methods allows to add Document objects and paths to PDF documents and images.
+
+// Crear copilot de resumen.
+IOcrCopilot ocrCopilot = AICopilotFactory.CreateOcrCopilot(openAiClient, options);
+
+// Obtener reconocimientos de texto.
+List<TextRecognitionResult> textRecognitions = await ocrCopilot.GetTextRecognitionResultAsync();
+
+// Acceso al texto extraído.
+string text = textRecognitions[0].OcrDetails[0].ExtractedText;
+```
+
+```csharp
+public class OpenAIOcrCopilot : IOcrCopilot
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [OpenAIOcrCopilot](openaiocrcopilot/)(IOpenAIClient, IOcrCopilotOptions&lt;OpenAIOcrCopilotOptions&gt;) | Inicializa una nueva instancia de la clase `OpenAIOcrCopilot`. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [HasContext](../../aspose.pdf.ai/openaiocrcopilot/hascontext/) { get; } |  |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [GetTextRecognitionResultAsync](../../aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/)(CancellationToken?) |  |
+
+### Ver también
+
+* interface [IOcrCopilot](../iocrcopilot/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilot.GetTextRecognitionResultAsync"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilot."
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/openaiocrcopilot/gettextrecognitionresultasync/
+---
+## OpenAIOcrCopilot.GetTextRecognitionResultAsync method
+
+```csharp
+public Task<List<TextRecognitionResult>> GetTextRecognitionResultAsync(
+    CancellationToken? cancellationToken = default)
+```
+
+### Ver también
+
+* class [TextRecognitionResult](../../textrecognitionresult/)
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilot/hascontext/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilot/hascontext/_index.md
@@ -1,0 +1,21 @@
+---
+title: "OpenAIOcrCopilot.HasContext"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OpenAIOcrCopilot."
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.ai/openaiocrcopilot/hascontext/
+---
+## OpenAIOcrCopilot.HasContext property
+
+```csharp
+public bool HasContext { get; }
+```
+
+### Ver también
+
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilot.OpenAIOcrCopilot"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor OpenAIOcrCopilot. Inicializa una nueva instancia de la clase OpenAIOcrCopilot."
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/openaiocrcopilot/openaiocrcopilot/
+---
+## OpenAIOcrCopilot constructor
+
+Inicializa una nueva instancia de la clase [`OpenAIOcrCopilot`](../).
+
+```csharp
+public OpenAIOcrCopilot(IOpenAIClient client, IOcrCopilotOptions<OpenAIOcrCopilotOptions> options)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| client | IOpenAIClient | El cliente OpenAI utilizado para operaciones de OCR. |
+| opciones | IOcrCopilotOptions`1 | Las opciones utilizadas para configurar el copiloto OCR. |
+
+### Ver también
+
+* interface [IOpenAIClient](../../iopenaiclient/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../../iocrcopilotoptions-1/)
+* class [OpenAIOcrCopilotOptions](../../openaiocrcopilotoptions/)
+* class [OpenAIOcrCopilot](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Clase OpenAIOcrCopilotOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Aspose.Pdf.AI.OpenAIOcrCopilotOptions class. Representa las opciones para configurar el OpenAIOcrCopilot"
+type: docs
+weight: 990
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/
+---
+## OpenAIOcrCopilotOptions class
+
+Representa las opciones para configurar el OpenAIOcrCopilot.
+
+```csharp
+public class OpenAIOcrCopilotOptions : OpenAIAssistantCopilotOptionsBase, 
+    IOcrCopilotOptions<OpenAIOcrCopilotOptions>
+```
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [Detail](../../aspose.pdf.ai/openaiocrcopilotoptions/detail/) { get; set; } | Obtiene o establece el nivel de detalle para el análisis de imágenes. |
+| [DocumentCollection](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/documentcollection/) { get; set; } | Obtiene o establece la colección de documentos a procesar. |
+| [MaxCompletionTokens](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/maxcompletiontokens/) { get; set; } | Obtiene o establece el número máximo de tokens de finalización que pueden usarse durante la ejecución. |
+| [Model](../../aspose.pdf.ai/openaicopilotoptionsbase/model/) { get; set; } | Obtiene o establece el modelo a usar para el asistente. |
+| [Resolution](../../aspose.pdf.ai/openaiocrcopilotoptions/resolution/) { get; set; } | Obtiene o establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi. |
+| [SystemInstructions](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/systeminstructions/) { get; set; } | Obtiene o establece la ruta del archivo de texto que contiene las instrucciones del sistema del asistente. |
+| [Temperature](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/temperature/) { get; set; } | Obtiene o establece la temperatura de muestreo a usar para el modelo. |
+| [TopP](../../aspose.pdf.ai/openaiassistantcopilotoptionsbase/topp/) { get; set; } | Obtiene o establece el valor top-p para el muestreo de núcleo. |
+| [UserInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/) { get; set; } | Obtiene o establece la solicitud del usuario. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| static [Create](../../aspose.pdf.ai/openaiocrcopilotoptions/create/#create)() | Crea una nueva instancia de `OpenAIOcrCopilotOptions`. |
+| static [Create](../../aspose.pdf.ai/openaiocrcopilotoptions/create/#create_1)(Action&lt;OpenAIOcrCopilotOptions&gt;) | Crea una instancia de `OpenAIOcrCopilotOptions` y la configura usando el delegado proporcionado. |
+| [GetOptions](../../aspose.pdf.ai/openaiocrcopilotoptions/getoptions/)() | Obtiene el `OpenAIOcrCopilotOptions` actual. |
+| [WithDetail](../../aspose.pdf.ai/openaiocrcopilotoptions/withdetail/)(Detail) | Establece el nivel de detalle para el análisis de imágenes. |
+| [WithDocument](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocument/#withdocument)(PdfDocument) | Agrega un documento PDF a la colección de documentos. |
+| [WithDocument](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocument/#withdocument_1)(string) | Agrega una ruta de documento a la colección de documentos. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments)(DocumentCollection) | Establece la colección de documentos. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments_1)(List&lt;PdfDocument&gt;) | Agrega varios documentos PDF a la colección de documentos. |
+| [WithDocuments](../../aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/#withdocuments_2)(List&lt;string&gt;) | Agrega varias rutas de documentos a la colección de documentos. |
+| [WithMaxCompletionTokens](../../aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/)(int?) | Establece el número máximo de tokens de finalización. |
+| [WithModel](../../aspose.pdf.ai/openaiocrcopilotoptions/withmodel/)(string) | Establece el modelo. |
+| [WithResolution](../../aspose.pdf.ai/openaiocrcopilotoptions/withresolution/)(int) | Establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi. |
+| [WithSystemInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/)(string) | Establece las instrucciones para las opciones del copilot OCR. |
+| [WithTemperature](../../aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/)(double?) | Establece la temperatura. |
+| [WithTopP](../../aspose.pdf.ai/openaiocrcopilotoptions/withtopp/)(double?) | Establece el valor top P. |
+| [WithUserInstructions](../../aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/)(string) | Establece el mensaje del usuario. |
+
+### Ver también
+
+* class [OpenAIAssistantCopilotOptionsBase](../openaiassistantcopilotoptionsbase/)
+* interface [IOcrCopilotOptions&lt;TOptions&gt;](../iocrcopilotoptions-1/)
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/create/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/create/_index.md
@@ -1,0 +1,51 @@
+---
+title: "OpenAIOcrCopilotOptions.Create"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions método. Crea una nueva instancia de OpenAIOcrCopilotOptions"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/create/
+---
+## Create() {#create}
+
+Crea una nueva instancia de [`OpenAIOcrCopilotOptions`](../).
+
+```csharp
+public static OpenAIOcrCopilotOptions Create()
+```
+
+### Valor devuelto
+
+Una nueva instancia de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## Create(Action&lt;OpenAIOcrCopilotOptions&gt;) {#create_1}
+
+Crea una instancia de [`OpenAIOcrCopilotOptions`](../) y la configura usando el delegado proporcionado.
+
+```csharp
+public static OpenAIOcrCopilotOptions Create(Action<OpenAIOcrCopilotOptions> config)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| config | Action`1 | El delegado para configurar las opciones. |
+
+### Valor devuelto
+
+La instancia configurada de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OpenAIOcrCopilotOptions.Detail"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions propiedad. Obtiene o establece el nivel de detalle para el análisis de imágenes"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/detail/
+---
+## OpenAIOcrCopilotOptions.Detail property
+
+Obtiene o establece el nivel de detalle para el análisis de imágenes.
+
+```csharp
+public Detail Detail { get; set; }
+```
+
+### Ver también
+
+* enum [Detail](../../detail/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "OpenAIOcrCopilotOptions.GetOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Obtiene el OpenAIOcrCopilotOptions actual"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/getoptions/
+---
+## OpenAIOcrCopilotOptions.GetOptions method
+
+Obtiene el [`OpenAIOcrCopilotOptions`](../) actual.
+
+```csharp
+public OpenAIOcrCopilotOptions GetOptions()
+```
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilotOptions.Resolution"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions propiedad. Obtiene o establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/resolution/
+---
+## OpenAIOcrCopilotOptions.Resolution property
+
+Obtiene o establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi.
+
+```csharp
+public int Resolution { get; set; }
+```
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAIOcrCopilotOptions.UserInstructions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions propiedad. Obtiene o establece la solicitud del usuario"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/userinstructions/
+---
+## OpenAIOcrCopilotOptions.UserInstructions property
+
+Obtiene o establece la solicitud del usuario.
+
+```csharp
+public string UserInstructions { get; set; }
+```
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/_index.md
@@ -1,0 +1,32 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDetail"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece el nivel de detalle para el análisis de imágenes"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withdetail/
+---
+## OpenAIOcrCopilotOptions.WithDetail method
+
+Establece el nivel de detalle para el análisis de imágenes.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDetail(Detail detail)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| detalle | Detalle | El nivel de detalle. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* enum [Detail](../../detail/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/_index.md
@@ -1,0 +1,56 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDocument"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Añade un documento PDF a la colección de documentos"
+type: docs
+weight: 70
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocument/
+---
+## WithDocument(PdfDocument) {#withdocument}
+
+Agrega un documento PDF a la colección de documentos.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocument(PdfDocument pdfDocument)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pdfDocument | PdfDocument | El documento PDF a agregar. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [PdfDocument](../../pdfdocument/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocument(string) {#withdocument_1}
+
+Agrega una ruta de documento a la colección de documentos.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocument(string filePath)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePath | Cadena | La ruta del archivo del documento a agregar. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/_index.md
@@ -1,0 +1,81 @@
+---
+title: "OpenAIOcrCopilotOptions.WithDocuments"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece la colección de documentos"
+type: docs
+weight: 80
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withdocuments/
+---
+## WithDocuments(DocumentCollection) {#withdocuments}
+
+Establece la colección de documentos.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(DocumentCollection documentCollection)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| documentCollection | DocumentCollection | La colección de documentos a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [DocumentCollection](../../documentcollection/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocuments(List&lt;PdfDocument&gt;) {#withdocuments_1}
+
+Agrega varios documentos PDF a la colección de documentos.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(List<PdfDocument> pdfDocuments)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pdfDocuments | List`1 | La lista de documentos PDF a agregar. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [PdfDocument](../../pdfdocument/)
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## WithDocuments(List&lt;string&gt;) {#withdocuments_2}
+
+Agrega varias rutas de documentos a la colección de documentos.
+
+```csharp
+public OpenAIOcrCopilotOptions WithDocuments(List<string> filePaths)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePaths | List`1 | La lista de rutas de archivo a agregar. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithMaxCompletionTokens"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece los tokens máximos de finalización"
+type: docs
+weight: 90
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withmaxcompletiontokens/
+---
+## OpenAIOcrCopilotOptions.WithMaxCompletionTokens method
+
+Establece el número máximo de tokens de finalización.
+
+```csharp
+public OpenAIOcrCopilotOptions WithMaxCompletionTokens(int? maxCompletionTokens)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| maxCompletionTokens | Nullable`1 | Los tokens máximos de finalización a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithModel"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions método. Establece el modelo"
+type: docs
+weight: 100
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withmodel/
+---
+## OpenAIOcrCopilotOptions.WithModel method
+
+Establece el modelo.
+
+```csharp
+public OpenAIOcrCopilotOptions WithModel(string model)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| modelo | Cadena | El modelo a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithResolution"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi"
+type: docs
+weight: 110
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withresolution/
+---
+## OpenAIOcrCopilotOptions.WithResolution method
+
+Establece la resolución utilizada para convertir páginas PDF en imágenes. El valor predeterminado es 300 dpi.
+
+```csharp
+public OpenAIOcrCopilotOptions WithResolution(int resolution)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| resolution | Int32 | La resolución en dpi. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithSystemInstructions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "OpenAIOcrCopilotOptions método. Establece las instrucciones para las opciones del copilot ocr"
+type: docs
+weight: 120
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withsysteminstructions/
+---
+## OpenAIOcrCopilotOptions.WithSystemInstructions method
+
+Establece las instrucciones para las opciones del copilot OCR.
+
+```csharp
+public OpenAIOcrCopilotOptions WithSystemInstructions(string text)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| texto | Cadena | Las instrucciones a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithTemperature"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece la temperatura"
+type: docs
+weight: 130
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withtemperature/
+---
+## OpenAIOcrCopilotOptions.WithTemperature method
+
+Establece la temperatura.
+
+```csharp
+public OpenAIOcrCopilotOptions WithTemperature(double? temperature)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| temperatura | Nullable`1 | La temperatura a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithTopP"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece el valor top P"
+type: docs
+weight: 140
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withtopp/
+---
+## OpenAIOcrCopilotOptions.WithTopP method
+
+Establece el valor top P.
+
+```csharp
+public OpenAIOcrCopilotOptions WithTopP(double? topP)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| topP | Nullable`1 | El valor top P a establecer. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "OpenAIOcrCopilotOptions.WithUserInstructions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método OpenAIOcrCopilotOptions. Establece el mensaje del usuario"
+type: docs
+weight: 150
+url: /es/net/aspose.pdf.ai/openaiocrcopilotoptions/withuserinstructions/
+---
+## OpenAIOcrCopilotOptions.WithUserInstructions method
+
+Establece el mensaje del usuario.
+
+```csharp
+public OpenAIOcrCopilotOptions WithUserInstructions(string text)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| texto | Cadena | El texto del mensaje. |
+
+### Valor devuelto
+
+La instancia actual de [`OpenAIOcrCopilotOptions`](../).
+
+### Ver también
+
+* class [OpenAIOcrCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/_index.md
+++ b/spanish/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OpenAISummaryCopilotOptions.MaxPromptTokens"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OpenAISummaryCopilotOptions. Obtiene o establece el número máximo de tokens de solicitud que pueden usarse a lo largo de la ejecución."
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/openaisummarycopilotoptions/maxprompttokens/
+---
+## OpenAISummaryCopilotOptions.MaxPromptTokens property
+
+Obtiene o establece el número máximo de tokens de solicitud que pueden usarse a lo largo de la ejecución.
+
+```csharp
+public int? MaxPromptTokens { get; set; }
+```
+
+### Ver también
+
+* class [OpenAISummaryCopilotOptions](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/_index.md
@@ -1,0 +1,38 @@
+---
+title: "Clase TextRecognitionResult"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.AI.TextRecognitionResult. Representa los resultados OCR agregados para un único documento fuente"
+type: docs
+weight: 1180
+url: /es/net/aspose.pdf.ai/textrecognitionresult/
+---
+## TextRecognitionResult class
+
+Representa los resultados OCR agregados para un único documento fuente.
+
+```csharp
+public class TextRecognitionResult
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [TextRecognitionResult](textrecognitionresult/)() | El constructor predeterminado. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [OcrDetails](../../aspose.pdf.ai/textrecognitionresult/ocrdetails/) { get; set; } | Una lista que contiene los resultados OCR detallados para cada página del documento. Para archivos de una sola imagen, esta lista normalmente contendrá una entrada OcrDetail con PageNumber = 1. |
+| [OverallSuccess](../../aspose.pdf.ai/textrecognitionresult/overallsuccess/) { get; set; } | Indica si OCR fue exitoso para TODAS las páginas de este documento. False si algún OcrDetail en OcrDetails tiene Success = false. |
+| [SourceIdentifier](../../aspose.pdf.ai/textrecognitionresult/sourceidentifier/) { get; set; } | Identificador del archivo fuente (p. ej., la ruta completa o un nombre único). |
+| [SummaryErrorMessage](../../aspose.pdf.ai/textrecognitionresult/summaryerrormessage/) { get; set; } | Un mensaje de error consolidado si OverallSuccess es false, o un resumen si alguna página falló. Null si OverallSuccess es true. |
+| [TotalUsage](../../aspose.pdf.ai/textrecognitionresult/totalusage/) { get; set; } | Obtiene o establece las estadísticas totales de uso para procesar este documento (todas las páginas). |
+
+### Ver también
+
+* namespace [Aspose.Pdf.AI](../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextRecognitionResult.OcrDetails"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult propiedad. Una lista que contiene los resultados detallados de OCR para cada página del documento. Para archivos de una sola imagen, esta lista normalmente contendrá una entrada OcrDetail con PageNumber 1"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.ai/textrecognitionresult/ocrdetails/
+---
+## TextRecognitionResult.OcrDetails property
+
+Una lista que contiene los resultados OCR detallados para cada página del documento. Para archivos de una sola imagen, esta lista normalmente contendrá una entrada OcrDetail con PageNumber = 1.
+
+```csharp
+public List<OcrDetail> OcrDetails { get; set; }
+```
+
+### Ver también
+
+* class [OcrDetail](../../ocrdetail/)
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.OverallSuccess"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult propiedad. Indica si OCR fue exitoso para TODAS las páginas dentro de este documento. False si cualquier OcrDetail en OcrDetails tiene Success false"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.ai/textrecognitionresult/overallsuccess/
+---
+## TextRecognitionResult.OverallSuccess property
+
+Indica si OCR fue exitoso para TODAS las páginas de este documento. False si algún OcrDetail en OcrDetails tiene Success = false.
+
+```csharp
+public bool OverallSuccess { get; set; }
+```
+
+### Ver también
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.SourceIdentifier"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult propiedad. Identificador del archivo de origen, p. ej. la ruta completa o un nombre único"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.ai/textrecognitionresult/sourceidentifier/
+---
+## TextRecognitionResult.SourceIdentifier property
+
+Identificador del archivo fuente (p. ej., la ruta completa o un nombre único).
+
+```csharp
+public string SourceIdentifier { get; set; }
+```
+
+### Ver también
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.SummaryErrorMessage"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult propiedad. Un mensaje de error consolidado si OverallSuccess es false o un resumen si alguna página falló. Null si OverallSuccess es true"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.ai/textrecognitionresult/summaryerrormessage/
+---
+## TextRecognitionResult.SummaryErrorMessage property
+
+Un mensaje de error consolidado si OverallSuccess es false, o un resumen si alguna página falló. Null si OverallSuccess es true.
+
+```csharp
+public string SummaryErrorMessage { get; set; }
+```
+
+### Ver también
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/_index.md
@@ -1,0 +1,23 @@
+---
+title: "TextRecognitionResult.TextRecognitionResult"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult constructor. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.ai/textrecognitionresult/textrecognitionresult/
+---
+## TextRecognitionResult constructor
+
+El constructor predeterminado.
+
+```csharp
+public TextRecognitionResult()
+```
+
+### Ver también
+
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.ai/textrecognitionresult/totalusage/_index.md
+++ b/spanish/net/aspose.pdf.ai/textrecognitionresult/totalusage/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextRecognitionResult.TotalUsage"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "TextRecognitionResult propiedad. Obtiene o establece las estadísticas de uso total para procesar este documento en todas sus páginas"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.ai/textrecognitionresult/totalusage/
+---
+## TextRecognitionResult.TotalUsage property
+
+Obtiene o establece las estadísticas totales de uso para procesar este documento (todas las páginas).
+
+```csharp
+public Usage TotalUsage { get; set; }
+```
+
+### Ver también
+
+* class [Usage](../../usage/)
+* class [TextRecognitionResult](../)
+* namespace [Aspose.Pdf.AI](../../../aspose.pdf.ai/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.annotations/freetextannotation/settextstyle/_index.md
+++ b/spanish/net/aspose.pdf.annotations/freetextannotation/settextstyle/_index.md
@@ -1,0 +1,55 @@
+---
+title: "FreeTextAnnotation.SetTextStyle"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método FreeTextAnnotation. Establece el formato determinado por el parámetro textStyle para todo el texto de la anotación"
+type: docs
+weight: 150
+url: /es/net/aspose.pdf.annotations/freetextannotation/settextstyle/
+---
+## SetTextStyle(RichTextFontStyles, string, double, Color) {#settextstyle}
+
+Establece el formato determinado por el parámetro textStyle para todo el texto de la anotación.
+
+```csharp
+public void SetTextStyle(RichTextFontStyles textStyles, string fontName, double fontSize, 
+    Color fontColor)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| textStyles | RichTextFontStyles | Estilo(s) aplicado(s) al texto de la anotación. |
+| fontName | Cadena | Nombre de fuente aplicado al texto de la anotación. |
+| fontSize | Double | Tamaño de fuente aplicado al texto de la anotación. |
+| fontColor | Color | Color de fuente aplicado al texto de la anotación. |
+
+### Ver también
+
+* enum [RichTextFontStyles](../../richtextfontstyles/)
+* class [FreeTextAnnotation](../)
+* namespace [Aspose.Pdf.Annotations](../../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## SetTextStyle(int, int, RichTextFontStyles) {#settextstyle_1}
+
+Establece el formato determinado por el parámetro textStyle para un fragmento de texto desde el índice fromInd hasta el índice toInd.
+
+```csharp
+public void SetTextStyle(int fromInd, int toInd, RichTextFontStyles textStyles)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fromInd | Int32 | Índice inicial del fragmento de texto (desde 0). |
+| toInd | Int32 | Índice final del fragmento de texto (contando desde 0, este no está incluido). |
+| textStyles | RichTextFontStyles | Estilo(s) aplicado(s) al fragmento de texto. |
+
+### Ver también
+
+* enum [RichTextFontStyles](../../richtextfontstyles/)
+* class [FreeTextAnnotation](../)
+* namespace [Aspose.Pdf.Annotations](../../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.annotations/richtextfontstyles/_index.md
+++ b/spanish/net/aspose.pdf.annotations/richtextfontstyles/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum RichTextFontStyles"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Enum Aspose.Pdf.Annotations.RichTextFontStyles. Opciones para dar estilo a fragmentos de texto en RichText"
+type: docs
+weight: 2600
+url: /es/net/aspose.pdf.annotations/richtextfontstyles/
+---
+## RichTextFontStyles enumeration
+
+Opciones para dar estilo a fragmentos de texto en RichText.
+
+```csharp
+[Flags]
+public enum RichTextFontStyles
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| ClearExisting | `1` | Si está establecido, elimina todos los estilos existentes antes de aplicar los adicionales. Cuando se combina con otras banderas de estilo (e.g., Bold), primero restablece los estilos y luego aplica los especificados. Sin esta bandera, los nuevos estilos se añaden a los existentes. |
+| Bold | `2` | Opción que especifica negrita. |
+| Italic | `4` | Opción que especifica cursiva. |
+| Underline | `8` | Opción que especifica subrayado. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.Annotations](../../aspose.pdf.annotations/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.devices/imagedevice/getbitmap/_index.md
+++ b/spanish/net/aspose.pdf.devices/imagedevice/getbitmap/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ImageDevice.GetBitmap"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ImageDevice. Convierte la página en Bitmap"
+type: docs
+weight: 80
+url: /es/net/aspose.pdf.devices/imagedevice/getbitmap/
+---
+## ImageDevice.GetBitmap method
+
+Convierte la página en Bitmap.
+
+```csharp
+public Bitmap GetBitmap(Page page)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| página | Página | La página a convertir. |
+
+### Ver también
+
+* class [Page](../../../aspose.pdf/page/)
+* class [ImageDevice](../)
+* namespace [Aspose.Pdf.Devices](../../../aspose.pdf.devices/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/_index.md
+++ b/spanish/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/_index.md
@@ -1,0 +1,59 @@
+---
+title: "PdfFileSignature.TryExtractCertificate"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método PdfFileSignature. Extrae el certificado único X.509 de la firma"
+type: docs
+weight: 310
+url: /es/net/aspose.pdf.facades/pdffilesignature/tryextractcertificate/
+---
+## TryExtractCertificate(SignatureName, out X509Certificate2) {#tryextractcertificate_1}
+
+Extrae el certificado único X.509 de la firma.
+
+```csharp
+public bool TryExtractCertificate(SignatureName signName, out X509Certificate2 certificate)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| signName | SignatureName | El nombre de la firma. |
+| certificate | X509Certificate2& | Si se encontró un certificado, devuelve el objeto de certificado único X.509; de lo contrario, null. |
+
+### Valor devuelto
+
+Se encontró un certificado verdadero.
+
+### Ver también
+
+* class [SignatureName](../../signaturename/)
+* class [PdfFileSignature](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## TryExtractCertificate(SignatureName, out Stream) {#tryextractcertificate}
+
+Extrae el certificado único X.509 de la firma como un flujo.
+
+```csharp
+public bool TryExtractCertificate(SignatureName signName, out Stream stream)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| signName | SignatureName | El nombre de la firma. |
+| stream | Stream& | Si se encontró un certificado, devuelve el flujo del certificado único X.509; de lo contrario, null. |
+
+### Valor devuelto
+
+Se encontró un certificado verdadero.
+
+### Ver también
+
+* class [SignatureName](../../signaturename/)
+* class [PdfFileSignature](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.facades/pdfviewer/printdocuments/_index.md
+++ b/spanish/net/aspose.pdf.facades/pdfviewer/printdocuments/_index.md
@@ -1,0 +1,487 @@
+---
+title: "PdfViewer.PrintDocuments"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método PdfViewer. Imprime varios documentos PDF usando la impresora predeterminada y la configuración de página."
+type: docs
+weight: 370
+url: /es/net/aspose.pdf.facades/pdfviewer/printdocuments/
+---
+## PrintDocuments(params Document[]) {#printdocuments}
+
+Imprime varios documentos PDF usando la impresora predeterminada y la configuración de página.
+
+```csharp
+public static void PrintDocuments(params Document[] documents)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| documents | Document[] | Una matriz de objetos [`Document`](../../../aspose.pdf/document/) que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única tarea de impresión.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(document1, document2, document3)
+End Using
+```
+
+### Ver también
+
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(params string[]) {#printdocuments_8}
+
+Imprime varios documentos PDF usando la impresora predeterminada y la configuración de página.
+
+```csharp
+public static void PrintDocuments(params string[] filePaths)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePaths | String[] | Una matriz de rutas de archivo que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única tarea de impresión. Asegúrese de que las rutas de archivo proporcionadas sean válidas y accesibles.
+
+## Ejemplos
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(path1, path2, path3)
+```
+
+### Ver también
+
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(params Stream[]) {#printdocuments_7}
+
+Imprime varios documentos PDF desde los flujos proporcionados usando la impresora predeterminada y la configuración de página.
+
+```csharp
+public static void PrintDocuments(params Stream[] documentStreams)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| documentStreams | Stream[] | Una matriz de flujos que contienen los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única operación. Asegúrese de que los flujos proporcionados sean válidos y accesibles durante el proceso de impresión.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(stream1, stream2, stream3)
+End Using
+```
+
+### Ver también
+
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params Document[]) {#printdocuments_1}
+
+Imprime varios documentos PDF usando la configuración de impresora especificada.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params Document[] documents)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | El objeto [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) que especifica la configuración de impresora a usar para la impresión. |
+| documents | Document[] | Una matriz de objetos [`Document`](../../../aspose.pdf/document/) que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF con configuraciones de impresora personalizadas.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Dim printDocument As New PrintDocument()
+     Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+     printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, document1, document2, document3)
+End Using
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params string[]) {#printdocuments_6}
+
+Imprime varios documentos PDF usando la configuración de impresora especificada.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params string[] filePaths)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | El objeto [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) que contiene los detalles de configuración de la impresora. |
+| filePaths | String[] | Una matriz de rutas de archivo que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única tarea de impresión. Asegúrese de que las rutas de archivo proporcionadas sean válidas y accesibles.
+
+## Ejemplos
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+var printDocument = new PrintDocument();
+Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Dim printDocument As New PrintDocument()
+Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, path1, path2, path3)
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, params Stream[]) {#printdocuments_5}
+
+Imprime varios documentos PDF desde los flujos proporcionados utilizando la configuración de impresora especificada.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, params Stream[] documentStreams)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | La configuración de la impresora que se aplicará durante el proceso de impresión. |
+| documentStreams | Stream[] | Una matriz de flujos que contienen los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única operación. Asegúrese de que los flujos proporcionados sean válidos y accesibles durante el proceso de impresión.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Dim printDocument As New PrintDocument()
+    Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, stream1, stream2, stream3)
+End Using
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params Document[]) {#printdocuments_2}
+
+Imprime varios documentos PDF utilizando la impresora y la configuración de página especificadas.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params Document[] documents)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | El objeto [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) que especifica la configuración de impresora a usar para la impresión. |
+| pageSettings | PageSettings | El objeto [`PageSettings`](../../../aspose.pdf.printing/pagesettings/) que especifica la configuración de página a usar para la impresión. |
+| documents | Document[] | Una matriz de objetos [`Document`](../../../aspose.pdf/document/) que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF con configuraciones personalizadas de impresora y página.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Aspose.Pdf.Document document1 = new Aspose.Pdf.Document(dataDir + "PrintDocument.pdf"),
+                           document2 = new Aspose.Pdf.Document(dataDir + "Print-PageRange.pdf"),
+                           document3 = new Aspose.Pdf.Document(dataDir + "35925_1_3.xps", new Aspose.Pdf.XpsLoadOptions()))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+    pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, document1, document2, document3);
+}
+
+[VisualBasic]
+Using document1 As New Aspose.Pdf.Document(dataDir & "PrintDocument.pdf"),
+      document2 As New Aspose.Pdf.Document(dataDir & "Print-PageRange.pdf"),
+      document3 As New Aspose.Pdf.Document(dataDir & "35925_1_3.xps", New Aspose.Pdf.XpsLoadOptions())
+     Dim printDocument As New PrintDocument()
+     Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+     printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+     Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+     pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+     pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+     Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, document1, document2, document3)
+End Using
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [Document](../../../aspose.pdf/document/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params string[]) {#printdocuments_4}
+
+Imprime varios documentos PDF utilizando la impresora y la configuración de página especificadas.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params string[] filePaths)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | El objeto [`PrinterSettings`](../../../aspose.pdf.printing/printersettings/) que contiene los detalles de configuración de la impresora. |
+| pageSettings | PageSettings | El objeto [`PageSettings`](../../../aspose.pdf.printing/pagesettings/) que especifica el diseño y la configuración de la página. |
+| filePaths | String[] | Una matriz de rutas de archivo que representan los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única tarea de impresión. Asegúrese de que las rutas de archivo proporcionadas sean válidas y accesibles.
+
+## Ejemplos
+
+```csharp
+[C#]
+var path1 = dataDir + "PrintDocument.pdf";
+var path2 = dataDir + "Print-PageRange.pdf";
+var path3 = dataDir + "35925_1_3.xps";
+
+var printDocument = new PrintDocument();
+Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, path1, path2, path3);
+
+[VisualBasic]
+Dim path1 As String = dataDir & "PrintDocument.pdf"
+Dim path2 As String = dataDir & "Print-PageRange.pdf"
+Dim path3 As String = dataDir & "35925_1_3.xps"
+
+Dim printDocument As New PrintDocument()
+Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, path1, path2, path3)
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## PrintDocuments(PrinterSettings, PageSettings, params Stream[]) {#printdocuments_3}
+
+Imprime varios documentos PDF desde los flujos proporcionados utilizando la impresora y la configuración de página especificadas.
+
+```csharp
+public static void PrintDocuments(PrinterSettings printerSettings, PageSettings pageSettings, 
+    params Stream[] documentStreams)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerSettings | PrinterSettings | La configuración de la impresora que se aplicará durante el proceso de impresión. |
+| pageSettings | PageSettings | La configuración de página que se aplicará a cada documento durante la impresión. |
+| documentStreams | Stream[] | Una matriz de flujos que contienen los documentos PDF a imprimir. |
+
+## Observaciones
+
+Este método permite imprimir varios documentos PDF en una única operación. Asegúrese de que los flujos proporcionados sean válidos y accesibles durante el proceso de impresión.
+
+## Ejemplos
+
+```csharp
+[C#]
+using (Stream stream1 = File.OpenRead(dataDir + "PrintDocument.pdf"),
+              stream2 = File.OpenRead(dataDir + "Print-PageRange.pdf"),
+              stream3 = File.OpenRead(dataDir + "35925_1_3.xps"))
+{
+    var printDocument = new PrintDocument();
+    Aspose.Pdf.Printing.PrinterSettings printerSettings = new Aspose.Pdf.Printing.PrinterSettings();
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName;
+
+    Aspose.Pdf.Printing.PageSettings pageSettings = new Aspose.Pdf.Printing.PageSettings();
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4;
+    pageSettings.Margins = new Aspose.Pdf.Devices.Margins(0, 0, 0, 0);
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, stream1, stream2, stream3);
+}
+
+[VisualBasic]
+Using stream1 As Stream = File.OpenRead(dataDir & "PrintDocument.pdf"),
+      stream2 As Stream = File.OpenRead(dataDir & "Print-PageRange.pdf"),
+      stream3 As Stream = File.OpenRead(dataDir & "35925_1_3.xps")
+    Dim printDocument As New PrintDocument()
+    Dim printerSettings As New Aspose.Pdf.Printing.PrinterSettings()
+    printerSettings.PrinterName = printDocument.PrinterSettings.PrinterName
+
+    Dim pageSettings As New Aspose.Pdf.Printing.PageSettings()
+    pageSettings.PaperSize = Aspose.Pdf.Printing.PaperSizes.A4
+    pageSettings.Margins = New Aspose.Pdf.Devices.Margins(0, 0, 0, 0)
+
+    Aspose.Pdf.Facades.PdfViewer.PrintDocuments(printerSettings, pageSettings, stream1, stream2, stream3)
+End Using
+```
+
+### Ver también
+
+* class [PrinterSettings](../../../aspose.pdf.printing/printersettings/)
+* class [PageSettings](../../../aspose.pdf.printing/pagesettings/)
+* class [PdfViewer](../)
+* namespace [Aspose.Pdf.Facades](../../../aspose.pdf.facades/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.forms/form/hasxfa/_index.md
+++ b/spanish/net/aspose.pdf.forms/form/hasxfa/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Form.HasXfa"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad Form. Obtiene un valor que indica si el documento contiene un formulario XFA. Esta propiedad se introdujo para determinar si se debe usar IgnoreNeedsRendering para eliminar el formulario XFA en los casos en que el formulario XFA está presente y NeedsRendering es falso."
+type: docs
+weight: 90
+url: /es/net/aspose.pdf.forms/form/hasxfa/
+---
+## Form.HasXfa property
+
+Obtiene un valor que indica si el documento contiene un formulario XFA. Esta propiedad se introdujo para determinar si se debe usar [`IgnoreNeedsRendering`](../ignoreneedsrendering/) para eliminar el formulario XFA en los casos en que el formulario XFA está presente y [`NeedsRendering`](../needsrendering/) es falso.
+
+```csharp
+public bool HasXfa { get; }
+```
+
+### Ver también
+
+* class [Form](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.forms/form/needsrendering/_index.md
+++ b/spanish/net/aspose.pdf.forms/form/needsrendering/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Form.NeedsRendering"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad Form. Obtiene un valor que indica si el documento requiere la eliminación del formulario XFA dinámico. Esta propiedad se introdujo para determinar si se debe usar IgnoreNeedsRendering para eliminar el formulario XFA en los casos en que el formulario XFA está presente y NeedsRendering es falso."
+type: docs
+weight: 130
+url: /es/net/aspose.pdf.forms/form/needsrendering/
+---
+## Form.NeedsRendering property
+
+Obtiene un valor que indica si el documento requiere la eliminación del formulario XFA dinámico. Esta propiedad se introdujo para determinar si se debe usar [`IgnoreNeedsRendering`](../ignoreneedsrendering/) para eliminar el formulario XFA en los casos en que el formulario XFA está presente y `NeedsRendering` es falso.
+
+```csharp
+public bool NeedsRendering { get; }
+```
+
+### Ver también
+
+* class [Form](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/_index.md
+++ b/spanish/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/_index.md
@@ -1,0 +1,23 @@
+---
+title: "SignatureCustomAppearance.IsForegroundImage"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad SignatureCustomAppearance. Obtiene o establece un valor que indica si la imagen en la apariencia de la firma se dibuja como una imagen de primer plano. Valor predeterminado false."
+type: docs
+weight: 130
+url: /es/net/aspose.pdf.forms/signaturecustomappearance/isforegroundimage/
+---
+## SignatureCustomAppearance.IsForegroundImage property
+
+Obtiene o establece un valor que indica si la imagen en la apariencia de la firma se dibuja como una imagen de primer plano. Valor predeterminado: false.
+
+```csharp
+public bool IsForegroundImage { get; set; }
+```
+
+### Ver también
+
+* class [SignatureCustomAppearance](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.forms/signaturefield/extractcertificateobject/_index.md
+++ b/spanish/net/aspose.pdf.forms/signaturefield/extractcertificateobject/_index.md
@@ -1,0 +1,27 @@
+---
+title: "SignatureField.ExtractCertificateObject"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método SignatureField. Extrae el objeto de certificado X.509 único"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.forms/signaturefield/extractcertificateobject/
+---
+## SignatureField.ExtractCertificateObject method
+
+Extrae el único objeto de certificado X.509.
+
+```csharp
+public X509Certificate2 ExtractCertificateObject()
+```
+
+### Valor devuelto
+
+Si se encontró el certificado, devuelve el certificado X.509 único; de lo contrario, null.
+
+### Ver también
+
+* class [SignatureField](../)
+* namespace [Aspose.Pdf.Forms](../../../aspose.pdf.forms/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofd/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofd/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Clase Ofd"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.Plugins.Ofd. Representa el complemento Ofd"
+type: docs
+weight: 9090
+url: /es/net/aspose.pdf.plugins/ofd/
+---
+## Ofd class
+
+Representa el complemento `Ofd`.
+
+```csharp
+public sealed class Ofd : IDisposable, IPlugin
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [Ofd](ofd/)() | El constructor predeterminado. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [Dispose](../../aspose.pdf.plugins/ofd/dispose/)() | Implementación de IDisposable. |
+| [Process](../../aspose.pdf.plugins/ofd/process/)(IPluginOptions) | Inicia el procesamiento `Ofd` con los parámetros especificados. |
+
+### Ver también
+
+* interface [IPlugin](../iplugin/)
+* namespace [Aspose.Pdf.Plugins](../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofd/dispose/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofd/dispose/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ofd.Dispose"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método Ofd. Implementación de IDisposable"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.plugins/ofd/dispose/
+---
+## Ofd.Dispose method
+
+Implementación de IDisposable.
+
+```csharp
+public void Dispose()
+```
+
+### Ver también
+
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofd/ofd/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofd/ofd/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Ofd.Ofd"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor Ofd. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.plugins/ofd/ofd/
+---
+## Ofd constructor
+
+El constructor predeterminado.
+
+```csharp
+public Ofd()
+```
+
+### Ver también
+
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofd/process/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofd/process/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Ofd.Process"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método Ofd. Inicia el procesamiento Ofd con los parámetros especificados"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.plugins/ofd/process/
+---
+## Ofd.Process method
+
+Inicia el procesamiento de [`Ofd`](../) con los parámetros especificados.
+
+```csharp
+public ResultContainer Process(IPluginOptions options)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| options | IPluginOptions | Un objeto de opciones que contiene instrucciones para el [`Ofd`](../). |
+
+### Valor devuelto
+
+Un objeto [`ResultContainer`](../../resultcontainer/) que contiene el resultado de la operación.
+
+### Ver también
+
+* class [ResultContainer](../../resultcontainer/)
+* interface [IPluginOptions](../../ipluginoptions/)
+* class [Ofd](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Clase OfdToPdfOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.Plugins.OfdToPdfOptions. Representa opciones para convertir OFD a PDF"
+type: docs
+weight: 9100
+url: /es/net/aspose.pdf.plugins/ofdtopdfoptions/
+---
+## OfdToPdfOptions class
+
+Representa opciones para convertir OFD a PDF.
+
+```csharp
+public class OfdToPdfOptions : PdfConverterOptions
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [OfdToPdfOptions](ofdtopdfoptions/)() | El constructor predeterminado. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [Inputs](../../aspose.pdf.plugins/pdfconverteroptions/inputs/) { get; } | Devuelve la colección de datos del complemento PdfConverterOptions. |
+| [OfdLoadOptions](../../aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/) { get; set; } | Obtiene o establece las opciones de carga OFD. |
+| override [OperationName](../../aspose.pdf.plugins/ofdtopdfoptions/operationname/) { get; } | Obtiene el nombre de la operación. |
+| [Outputs](../../aspose.pdf.plugins/pdfconverteroptions/outputs/) { get; } | Obtiene la colección de destinos añadidos para guardar los resultados de la operación. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [AddInput](../../aspose.pdf.plugins/pdfconverteroptions/addinput/)(IDataSource) | Agrega una nueva fuente de datos a la colección de datos del complemento PdfConverter. |
+| [AddOutput](../../aspose.pdf.plugins/pdfconverteroptions/addoutput/)(IDataSource) | Agrega una nueva fuente de datos a la colección de datos del complemento PdfToXLSXConverterOptions. |
+
+### Ver también
+
+* class [PdfConverterOptions](../pdfconverteroptions/)
+* namespace [Aspose.Pdf.Plugins](../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "OfdToPdfOptions.OfdLoadOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OfdToPdfOptions. Obtiene o establece las opciones de carga OFD"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.plugins/ofdtopdfoptions/ofdloadoptions/
+---
+## OfdToPdfOptions.OfdLoadOptions property
+
+Obtiene o establece las opciones de carga OFD.
+
+```csharp
+public OfdLoadOptions OfdLoadOptions { get; set; }
+```
+
+### Ver también
+
+* class [OfdLoadOptions](../../../aspose.pdf/ofdloadoptions/)
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OfdToPdfOptions.OfdToPdfOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor OfdToPdfOptions. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.plugins/ofdtopdfoptions/ofdtopdfoptions/
+---
+## OfdToPdfOptions constructor
+
+El constructor predeterminado.
+
+```csharp
+public OfdToPdfOptions()
+```
+
+### Ver también
+
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/_index.md
+++ b/spanish/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/_index.md
@@ -1,0 +1,23 @@
+---
+title: "OfdToPdfOptions.OperationName"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad OfdToPdfOptions. Obtiene el nombre de la operación"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.plugins/ofdtopdfoptions/operationname/
+---
+## OfdToPdfOptions.OperationName property
+
+Obtiene el nombre de la operación.
+
+```csharp
+public override string OperationName { get; }
+```
+
+### Ver también
+
+* class [OfdToPdfOptions](../)
+* namespace [Aspose.Pdf.Plugins](../../../aspose.pdf.plugins/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/certificateencryptionoptions/_index.md
+++ b/spanish/net/aspose.pdf.security/certificateencryptionoptions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Clase CertificateEncryptionOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.Security.CertificateEncryptionOptions. Representa una clase para cifrar opciones de un documento PDF usando un método de cifrado basado en certificado. Utilizada para abrir documentos PDF cifrados"
+type: docs
+weight: 10100
+url: /es/net/aspose.pdf.security/certificateencryptionoptions/
+---
+## CertificateEncryptionOptions class
+
+Representa una clase para cifrar opciones de un documento PDF usando un método de cifrado basado en certificado. Se utiliza para abrir documentos PDF cifrados.
+
+```csharp
+public class CertificateEncryptionOptions
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_2)(string, StoreName, StoreLocation) | Crea una instancia de la clase `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_3)(string, string, string) | Crea una instancia de la clase `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor)(X509Certificate2, StoreName, StoreLocation) | Crea una instancia de la clase `CertificateEncryptionOptions`. |
+| [CertificateEncryptionOptions](certificateencryptionoptions/#constructor_1)(X509Certificate2, string, string) | Crea una instancia de la clase `CertificateEncryptionOptions`. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/_index.md
+++ b/spanish/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/_index.md
@@ -1,0 +1,99 @@
+---
+title: "CertificateEncryptionOptions.CertificateEncryptionOptions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "CertificateEncryptionOptions constructor. Crea una instancia de la clase CertificateEncryptionOptions"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.security/certificateencryptionoptions/certificateencryptionoptions/
+---
+## CertificateEncryptionOptions(string, string, string) {#constructor_3}
+
+Crea una instancia de la clase [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(string publicCertificatePath, string pfxPath, 
+    string pfxPassword)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| publicCertificatePath | Cadena | La ruta del archivo del certificado público. |
+| pfxPath | Cadena | La ruta del archivo p12. |
+| pfxPassword | Cadena | La contraseña del archivo p12. |
+
+### Ver también
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(string, StoreName, StoreLocation) {#constructor_2}
+
+Crea una instancia de la clase [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(string publicCertificatePath, 
+    StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| publicCertificatePath | Cadena | La ruta del archivo del certificado público. |
+| storeName | StoreName | El nombre del almacén para obtener un certificado de clave privada. |
+| storeLocation | StoreLocation | La ubicación del almacén para obtener un certificado de clave privada. |
+
+### Ver también
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(X509Certificate2, StoreName, StoreLocation) {#constructor}
+
+Crea una instancia de la clase [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(X509Certificate2 publicCertificate, 
+    StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| publicCertificate | X509Certificate2 | El certificado público. |
+| storeName | StoreName | El nombre del almacén para obtener un certificado de clave privada. |
+| storeLocation | StoreLocation | La ubicación del almacén para obtener un certificado de clave privada. |
+
+### Ver también
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## CertificateEncryptionOptions(X509Certificate2, string, string) {#constructor_1}
+
+Crea una instancia de la clase [`CertificateEncryptionOptions`](../).
+
+```csharp
+public CertificateEncryptionOptions(X509Certificate2 publicCertificate, string pfxPath, 
+    string pfxPassword)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| publicCertificate | X509Certificate2 | El certificado público. |
+| pfxPath | Cadena | La ruta del archivo p12. |
+| pfxPassword | Cadena | La contraseña del archivo p12. |
+
+### Ver también
+
+* class [CertificateEncryptionOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Clase EncryptionParameters"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.Security.EncryptionParameters. Representa una clase de parámetros de cifrado"
+type: docs
+weight: 10140
+url: /es/net/aspose.pdf.security/encryptionparameters/
+---
+## EncryptionParameters class
+
+Representa una clase de parámetros de cifrado.
+
+```csharp
+public class EncryptionParameters
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [EncryptionParameters](encryptionparameters/)() | El constructor predeterminado. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [Filter](../../aspose.pdf.security/encryptionparameters/filter/) { get; } | Obtiene el nombre del filtro. |
+| [KeyLength](../../aspose.pdf.security/encryptionparameters/keylength/) { get; } | Obtiene la longitud de la clave. |
+| [OwnerKey](../../aspose.pdf.security/encryptionparameters/ownerkey/) { get; } | Obtiene la clave del propietario (el campo "O" del diccionario de cifrado.) |
+| [Password](../../aspose.pdf.security/encryptionparameters/password/) { get; } | Obtiene la contraseña de la entrada. |
+| [Permissions](../../aspose.pdf.security/encryptionparameters/permissions/) { get; } | Los permisos del documento. |
+| [PermissionsInt](../../aspose.pdf.security/encryptionparameters/permissionsint/) { get; } | La representación entera de los permisos del documento. |
+| [Perms](../../aspose.pdf.security/encryptionparameters/perms/) { get; } | Obtiene los datos del campo Perms. Es un permiso cifrado. |
+| [Revision](../../aspose.pdf.security/encryptionparameters/revision/) { get; } | Obtiene la revisión del controlador o del algoritmo de cifrado. |
+| [SubFilter](../../aspose.pdf.security/encryptionparameters/subfilter/) { get; } | Obtiene el nombre del subfiltro. |
+| [UserKey](../../aspose.pdf.security/encryptionparameters/userkey/) { get; } | Obtiene la clave de usuario (El campo "U" del diccionario de cifrado.) |
+| [Version](../../aspose.pdf.security/encryptionparameters/version/) { get; } | Obtiene la versión del controlador o del algoritmo de cifrado. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/encryptionparameters/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/encryptionparameters/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.EncryptionParameters"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor EncryptionParameters. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.security/encryptionparameters/encryptionparameters/
+---
+## EncryptionParameters constructor
+
+El constructor predeterminado.
+
+```csharp
+public EncryptionParameters()
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/filter/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/filter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Filter"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene el nombre del filtro"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.security/encryptionparameters/filter/
+---
+## EncryptionParameters.Filter property
+
+Obtiene el nombre del filtro.
+
+```csharp
+public string Filter { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/keylength/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/keylength/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.KeyLength"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la longitud de la clave"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.security/encryptionparameters/keylength/
+---
+## EncryptionParameters.KeyLength property
+
+Obtiene la longitud de la clave.
+
+```csharp
+public int KeyLength { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/ownerkey/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/ownerkey/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.OwnerKey"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la clave del propietario. El campo O del diccionario de cifrado"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.security/encryptionparameters/ownerkey/
+---
+## EncryptionParameters.OwnerKey property
+
+Obtiene la clave del propietario (el campo "O" del diccionario de cifrado.)
+
+```csharp
+public byte[] OwnerKey { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/password/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/password/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Password"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la contraseña de la entrada"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.security/encryptionparameters/password/
+---
+## EncryptionParameters.Password property
+
+Obtiene la contraseña de la entrada.
+
+```csharp
+public string Password { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/permissions/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/permissions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "EncryptionParameters.Permissions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Los permisos del documento"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.security/encryptionparameters/permissions/
+---
+## EncryptionParameters.Permissions property
+
+Los permisos del documento.
+
+```csharp
+public Permissions Permissions { get; }
+```
+
+### Ver también
+
+* enum [Permissions](../../../aspose.pdf/permissions/)
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/permissionsint/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/permissionsint/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.PermissionsInt"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. La representación entera de los permisos del documento"
+type: docs
+weight: 70
+url: /es/net/aspose.pdf.security/encryptionparameters/permissionsint/
+---
+## EncryptionParameters.PermissionsInt property
+
+La representación entera de los permisos del documento.
+
+```csharp
+public int PermissionsInt { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/perms/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/perms/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Perms"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene los datos del campo Perms. Es un permiso cifrado"
+type: docs
+weight: 80
+url: /es/net/aspose.pdf.security/encryptionparameters/perms/
+---
+## EncryptionParameters.Perms property
+
+Obtiene los datos del campo Perms. Es un permiso cifrado.
+
+```csharp
+public byte[] Perms { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/revision/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/revision/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Revision"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la revisión del controlador o algoritmo de cifrado"
+type: docs
+weight: 90
+url: /es/net/aspose.pdf.security/encryptionparameters/revision/
+---
+## EncryptionParameters.Revision property
+
+Obtiene la revisión del controlador o del algoritmo de cifrado.
+
+```csharp
+public int Revision { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/subfilter/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/subfilter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.SubFilter"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene el nombre del subfiltro"
+type: docs
+weight: 100
+url: /es/net/aspose.pdf.security/encryptionparameters/subfilter/
+---
+## EncryptionParameters.SubFilter property
+
+Obtiene el nombre del subfiltro.
+
+```csharp
+public string SubFilter { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/userkey/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/userkey/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.UserKey"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la clave del usuario. El campo U del diccionario de cifrado"
+type: docs
+weight: 110
+url: /es/net/aspose.pdf.security/encryptionparameters/userkey/
+---
+## EncryptionParameters.UserKey property
+
+Obtiene la clave de usuario (El campo "U" del diccionario de cifrado.)
+
+```csharp
+public byte[] UserKey { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/encryptionparameters/version/_index.md
+++ b/spanish/net/aspose.pdf.security/encryptionparameters/version/_index.md
@@ -1,0 +1,23 @@
+---
+title: "EncryptionParameters.Version"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad EncryptionParameters. Obtiene la versión del controlador o algoritmo de cifrado"
+type: docs
+weight: 120
+url: /es/net/aspose.pdf.security/encryptionparameters/version/
+---
+## EncryptionParameters.Version property
+
+Obtiene la versión del controlador o del algoritmo de cifrado.
+
+```csharp
+public int Version { get; }
+```
+
+### Ver también
+
+* class [EncryptionParameters](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Interfaz ICustomSecurityHandler"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Interfaz Aspose.Pdf.Security.ICustomSecurityHandler. La interfaz del controlador de seguridad personalizado"
+type: docs
+weight: 10150
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/
+---
+## ICustomSecurityHandler interface
+
+La interfaz del controlador de seguridad personalizado.
+
+```csharp
+public interface ICustomSecurityHandler
+```
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [Filter](../../aspose.pdf.security/icustomsecurityhandler/filter/) { get; } | Obtiene el nombre del filtro. |
+| [KeyLength](../../aspose.pdf.security/icustomsecurityhandler/keylength/) { get; } | Obtiene la longitud de la clave. |
+| [Revision](../../aspose.pdf.security/icustomsecurityhandler/revision/) { get; } | Obtiene la revisión del controlador o del algoritmo de cifrado. |
+| [SubFilter](../../aspose.pdf.security/icustomsecurityhandler/subfilter/) { get; } | Obtiene el nombre del subfiltro. |
+| [Version](../../aspose.pdf.security/icustomsecurityhandler/version/) { get; } | Obtiene la versión del controlador o del algoritmo de cifrado. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [CalculateEncryptionKey](../../aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/)(string) | Calcula la EncryptionKey. Generalmente la clave se calcula en base a la UserKey. Puedes usar valores de EncryptionParams, que contiene los parámetros actuales en el momento de la llamada. Este valor se pasa como argumento de clave en [`Encrypt`](./encrypt/) y [`Decrypt`](./decrypt/). |
+| [Decrypt](../../aspose.pdf.security/icustomsecurityhandler/decrypt/)(byte[], int, int, byte[]) | Descifra la matriz de datos. |
+| [Encrypt](../../aspose.pdf.security/icustomsecurityhandler/encrypt/)(byte[], int, int, byte[]) | Cifra la matriz de datos. |
+| [EncryptPermissions](../../aspose.pdf.security/icustomsecurityhandler/encryptpermissions/)(int) | Cifra el campo de permisos del documento. El resultado se escribirá en el campo Perms del diccionario de cifrado. Al abrir un documento, el valor puede obtenerse en [`EncryptionParameters`](../encryptionparameters/) a través del campo Perms. Permite comprobar si los permisos del documento han cambiado. |
+| [GetOwnerKey](../../aspose.pdf.security/icustomsecurityhandler/getownerkey/)(string, string) | Crea una matriz codificada basada en contraseñas que se escribirá en el campo O del diccionario de cifrado. Debe basarse únicamente en los argumentos proporcionados. La contraseña de usuario puede calcularse a partir de este campo usando la contraseña del propietario. Se llama durante el cifrado para prepararla y rellenar el diccionario de cifrado. El valor estará disponible en [`CalculateEncryptionKey`](./calculateencryptionkey/) para obtener la clave a partir de la UserKey. Las contraseñas especificadas por el usuario al invocar el cifrado del documento se pasarán. Puede que no se especifiquen contraseñas o que solo se especifique una. |
+| [GetUserKey](../../aspose.pdf.security/icustomsecurityhandler/getuserkey/)(string) | Crea una matriz codificada basada en la contraseña del usuario. Este valor se usa típicamente para comprobar si la contraseña pertenece al usuario o al propietario, y para obtener la clave de cifrado. Se llama durante el cifrado para prepararla y rellenar el diccionario de cifrado. La contraseña especificada por el usuario se pasa como argumento al invocar el cifrado del documento. |
+| [Initialize](../../aspose.pdf.security/icustomsecurityhandler/initialize/)(EncryptionParameters) | Se llama para inicializar la instancia actual para el cifrado. Ten en cuenta que al cifrar, se rellenará con los datos de las propiedades transferidas `ICustomSecurityHandler`, y al abrir el documento desde el diccionario de cifrado. Si el método se llama durante un nuevo cifrado, entonces [`UserKey`](../encryptionparameters/userkey/) y [`OwnerKey`](../encryptionparameters/ownerkey/) serán nulos. |
+| [IsOwnerPassword](../../aspose.pdf.security/icustomsecurityhandler/isownerpassword/)(string) | Comprueba si la contraseña es la del propietario del documento. El método se llama después de Initialize. La llamada al método se usa en la API PDF. |
+| [IsUserPassword](../../aspose.pdf.security/icustomsecurityhandler/isuserpassword/)(string) | Comprueba si la contraseña pertenece al usuario (contraseña para abrir el documento). El método se llama después de Initialize. La llamada al método se usa en la API PDF. |
+
+### Ver también
+
+* namespace [Aspose.Pdf.Security](../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.CalculateEncryptionKey"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Calcula la EncryptionKey. Generalmente la clave se calcula a partir de la UserKey. Puedes usar valores de EncryptionParams, que contiene los parámetros actuales en el momento de la llamada. Este valor se pasa como argumento de clave en Encrypt y Decrypt."
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/calculateencryptionkey/
+---
+## ICustomSecurityHandler.CalculateEncryptionKey method
+
+Calcula la EncryptionKey. Generalmente la clave se calcula a partir de la UserKey. Puedes usar valores de EncryptionParams, que contiene los parámetros actuales en el momento de la llamada. Este valor se pasa como argumento de clave en [`Encrypt`](../encrypt/) y [`Decrypt`](../decrypt/).
+
+```csharp
+public byte[] CalculateEncryptionKey(string password)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| password | Cadena | Contraseña introducida por el usuario. |
+
+### Valor devuelto
+
+La matriz de la clave de cifrado.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/decrypt/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/decrypt/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ICustomSecurityHandler.Decrypt"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Descifra el arreglo de datos"
+type: docs
+weight: 70
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/decrypt/
+---
+## ICustomSecurityHandler.Decrypt method
+
+Descifra la matriz de datos.
+
+```csharp
+public byte[] Decrypt(byte[] data, int objectNumber, int generation, byte[] key)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| datos | Byte[] | Datos a descifrar. |
+| objectNumber | Int32 | Número del objeto que contiene los datos cifrados. |
+| generation | Int32 | Generación del objeto. |
+| key | Byte[] | Clave obtenida mediante el método CalculateEncryptionKey |
+
+### Valor devuelto
+
+Los datos descifrados.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/encrypt/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/encrypt/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ICustomSecurityHandler.Encrypt"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Cifra el arreglo de datos"
+type: docs
+weight: 80
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/encrypt/
+---
+## ICustomSecurityHandler.Encrypt method
+
+Cifra la matriz de datos.
+
+```csharp
+public byte[] Encrypt(byte[] data, int objectNumber, int generation, byte[] key)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| datos | Byte[] | Datos para cifrar. |
+| objectNumber | Int32 | Número del objeto que contiene los datos cifrados. |
+| generation | Int32 | Generación del objeto. |
+| key | Byte[] | Clave obtenida mediante el método CalculateEncryptionKey |
+
+### Valor devuelto
+
+Los datos cifrados.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.EncryptPermissions"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Cifra el campo de permisos del documento. El resultado se escribirá en el campo del diccionario de cifrado Perms. Al abrir un documento, el valor puede obtenerse en EncryptionParameters a través del campo Perms. Permite comprobar si los permisos del documento han cambiado."
+type: docs
+weight: 90
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/encryptpermissions/
+---
+## ICustomSecurityHandler.EncryptPermissions method
+
+Cifra el campo de permisos del documento. El resultado se escribirá en el campo del diccionario de cifrado Perms. Al abrir un documento, el valor puede obtenerse en [`EncryptionParameters`](../../encryptionparameters/) a través del campo Perms. Permite comprobar si los permisos del documento han cambiado.
+
+```csharp
+public byte[] EncryptPermissions(int permissions)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| permisos | Int32 | Los permisos del documento en representación entera. |
+
+### Valor devuelto
+
+La matriz cifrada.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/filter/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/filter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Filter"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ICustomSecurityHandler. Obtiene el nombre del filtro"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/filter/
+---
+## ICustomSecurityHandler.Filter property
+
+Obtiene el nombre del filtro.
+
+```csharp
+public string Filter { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/_index.md
@@ -1,0 +1,32 @@
+---
+title: "ICustomSecurityHandler.GetOwnerKey"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Crea una matriz codificada basada en contraseñas que se escribirá en el campo O del diccionario de cifrado. Sólo debe depender de los argumentos pasados. La contraseña del usuario puede calcularse a partir de este campo usando la contraseña del propietario. Se llama durante el cifrado para prepararla y rellenar el diccionario de cifrado. El valor estará disponible en CalculateEncryptionKey para obtener la clave a partir de la UserKey. Las contraseñas especificadas por el usuario al llamar al cifrado del documento se pasarán. Puede que no se especifiquen contraseñas o que sólo se especifique una."
+type: docs
+weight: 100
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/getownerkey/
+---
+## ICustomSecurityHandler.GetOwnerKey method
+
+Crea una matriz codificada basada en contraseñas que se escribirá en el campo O del diccionario de cifrado. Debe basarse únicamente en los argumentos pasados. La contraseña de usuario puede calcularse a partir de este campo usando la contraseña del propietario. Se llama durante el cifrado para prepararlo y rellenar el diccionario de cifrado. El valor estará disponible en [`CalculateEncryptionKey`](../calculateencryptionkey/) para obtener la clave del UserKey. Las contraseñas especificadas por el usuario al llamar al cifrado del documento serán pasadas. Puede que no se especifiquen contraseñas o que solo se especifique una.
+
+```csharp
+public byte[] GetOwnerKey(string userPassword, string ownerPassword)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| userPassword | Cadena | La contraseña del usuario. |
+| ownerPassword | Cadena | La contraseña del propietario. |
+
+### Valor devuelto
+
+La matriz de la clave del propietario.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.GetUserKey"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Crea una matriz codificada basada en la contraseña del usuario. Este valor se usa típicamente para verificar si la contraseña pertenece al usuario o al propietario y para obtener la clave de cifrado. Se llama durante el cifrado para prepararla y rellenar el diccionario de cifrado. La contraseña especificada por el usuario se pasa como argumento al llamar al cifrado del documento."
+type: docs
+weight: 110
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/getuserkey/
+---
+## ICustomSecurityHandler.GetUserKey method
+
+Crea una matriz codificada basada en la contraseña del usuario. Este valor se usa típicamente para comprobar si la contraseña pertenece al usuario o al propietario, y para obtener la clave de cifrado. Se llama durante el cifrado para prepararla y rellenar el diccionario de cifrado. La contraseña especificada por el usuario se pasa como argumento al invocar el cifrado del documento.
+
+```csharp
+public byte[] GetUserKey(string userPassword)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| userPassword | Cadena | La contraseña del usuario. |
+
+### Valor devuelto
+
+La matriz de la clave de usuario.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/initialize/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/initialize/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ICustomSecurityHandler.Initialize"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Llamado para inicializar la instancia actual para el cifrado. Tenga en cuenta que al cifrar se rellenará con los datos de las propiedades transferidas ICustomSecurityHandler y al abrir el documento desde el diccionario de cifrado. Si el método se llama durante un nuevo cifrado, entonces UserKey y OwnerKey serán nulos"
+type: docs
+weight: 120
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/initialize/
+---
+## ICustomSecurityHandler.Initialize method
+
+Llamado para inicializar la instancia actual para el cifrado. Tenga en cuenta que al cifrar, se rellenará con los datos de las propiedades transferidas [`ICustomSecurityHandler`](../), y al abrir el documento desde el diccionario de cifrado. Si el método se llama durante un nuevo cifrado, entonces [`UserKey`](../../encryptionparameters/userkey/) y [`OwnerKey`](../../encryptionparameters/ownerkey/) serán nulos.
+
+```csharp
+public void Initialize(EncryptionParameters parameters)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| parámetros | EncryptionParameters | Los parámetros de cifrado. |
+
+### Ver también
+
+* class [EncryptionParameters](../../encryptionparameters/)
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.IsOwnerPassword"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Verifica si la contraseña es la contraseña del propietario del documento. El método se llama después de Initialize. La llamada al método se utiliza en la API PDF."
+type: docs
+weight: 130
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/isownerpassword/
+---
+## ICustomSecurityHandler.IsOwnerPassword method
+
+Comprueba si la contraseña es la del propietario del documento. El método se llama después de Initialize. La llamada al método se usa en la API PDF.
+
+```csharp
+public bool IsOwnerPassword(string password)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| password | Cadena | La contraseña. |
+
+### Valor devuelto
+
+True, si es una contraseña de propietario.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICustomSecurityHandler.IsUserPassword"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ICustomSecurityHandler. Verifica si la contraseña corresponde a la contraseña de usuario para abrir el documento. El método se llama después de Initialize. La llamada al método se usa en la API PDF"
+type: docs
+weight: 140
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/isuserpassword/
+---
+## ICustomSecurityHandler.IsUserPassword method
+
+Comprueba si la contraseña pertenece al usuario (contraseña para abrir el documento). El método se llama después de Initialize. La llamada al método se usa en la API PDF.
+
+```csharp
+public bool IsUserPassword(string password)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| password | Cadena | La contraseña. |
+
+### Valor devuelto
+
+True, si es una contraseña para abrir el documento.
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/keylength/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/keylength/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.KeyLength"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ICustomSecurityHandler. Obtiene la longitud de la clave"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/keylength/
+---
+## ICustomSecurityHandler.KeyLength property
+
+Obtiene la longitud de la clave.
+
+```csharp
+public int KeyLength { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/revision/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/revision/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Revision"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ICustomSecurityHandler. Obtiene la revisión del controlador o del algoritmo de cifrado"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/revision/
+---
+## ICustomSecurityHandler.Revision property
+
+Obtiene la revisión del controlador o del algoritmo de cifrado.
+
+```csharp
+public int Revision { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/subfilter/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/subfilter/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.SubFilter"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ICustomSecurityHandler. Obtiene el nombre del subfiltro"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/subfilter/
+---
+## ICustomSecurityHandler.SubFilter property
+
+Obtiene el nombre del subfiltro.
+
+```csharp
+public string SubFilter { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/icustomsecurityhandler/version/_index.md
+++ b/spanish/net/aspose.pdf.security/icustomsecurityhandler/version/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ICustomSecurityHandler.Version"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ICustomSecurityHandler. Obtiene la versión del controlador o del algoritmo de cifrado"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf.security/icustomsecurityhandler/version/
+---
+## ICustomSecurityHandler.Version property
+
+Obtiene la versión del controlador o del algoritmo de cifrado.
+
+```csharp
+public int Version { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.security/validationoptions/checkcertificatechain/_index.md
+++ b/spanish/net/aspose.pdf.security/validationoptions/checkcertificatechain/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ValidationOptions.CheckCertificateChain"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad ValidationOptions. Obtiene o establece un valor que indica si la cadena de certificados debe verificarse durante el proceso de validación."
+type: docs
+weight: 20
+url: /es/net/aspose.pdf.security/validationoptions/checkcertificatechain/
+---
+## ValidationOptions.CheckCertificateChain property
+
+Obtiene o establece un valor que indica si la cadena de certificados debe verificarse durante el proceso de validación.
+
+```csharp
+public bool CheckCertificateChain { get; set; }
+```
+
+## Observaciones
+
+Cuando la propiedad está establecida, se comprobará la existencia de una cadena de certificados; si está ausente, el resultado de la verificación será Undefined, lo que corresponde al comportamiento de Adobe Acrobat. Si solo desea comprobar el estado de revocación en línea, establezca el campo en `false`. El valor predeterminado es `false`.
+
+### Ver también
+
+* class [ValidationOptions](../)
+* namespace [Aspose.Pdf.Security](../../../aspose.pdf.security/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/_index.md
+++ b/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLblElement"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ITaggedContent. Crea ListLblElement"
+type: docs
+weight: 180
+url: /es/net/aspose.pdf.tagged/itaggedcontent/createlistlblelement/
+---
+## ITaggedContent.CreateListLblElement method
+
+Crea [`ListLblElement`](../../../aspose.pdf.logicalstructure/listlblelement/).
+
+```csharp
+public ListLblElement CreateListLblElement()
+```
+
+### Valor devuelto
+
+Elemento de estructura creado.
+
+### Ver también
+
+* class [ListLblElement](../../../aspose.pdf.logicalstructure/listlblelement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/_index.md
+++ b/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLBodyElement"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ITaggedContent. Crea ListLBodyElement"
+type: docs
+weight: 190
+url: /es/net/aspose.pdf.tagged/itaggedcontent/createlistlbodyelement/
+---
+## ITaggedContent.CreateListLBodyElement method
+
+Crea [`ListLBodyElement`](../../../aspose.pdf.logicalstructure/listlbodyelement/).
+
+```csharp
+public ListLBodyElement CreateListLBodyElement()
+```
+
+### Valor devuelto
+
+Elemento de estructura creado.
+
+### Ver también
+
+* class [ListLBodyElement](../../../aspose.pdf.logicalstructure/listlbodyelement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/_index.md
+++ b/spanish/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ITaggedContent.CreateListLIElement"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ITaggedContent. Crea ListLIElement"
+type: docs
+weight: 200
+url: /es/net/aspose.pdf.tagged/itaggedcontent/createlistlielement/
+---
+## ITaggedContent.CreateListLIElement method
+
+Crea [`ListLIElement`](../../../aspose.pdf.logicalstructure/listlielement/).
+
+```csharp
+public ListLIElement CreateListLIElement()
+```
+
+### Valor devuelto
+
+Elemento de estructura creado.
+
+### Ver también
+
+* class [ListLIElement](../../../aspose.pdf.logicalstructure/listlielement/)
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.tagged/itaggedcontent/presave/_index.md
+++ b/spanish/net/aspose.pdf.tagged/itaggedcontent/presave/_index.md
@@ -1,0 +1,23 @@
+---
+title: "ITaggedContent.PreSave"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ITaggedContent. Prepara el contenido etiquetado del documento para guardarlo. Este método realiza las operaciones de pre-guardado necesarias, asegurando que el árbol de estructura y otros elementos de contenido etiquetado estén configurados correctamente antes de que el documento se guarde."
+type: docs
+weight: 410
+url: /es/net/aspose.pdf.tagged/itaggedcontent/presave/
+---
+## ITaggedContent.PreSave method
+
+Prepara el contenido etiquetado del documento para guardarlo. Este método realiza las operaciones de pre-guardado necesarias, asegurando que el árbol de estructura y otros elementos de contenido etiquetado estén configurados correctamente antes de que el documento se guarde.
+
+```csharp
+public void PreSave()
+```
+
+### Ver también
+
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.tagged/itaggedcontent/save/_index.md
+++ b/spanish/net/aspose.pdf.tagged/itaggedcontent/save/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ITaggedContent.Save"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método ITaggedContent. Guarda el estado actual del contenido etiquetado en el documento PDF asociado"
+type: docs
+weight: 420
+url: /es/net/aspose.pdf.tagged/itaggedcontent/save/
+---
+## ITaggedContent.Save method
+
+Guarda el estado actual del contenido etiquetado en el documento PDF asociado.
+
+```csharp
+public void Save()
+```
+
+## Observaciones
+
+Este método garantiza que todos los elementos de contenido etiquetado se actualicen y guarden correctamente dentro del documento PDF. Realiza las operaciones necesarias, como actualizar MCID para elementos MCR, establecer operadores BDC y asegurar el cumplimiento de los estándares PDF/UA.
+
+### Ver también
+
+* interface [ITaggedContent](../)
+* namespace [Aspose.Pdf.Tagged](../../../aspose.pdf.tagged/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/_index.md
+++ b/spanish/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Enum TextReplaceOptions.FontSizeAdjustment"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Enum Aspose.Pdf.Text.TextReplaceOptionsFontSizeAdjustment. Especifica una política sobre cómo se debe ajustar el tamaño de fuente del texto para que encaje dentro de un área contenedora"
+type: docs
+weight: 11200
+url: /es/net/aspose.pdf.text/textreplaceoptions.fontsizeadjustment/
+---
+## TextReplaceOptions.FontSizeAdjustment enumeration
+
+Especifica una política sobre cómo se debe ajustar el tamaño de fuente del texto para que encaje dentro de un área contenedora.
+
+```csharp
+public enum FontSizeAdjustment
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| None | `0` | El tamaño de fuente no se cambia. |
+| ShrinkToFit | `1` | El tamaño de fuente se reduce si el texto es demasiado grande para encajar en los límites. El tamaño de fuente nunca se incrementa si el texto es más pequeño que los límites. |
+| ScaleToFill | `2` | El tamaño de fuente se ajusta (reduciéndose y aumentándose) para que el texto llene los límites del rectángulo tanto como sea posible. |
+
+### Ver también
+
+* class [TextReplaceOptions](../textreplaceoptions/)
+* namespace [Aspose.Pdf.Text](../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/_index.md
+++ b/spanish/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextReplaceOptions.FontSizeAdjustmentAction"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad TextReplaceOptions. Obtiene o establece la política para ajustar el tamaño de fuente para que quepa dentro de los límites definidos por el Rectangle"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf.text/textreplaceoptions/fontsizeadjustmentaction/
+---
+## TextReplaceOptions.FontSizeAdjustmentAction property
+
+Obtiene o establece la política para ajustar el tamaño de fuente para que quepa dentro de los límites definidos por el [`Rectangle`](../rectangle/).
+
+```csharp
+public FontSizeAdjustment FontSizeAdjustmentAction { get; set; }
+```
+
+### Ver también
+
+* enum [FontSizeAdjustment](../../textreplaceoptions.fontsizeadjustment/)
+* class [TextReplaceOptions](../)
+* namespace [Aspose.Pdf.Text](../../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf.text/textreplaceoptions/rectangle/_index.md
+++ b/spanish/net/aspose.pdf.text/textreplaceoptions/rectangle/_index.md
@@ -1,0 +1,24 @@
+---
+title: "TextReplaceOptions.Rectangle"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad TextReplaceOptions. Obtiene o establece el rectángulo para ajustar el texto después del reemplazo"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf.text/textreplaceoptions/rectangle/
+---
+## TextReplaceOptions.Rectangle property
+
+Obtiene o establece el rectángulo para ajustar el texto después del reemplazo.
+
+```csharp
+public Rectangle Rectangle { get; set; }
+```
+
+### Ver también
+
+* class [Rectangle](../../../aspose.pdf/rectangle/)
+* class [TextReplaceOptions](../)
+* namespace [Aspose.Pdf.Text](../../../aspose.pdf.text/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Clase AutoTaggingSettings"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.AutoTaggingSettings. Proporciona configuraciones para la funcionalidad de auto-tagging en documentos PDF"
+type: docs
+weight: 2910
+url: /es/net/aspose.pdf/autotaggingsettings/
+---
+## AutoTaggingSettings class
+
+Proporciona configuraciones para la funcionalidad de auto-tagging en documentos PDF.
+
+```csharp
+public sealed class AutoTaggingSettings
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [AutoTaggingSettings](autotaggingsettings/)() | El constructor predeterminado. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| static [Default](../../aspose.pdf/autotaggingsettings/default/) { get; } | Obtiene la configuración predeterminada para la funcionalidad de auto-tagging en documentos PDF. |
+| [EnableAutoTagging](../../aspose.pdf/autotaggingsettings/enableautotagging/) { get; set; } | Obtiene o establece un valor que indica si la funcionalidad de auto-tagging está habilitada. |
+| [HeadingLevels](../../aspose.pdf/autotaggingsettings/headinglevels/) { get; set; } | Obtiene o establece los niveles de encabezado utilizados para determinar la estructura de los encabezados en un documento PDF. |
+| [HeadingRecognitionStrategy](../../aspose.pdf/autotaggingsettings/headingrecognitionstrategy/) { get; set; } | Obtiene o establece la estrategia utilizada para reconocer encabezados en el documento durante el auto-tagging. |
+
+## Observaciones
+
+La clase `AutoTaggingSettings` permite configurar opciones para el etiquetado automático del contenido PDF. Incluye propiedades para habilitar o deshabilitar el auto-tagging, especificar una estrategia de reconocimiento de encabezados y definir niveles de encabezado basados en los tamaños de fuente.
+
+### Ver también
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/autotaggingsettings/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/autotaggingsettings/_index.md
@@ -1,0 +1,23 @@
+---
+title: "AutoTaggingSettings.AutoTaggingSettings"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor de AutoTaggingSettings. El constructor predeterminado"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf/autotaggingsettings/autotaggingsettings/
+---
+## AutoTaggingSettings constructor
+
+El constructor predeterminado.
+
+```csharp
+public AutoTaggingSettings()
+```
+
+### Ver también
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/default/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/default/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AutoTaggingSettings.Default"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad AutoTaggingSettings. Obtiene la configuración predeterminada para la funcionalidad de autoetiquetado en documentos PDF"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf/autotaggingsettings/default/
+---
+## AutoTaggingSettings.Default property
+
+Obtiene la configuración predeterminada para la funcionalidad de auto-tagging en documentos PDF.
+
+```csharp
+public static AutoTaggingSettings Default { get; }
+```
+
+## Observaciones
+
+La configuración predeterminada habilita el autoetiquetado y utiliza la estrategia automática para el reconocimiento de encabezados. Estas configuraciones pueden usarse como una configuración base para la conversión de formato PDF u otras operaciones que requieran el etiquetado automático del contenido PDF.
+
+### Ver también
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/enableautotagging/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/enableautotagging/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AutoTaggingSettings.EnableAutoTagging"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad AutoTaggingSettings. Obtiene o establece un valor que indica si la funcionalidad de autoetiquetado está habilitada"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf/autotaggingsettings/enableautotagging/
+---
+## AutoTaggingSettings.EnableAutoTagging property
+
+Obtiene o establece un valor que indica si la funcionalidad de auto-tagging está habilitada.
+
+```csharp
+public bool EnableAutoTagging { get; set; }
+```
+
+## Observaciones
+
+Cuando está habilitado, la funcionalidad de autoetiquetado genera automáticamente contenido etiquetado para el documento PDF, lo que puede mejorar la accesibilidad y la estructura.
+
+### Ver también
+
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/headinglevels/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/headinglevels/_index.md
@@ -1,0 +1,28 @@
+---
+title: "AutoTaggingSettings.HeadingLevels"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad AutoTaggingSettings. Obtiene o establece los niveles de encabezado utilizados para determinar la estructura de los encabezados en un documento PDF"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf/autotaggingsettings/headinglevels/
+---
+## AutoTaggingSettings.HeadingLevels property
+
+Obtiene o establece los niveles de encabezado utilizados para determinar la estructura de los encabezados en un documento PDF.
+
+```csharp
+public HeadingLevels HeadingLevels { get; set; }
+```
+
+## Observaciones
+
+La propiedad `HeadingLevels` permite configurar el mapeo de tamaños de fuente a niveles de encabezado. Esto se utiliza durante el proceso de autoetiquetado para identificar y asignar los niveles de encabezado apropiados según el tamaño de fuente de los elementos de texto en el documento.
+
+### Ver también
+
+* class [HeadingLevels](../../headinglevels/)
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/_index.md
+++ b/spanish/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/_index.md
@@ -1,0 +1,28 @@
+---
+title: "AutoTaggingSettings.HeadingRecognitionStrategy"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad AutoTaggingSettings. Obtiene o establece la estrategia utilizada para reconocer encabezados en el documento durante el autoetiquetado"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf/autotaggingsettings/headingrecognitionstrategy/
+---
+## AutoTaggingSettings.HeadingRecognitionStrategy property
+
+Obtiene o establece la estrategia utilizada para reconocer encabezados en el documento durante el auto-tagging.
+
+```csharp
+public HeadingRecognitionStrategy HeadingRecognitionStrategy { get; set; }
+```
+
+## Observaciones
+
+La propiedad `HeadingRecognitionStrategy` determina cómo se identifican los encabezados en el documento. Las estrategias disponibles incluyen reconocer encabezados basados en esquemas, análisis heurístico o detección automática. Establecer esta propiedad a None desactiva el reconocimiento de encabezados.
+
+### Ver también
+
+* enum [HeadingRecognitionStrategy](../../headingrecognitionstrategy/)
+* class [AutoTaggingSettings](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/convertexception/_index.md
+++ b/spanish/net/aspose.pdf/convertexception/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Clase ConvertException"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.ConvertException. Representa errores que ocurren durante la conversión PDF_A con objetos auxiliares"
+type: docs
+weight: 3480
+url: /es/net/aspose.pdf/convertexception/
+---
+## ConvertException class
+
+Representa errores que ocurren durante la conversión PDF_A con objetos auxiliares.
+
+```csharp
+public sealed class ConvertException : PdfException
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [ConvertException](convertexception/#constructor)(string) | Inicializa una nueva instancia de la clase `ConvertException`. |
+| [ConvertException](convertexception/#constructor_1)(string, Exception) | Inicializa una nueva instancia de la clase `ConvertException`. |
+
+### Ver también
+
+* class [PdfException](../pdfexception/)
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf/convertexception/convertexception/_index.md
+++ b/spanish/net/aspose.pdf/convertexception/convertexception/_index.md
@@ -1,0 +1,48 @@
+---
+title: "ConvertException.ConvertException"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor de ConvertException. Inicializa una nueva instancia de la clase ConvertException"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf/convertexception/convertexception/
+---
+## ConvertException(string) {#constructor}
+
+Inicializa una nueva instancia de la clase [`ConvertException`](../).
+
+```csharp
+public ConvertException(string message)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | Cadena | El mensaje. |
+
+### Ver también
+
+* class [ConvertException](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## ConvertException(string, Exception) {#constructor_1}
+
+Inicializa una nueva instancia de la clase [`ConvertException`](../).
+
+```csharp
+public ConvertException(string message, Exception innerException)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | Cadena | El mensaje. |
+| innerException | Exception | La excepción que es la causa de la excepción actual, o una referencia nula (Nothing en Visual Basic) si no se especifica una excepción interna. |
+
+### Ver también
+
+* class [ConvertException](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/document/customsecurityhandler/_index.md
+++ b/spanish/net/aspose.pdf/document/customsecurityhandler/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Document.CustomSecurityHandler"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad Document. Obtiene un controlador de seguridad personalizado"
+type: docs
+weight: 90
+url: /es/net/aspose.pdf/document/customsecurityhandler/
+---
+## Document.CustomSecurityHandler property
+
+Obtiene un controlador de seguridad personalizado.
+
+```csharp
+public ICustomSecurityHandler CustomSecurityHandler { get; }
+```
+
+### Ver también
+
+* interface [ICustomSecurityHandler](../../../aspose.pdf.security/icustomsecurityhandler/)
+* class [Document](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/document/enablenotificationlogging/_index.md
+++ b/spanish/net/aspose.pdf/document/enablenotificationlogging/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Document.EnableNotificationLogging"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad Document. Obtiene o establece un valor que indica si se debe habilitar el registro de notificaciones"
+type: docs
+weight: 170
+url: /es/net/aspose.pdf/document/enablenotificationlogging/
+---
+## Document.EnableNotificationLogging property
+
+Obtiene o establece un valor que indica si se debe habilitar el registro de notificaciones.
+
+```csharp
+public bool EnableNotificationLogging { get; set; }
+```
+
+### Ver también
+
+* class [Document](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/headinglevels/_index.md
+++ b/spanish/net/aspose.pdf/headinglevels/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Clase HeadingLevels"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.HeadingLevels. Representa una clase para trabajar con niveles de encabezado basados en el tamaño de fuente"
+type: docs
+weight: 5600
+url: /es/net/aspose.pdf/headinglevels/
+---
+## HeadingLevels class
+
+Representa una clase para trabajar con niveles de encabezado basados en el tamaño de fuente.
+
+```csharp
+public class HeadingLevels
+```
+
+## Constructores
+
+| Nombre | Descripción |
+| --- | --- |
+| [HeadingLevels](headinglevels/#constructor)() | Crea una nueva instancia de la clase HeadingLevels. |
+| [HeadingLevels](headinglevels/#constructor_1)(double) | Crea una nueva instancia de la clase HeadingLevels. |
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [AllLevels](../../aspose.pdf/headinglevels/alllevels/) { get; } | Obtiene todos los niveles de encabezado. |
+
+## Métodos
+
+| Nombre | Descripción |
+| --- | --- |
+| [AddLevels](../../aspose.pdf/headinglevels/addlevels/)(ICollection&lt;double&gt;) | Añade niveles de encabezado. La colección de tamaños de fuente debe estar ordenada de mayor a menor. |
+
+### Ver también
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf/headinglevels/addlevels/_index.md
+++ b/spanish/net/aspose.pdf/headinglevels/addlevels/_index.md
@@ -1,0 +1,33 @@
+---
+title: "HeadingLevels.AddLevels"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método HeadingLevels. Añade niveles de encabezado. La colección de tamaños de fuente debe estar ordenada por tamaño descendente"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf/headinglevels/addlevels/
+---
+## HeadingLevels.AddLevels method
+
+Añade niveles de encabezado. La colección de tamaños de fuente debe estar ordenada de mayor a menor.
+
+```csharp
+public void AddLevels(ICollection<double> fontSizes)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSizes | ICollection`1 | Los valores deben estar ordenados en orden descendente. |
+
+### Excepciones
+
+| excepción | condición |
+| --- | --- |
+| ArgumentException | Si el valor no está ordenado o el valor es menor que uno. |
+
+### Ver también
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/headinglevels/alllevels/_index.md
+++ b/spanish/net/aspose.pdf/headinglevels/alllevels/_index.md
@@ -1,0 +1,23 @@
+---
+title: "HeadingLevels.AllLevels"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad HeadingLevels. Obtiene todos los niveles de encabezado"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf/headinglevels/alllevels/
+---
+## HeadingLevels.AllLevels property
+
+Obtiene todos los niveles de encabezado.
+
+```csharp
+public IList<double> AllLevels { get; }
+```
+
+### Ver también
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/headinglevels/headinglevels/_index.md
+++ b/spanish/net/aspose.pdf/headinglevels/headinglevels/_index.md
@@ -1,0 +1,43 @@
+---
+title: "HeadingLevels.HeadingLevels"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Constructor HeadingLevels. Crea una nueva instancia de la clase HeadingLevels"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf/headinglevels/headinglevels/
+---
+## HeadingLevels() {#constructor}
+
+Crea una nueva instancia de la clase HeadingLevels.
+
+```csharp
+public HeadingLevels()
+```
+
+### Ver también
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+---
+
+## HeadingLevels(double) {#constructor_1}
+
+Crea una nueva instancia de la clase HeadingLevels.
+
+```csharp
+public HeadingLevels(double threshold)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| threshold | Double | El valor de umbral para comparar tamaños de fuente. Dentro del umbral, los niveles de encabezado son los mismos. El valor predeterminado del umbral es 0,01. |
+
+### Ver también
+
+* class [HeadingLevels](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/license/clearlicense/_index.md
+++ b/spanish/net/aspose.pdf/license/clearlicense/_index.md
@@ -1,0 +1,23 @@
+---
+title: "License.ClearLicense"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método License. Borra la licencia actual"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf/license/clearlicense/
+---
+## License.ClearLicense method
+
+Borra la licencia actual.
+
+```csharp
+public void ClearLicense()
+```
+
+### Ver también
+
+* class [License](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/license/licenseinfo/_index.md
+++ b/spanish/net/aspose.pdf/license/licenseinfo/_index.md
@@ -1,0 +1,24 @@
+---
+title: "License.LicenseInfo"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad License. Obtiene la información de licencia actual"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf/license/licenseinfo/
+---
+## License.LicenseInfo property
+
+Obtiene la información de licencia actual.
+
+```csharp
+public LicenseInfo LicenseInfo { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../../licenseinfo/)
+* class [License](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/_index.md
@@ -1,0 +1,35 @@
+---
+title: "Clase LicenseInfo"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Clase Aspose.Pdf.LicenseInfo. Representa información de licencia"
+type: docs
+weight: 6230
+url: /es/net/aspose.pdf/licenseinfo/
+---
+## LicenseInfo class
+
+Representa información de licencia.
+
+```csharp
+public class LicenseInfo
+```
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| [EditionType](../../aspose.pdf/licenseinfo/editiontype/) { get; } | Obtiene el tipo de edición de la licencia. |
+| [EmailTo](../../aspose.pdf/licenseinfo/emailto/) { get; } | Obtiene la dirección de correo electrónico utilizada para la licencia. |
+| [LicensedTo](../../aspose.pdf/licenseinfo/licensedto/) { get; } | Obtiene la información sobre el licenciatario. |
+| [LicenseExpiry](../../aspose.pdf/licenseinfo/licenseexpiry/) { get; } | Obtiene la fecha de vencimiento de la licencia. |
+| [LicenseNote](../../aspose.pdf/licenseinfo/licensenote/) { get; } | Obtiene la nota de la licencia. |
+| [LicenseType](../../aspose.pdf/licenseinfo/licensetype/) { get; } | Obtiene el tipo de licencia. |
+| [Products](../../aspose.pdf/licenseinfo/products/) { get; } | Obtiene la lista de productos licenciados. |
+| [SubscriptionExpiry](../../aspose.pdf/licenseinfo/subscriptionexpiry/) { get; } | Obtiene la fecha de lanzamiento del ensamblado para la cual son posibles actualizaciones. |
+
+### Ver también
+
+* namespace [Aspose.Pdf](../../aspose.pdf/)
+* assembly [Aspose.PDF](../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/editiontype/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/editiontype/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.EditionType"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene el tipo de edición de la licencia"
+type: docs
+weight: 10
+url: /es/net/aspose.pdf/licenseinfo/editiontype/
+---
+## LicenseInfo.EditionType property
+
+Obtiene el tipo de edición de la licencia.
+
+```csharp
+public string EditionType { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/emailto/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/emailto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.EmailTo"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la dirección de correo electrónico utilizada para la licencia"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf/licenseinfo/emailto/
+---
+## LicenseInfo.EmailTo property
+
+Obtiene la dirección de correo electrónico utilizada para la licencia.
+
+```csharp
+public string EmailTo { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/licensedto/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/licensedto/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicensedTo"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la información sobre el licenciatario"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf/licenseinfo/licensedto/
+---
+## LicenseInfo.LicensedTo property
+
+Obtiene la información sobre el licenciatario.
+
+```csharp
+public string LicensedTo { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/licenseexpiry/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/licenseexpiry/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseExpiry"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la fecha de expiración de la licencia"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf/licenseinfo/licenseexpiry/
+---
+## LicenseInfo.LicenseExpiry property
+
+Obtiene la fecha de vencimiento de la licencia.
+
+```csharp
+public DateTime LicenseExpiry { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/licensenote/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/licensenote/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseNote"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la nota de la licencia"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf/licenseinfo/licensenote/
+---
+## LicenseInfo.LicenseNote property
+
+Obtiene la nota de la licencia.
+
+```csharp
+public string LicenseNote { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/licensetype/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/licensetype/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.LicenseType"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene el tipo de licencia"
+type: docs
+weight: 60
+url: /es/net/aspose.pdf/licenseinfo/licensetype/
+---
+## LicenseInfo.LicenseType property
+
+Obtiene el tipo de licencia.
+
+```csharp
+public string LicenseType { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/products/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/products/_index.md
@@ -1,0 +1,23 @@
+---
+title: "LicenseInfo.Products"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la lista de productos licenciados"
+type: docs
+weight: 70
+url: /es/net/aspose.pdf/licenseinfo/products/
+---
+## LicenseInfo.Products property
+
+Obtiene la lista de productos licenciados.
+
+```csharp
+public List<string> Products { get; }
+```
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/licenseinfo/subscriptionexpiry/_index.md
+++ b/spanish/net/aspose.pdf/licenseinfo/subscriptionexpiry/_index.md
@@ -1,0 +1,27 @@
+---
+title: "LicenseInfo.SubscriptionExpiry"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad LicenseInfo. Obtiene la fecha de lanzamiento del ensamblado a la que son posibles las actualizaciones"
+type: docs
+weight: 80
+url: /es/net/aspose.pdf/licenseinfo/subscriptionexpiry/
+---
+## LicenseInfo.SubscriptionExpiry property
+
+Obtiene la fecha de lanzamiento del ensamblado para la cual son posibles actualizaciones.
+
+```csharp
+public DateTime SubscriptionExpiry { get; }
+```
+
+## Observaciones
+
+No puede usar la licencia para la versión de los ensamblados con las fechas de ensamblado anteriores.
+
+### Ver también
+
+* class [LicenseInfo](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/_index.md
+++ b/spanish/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PdfFormatConversionOptions.AutoTaggingSettings"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad PdfFormatConversionOptions. Obtiene o establece la configuración para el etiquetado automático durante la conversión de formato PDF"
+type: docs
+weight: 40
+url: /es/net/aspose.pdf/pdfformatconversionoptions/autotaggingsettings/
+---
+## PdfFormatConversionOptions.AutoTaggingSettings property
+
+Obtiene o establece la configuración para el etiquetado automático durante la conversión de formato PDF.
+
+```csharp
+public AutoTaggingSettings AutoTaggingSettings { get; set; }
+```
+
+## Observaciones
+
+La configuración de etiquetado automático se utiliza para configurar el comportamiento del proceso de autoetiquetado, que normalmente se emplea para mejorar la accesibilidad y la estructura de un documento PDF durante la conversión a un formato PDF específico.
+
+### Ver también
+
+* class [AutoTaggingSettings](../../autotaggingsettings/)
+* class [PdfFormatConversionOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/psloadoptions/convertfontstottf/_index.md
+++ b/spanish/net/aspose.pdf/psloadoptions/convertfontstottf/_index.md
@@ -1,0 +1,23 @@
+---
+title: "PsLoadOptions.ConvertFontsToTTF"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad PsLoadOptions. Especifica si se deben guardar las fuentes nonTrueType en TTF. Reduce significativamente el volumen del documento resultante en la conversión de PS a PDF y aumenta la velocidad de conversión de archivos PS con una gran cantidad de texto en fuentes nonTrueType a cualquier formato de salida. Sin embargo, hay un pequeño desplazamiento vertical del texto al convertir un archivo PostSctipt a imagen"
+type: docs
+weight: 20
+url: /es/net/aspose.pdf/psloadoptions/convertfontstottf/
+---
+## PsLoadOptions.ConvertFontsToTTF property
+
+Especifica si se deben guardar las fuentes non-TrueType en TTF. Reduce significativamente el volumen del documento resultante en la conversión de PS a PDF y aumenta la velocidad de conversión de archivos PS con una gran cantidad de texto en fuentes non-TrueType a cualquier formato de salida. Sin embargo, hay un pequeño desplazamiento vertical del texto al convertir un archivo PostSctipt a imagen.
+
+```csharp
+public bool ConvertFontsToTTF { get; set; }
+```
+
+### Ver también
+
+* class [PsLoadOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/ximage/getalternativetext/_index.md
+++ b/spanish/net/aspose.pdf/ximage/getalternativetext/_index.md
@@ -1,0 +1,32 @@
+---
+title: "XImage.GetAlternativeText"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método XImage. Devuelve una lista de cadenas con Texto Alternativo para un XImage"
+type: docs
+weight: 100
+url: /es/net/aspose.pdf/ximage/getalternativetext/
+---
+## XImage.GetAlternativeText method
+
+Devuelve una lista de cadenas con Texto Alternativo para un XImage.
+
+```csharp
+public List<string> GetAlternativeText(Page page)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| página | Página | La página donde se encuentra el XImage. |
+
+### Valor devuelto
+
+Lista de cadenas con Texto Alternativo para un XImage.
+
+### Ver también
+
+* class [Page](../../page/)
+* class [XImage](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/ximage/trysetalternativetext/_index.md
+++ b/spanish/net/aspose.pdf/ximage/trysetalternativetext/_index.md
@@ -1,0 +1,37 @@
+---
+title: "XImage.TrySetAlternativeText"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Método XImage. Establece texto alternativo para un XImage en la página"
+type: docs
+weight: 180
+url: /es/net/aspose.pdf/ximage/trysetalternativetext/
+---
+## XImage.TrySetAlternativeText method
+
+Establece texto alternativo para un XImage en la página.
+
+```csharp
+public bool TrySetAlternativeText(string alternativeText, Page page)
+```
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| alternativeText | Cadena | El texto alternativo a especificar. |
+| página | Página | Página donde se encuentra el XImage. |
+
+### Valor devuelto
+
+True si alternativeText para XImage está establecido. False si alternativeText para XImage no está establecido.
+
+## Observaciones
+
+El método devuelve false en los siguientes casos: - El XImage no se encuentra en la página especificada. - El XImage aparece varias veces en la página con diferentes elementos estructurales, lo que hace ambiguo qué instancia debe recibir el texto alternativo.
+
+### Ver también
+
+* class [Page](../../page/)
+* class [XImage](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/xpssaveoptions/defaultfont/_index.md
+++ b/spanish/net/aspose.pdf/xpssaveoptions/defaultfont/_index.md
@@ -1,0 +1,23 @@
+---
+title: "XpsSaveOptions.DefaultFont"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad XpsSaveOptions. Obtiene/establece el nombre de la fuente predeterminada. Se usa si el nombre de la fuente incrustada no se encuentra en el sistema"
+type: docs
+weight: 30
+url: /es/net/aspose.pdf/xpssaveoptions/defaultfont/
+---
+## XpsSaveOptions.DefaultFont property
+
+Obtiene/establece el nombre de la fuente predeterminada. Se usa si el nombre de la fuente incrustada no se encuentra en el sistema.
+
+```csharp
+public string DefaultFont { get; set; }
+```
+
+### Ver también
+
+* class [XpsSaveOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+

--- a/spanish/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/_index.md
+++ b/spanish/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/_index.md
@@ -1,0 +1,23 @@
+---
+title: "XpsSaveOptions.UseEmbeddedTrueTypeFonts"
+second_title: "Aspose.PDF para .NET Referencia de API"
+description: "Propiedad XpsSaveOptions. Obtiene/establece la bandera para usar fuentes TrueType incrustadas. Evitar el uso de fuentes TrueType incrustadas puede reducir el tiempo de conversión"
+type: docs
+weight: 50
+url: /es/net/aspose.pdf/xpssaveoptions/useembeddedtruetypefonts/
+---
+## XpsSaveOptions.UseEmbeddedTrueTypeFonts property
+
+Obtiene/establece la bandera para usar fuentes TrueType incrustadas. Evitar el uso de fuentes TrueType incrustadas puede reducir el tiempo de conversión.
+
+```csharp
+public bool UseEmbeddedTrueTypeFonts { get; set; }
+```
+
+### Ver también
+
+* class [XpsSaveOptions](../)
+* namespace [Aspose.Pdf](../../../aspose.pdf/)
+* assembly [Aspose.PDF](../../../)
+
+


### PR DESCRIPTION
🔄 **In progress** — incremental translation of NET API Reference to **Spanish** (`es`).

Updated at each cache checkpoint. Source: `english/net`

🤖 Generated by RDA