### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Japanese

### DIFF
--- a/japanese/nodejs-cpp/_index.md
+++ b/japanese/nodejs-cpp/_index.md
@@ -1,0 +1,134 @@
+---
+title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "C++ 経由で Node.js 用 Aspose.PDF"
+keywords:  "Node.js, Node, JavaScript, JS, PDF, PDF toolkit"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /ja/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Node.js via C++ allows developers manipulate them PDF files directly in the Node.js.
+
+
+## Convert from PDF functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposePdfPagesToJpg](./convert/asposepdfpagestojpg/) | PDF ファイルを JPG に変換します。 |
+| [AsposePdfPagesToPng](./convert/asposepdfpagestopng/) | PDF ファイルを PNG に変換します。 |
+| [AsposePdfPagesToTiff](./convert/asposepdfpagestotiff/) | PDF ファイルを TIFF に変換します。 |
+| [AsposePdfPagesToBmp](./convert/asposepdfpagestobmp/) | PDF ファイルを BMP に変換します。 |
+| [AsposePdfPagesToDICOM](./convert/asposepdfpagestodicom/) | PDF ファイルを DICOM に変換します。 |
+| [AsposePdfPagesToSvg](./convert/asposepdfpagestosvg/) | PDF ファイルを SVG に変換します。 |
+| [AsposePdfPagesToSvgZip](./convert/asposepdfpagestosvgzip/) | PDF ファイルを SVG(zip) に変換します。 |
+| [AsposePdfToTeX](./convert/asposepdftotex/) | PDF ファイルを TeX に変換します。 |
+| [AsposePdfToXps](./convert/asposepdftoxps/) | PDF ファイルを Xps に変換します。 |
+| [AsposePdfTablesToCSV](./convert/asposepdftablestocsv/) | PDF ファイルを CSV（テーブルを抽出）に変換します。 |
+| [AsposePdfToTxt](./convert/asposepdftotxt/) | PDF ファイルを Txt に変換します。 |
+| [AsposePdfConvertToGrayscale](./convert/asposepdfconverttograyscale/) | PDF ファイルをグレースケールに変換します。 |
+| [AsposePdfConvertToPDFA](./convert/asposepdfconverttopdfa/) | PDF ファイルを PDF/A に変換します。 |
+| [AsposePdfAConvertToPDF](./convert/asposepdfaconverttopdf/) | PDF/A ファイルを PDF に変換します。 |
+| [AsposePdfToDocX](./convert/asposepdftodocx/) | PDF ファイルを DocX に変換します。 |
+| [AsposePdfToXlsX](./convert/asposepdftoxlsx/) | PDF ファイルを XlsX に変換します。 |
+| [AsposePdfToEPUB](./convert/asposepdftoepub/) | PDF ファイルを ePub に変換します。 |
+| [AsposePdfToDoc](./convert/asposepdftodoc/) | PDF ファイルを Doc に変換します。 |
+| [AsposePdfToPptX](./convert/asposepdftopptx/) | PDF ファイルを PptX に変換します。 |
+| [AsposePdfExtractText](./convert/asposepdfextracttext/) | PDF ファイルからテキストを抽出します。 |
+| [AsposePdfExtractImage](./convert/asposepdfextractimage/) | PDF ファイルから画像を抽出します。 |
+| [AsposePdfExportFdf](./convert/asposepdfexportfdf/) | AcroForm を含む PDF ファイルを FDF にエクスポートします。 |
+| [AsposePdfExportXfdf](./convert/asposepdfexportxfdf/) | AcroForm を含む PDF ファイルを XFDF にエクスポートします。 |
+| [AsposePdfExportXml](./convert/asposepdfexportxml/) | AcroForm を含む PDF ファイルを XML にエクスポートします。 |
+| [AsposePdfPagesToPDF](./convert/asposepdfpagestopdf/) | PDF ファイルを PDF（個別ページ）に変換します。 |
+| [AsposePdfToMarkdown](./convert/asposepdftomarkdown/) | PDF ファイルを Markdown に変換します。 |
+| [AsposePdfToDocXEnhanced](./convert/asposepdftodocxenhanced/) | PDF ファイルを拡張認識モードで DocX に変換します。 |
+
+
+## Convert to PDF functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposePdfFromTxt](./convertpdf/asposepdffromtxt/) | TXT ファイルを PDF に変換します。 |
+| [AsposePdfFromImage](./convertpdf/asposepdffromimage/) | 画像ファイルを PDF に変換します。 |
+
+
+## Organize PDF functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposePdfOptimize](./organize/asposepdfoptimize/) | PDF ファイルを最適化します。 |
+| [AsposePdfMerge2Files](./organize/asposepdfmerge2files/) | 2 つの PDF ファイルを結合します。 |
+| [AsposePdfSplit2Files](./organize/asposepdfsplit2files/) | PDF を 2 つのファイルに分割します。 |
+| [AsposePdfRotateAllPages](./organize/asposepdfrotateallpages/) | PDF ページを回転します。 |
+| [AsposePdfDeletePages](./organize/asposepdfdeletepages/) | PDF ファイルからページを削除します。 |
+| [AsposePdfAddStamp](./organize/asposepdfaddstamp/) | PDF ファイルにスタンプを追加します。 |
+| [AsposePdfAddStampPages](./organize/asposepdfaddstamppages/) | PDF ファイルの特定ページにスタンプを追加します。 |
+| [AsposePdfAddImage](./organize/asposepdfaddimage/) | PDF ファイルの末尾に画像を追加します。 |
+| [AsposePdfAddPageNum](./organize/asposepdfaddpagenum/) | PDF ファイルにページ番号を追加します。 |
+| [AsposePdfAddBackgroundImage](./organize/asposepdfaddbackgroundimage/) | PDF ファイルに背景画像を追加します。 |
+| [AsposePdfAddTextHeaderFooter](./organize/asposepdfaddtextheaderfooter/) | PDF ファイルのヘッダー/フッターにテキストを追加します。 |
+| [AsposePdfRepair](./organize/asposepdfrepair/) | PDF ファイルを修復します。 |
+| [AsposePdfOptimizeResource](./organize/asposepdfoptimizeresource/) | PDF ファイルのリソースを最適化します。 |
+| [AsposePdfSetBackgroundColor](./organize/asposepdfsetbackgroundcolor/) | PDF ファイルの背景色を設定します。 |
+| [AsposePdfDeleteAnnotations](./organize/asposepdfdeleteannotations/) | PDF ファイルから注釈を削除します。 |
+| [AsposePdfDeleteBookmarks](./organize/asposepdfdeletebookmarks/) | PDF ファイルからブックマークを削除します。 |
+| [AsposePdfDeleteAttachments](./organize/asposepdfdeleteattachments/) | PDF ファイルから添付ファイルを削除します。 |
+| [AsposePdfDeleteImages](./organize/asposepdfdeleteimages/) | PDF ファイルから画像を削除します。 |
+| [AsposePdfDeleteJavaScripts](./organize/asposepdfdeletejavascripts/) | PDF ファイルから JavaScript を削除する。 |
+| [AsposePdfAddAttachment](./organize/asposepdfaddattachment/) | PDF ファイルに添付ファイルを追加する。 |
+| [AsposePdfGetAttachment](./organize/asposepdfgetattachment/) | PDF ファイルから添付ファイルを取得する。 |
+| [AsposePdfReplaceText](./organize/asposepdfreplacetext/) | PDF ファイル内のテキストを置換する。 |
+| [AsposePdfReplaceTextPages](./organize/asposepdfreplacetextpages/) | PDF ファイルのページ上のテキストを置換する。 |
+| [AsposePdfFindText](./organize/asposepdffindtext/) | PDF ファイル内のテキストを検索する。 |
+| [AsposePdfReplaceFont](./organize/asposepdfreplacefont/) | PDF ファイル内のフォントを置換する。 |
+| [AsposePdfValidatePDFA](./organize/asposepdfvalidatepdfa/) | PDF ファイルの PDF/A 互換性を検証する。 |
+| [AsposePdfFindHiddenText](./organize/asposepdffindhiddentext/) | PDF ファイル内の非表示テキストを検索する。 |
+| [AsposePdfDeleteHiddenText](./organize/asposepdfdeletehiddentext/) | PDF ファイルから非表示テキストを削除する。 |
+| [AsposePdfAddWatermark](./organize/asposepdfaddwatermark/) | PDF ファイルに透かしを追加する。 |
+| [AsposePdfDeleteWatermarks](./organize/asposepdfdeletewatermarks/) | PDF ファイルから透かしを削除する。 |
+| [AsposePdfMergeLayers](./organize/asposepdfmergelayers/) | PDF ファイルのレイヤーを結合する。 |
+| [AsposePdfFlatten](./organize/asposepdfflatten/) | PDF ファイルをフラット化する。 |
+| [AsposePdfMakeBooklet](./organize/asposepdfmakebooklet/) | PDF ファイルから小冊子を作成する。 |
+| [AsposePdfMakeNUp](./organize/asposepdfmakenup/) | PDF ファイルから N-Up ドキュメントを作成する。 |
+| [AsposePdfDeleteBlankPages](./organize/asposepdfdeleteblankpages/) | PDF ファイルから空白ページを削除する。 |
+| [AsposePdfEmbedFonts](./organize/asposepdfembedfonts/) | PDF ファイルにフォントを埋め込む。 |
+| [AsposePdfUnembedFonts](./organize/asposepdfunembedfonts/) | PDF ファイルからフォントの埋め込みを解除する。 |
+| [AsposePdfOptimizeFileSize](./organize/asposepdfoptimizefilesize/) | 画像圧縮品質で PDF ファイルのサイズを最適化する。 |
+| [AsposePdfDeleteTables](./organize/asposepdfdeletetables/) | PDF ファイルから表を削除する。 |
+| [AsposePdfCropPages](./organize/asposepdfcroppages/) | PDF ページをトリミングする。 |
+| [AsposePdfDeleteTextHeaders](./organize/asposepdfdeletetextheaders/) | PDF ファイルからテキストヘッダーを削除する。 |
+| [AsposePdfDeleteTextFooters](./organize/asposepdfdeletetextfooters/) | PDF ファイルからテキストフッターを削除する。 |
+| [AsposePdfReplaceTextEx](./organize/asposepdfreplacetextex/) | PDF ファイル内の複数のテキストフラグメントを配置制御付きで置換する。 |
+| [AsposePdfRecover](./organize/asposepdfrecover/) | PDFファイルの構造を復元し、無効なデータをトリムします。 |
+| [AsposePdfRebuildXrefAndTrailer](./organize/asposepdfrebuildxrefandtrailer/) | PDFファイルのクロスリファレンステーブルとトレーラ構造を再構築します。 |
+| [AsposePdfReversePages](./organize/asposepdfreversepages/) | PDFファイルのページ順序を逆にします。 |
+
+
+## Metadata PDF functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposePdfSetInfo](./metadata/asposepdfsetinfo/) | PDFファイルに情報（メタデータ）を設定します。 |
+| [AsposePdfGetInfo](./metadata/asposepdfgetinfo/) | PDFファイルから情報（メタデータ）を取得します。 |
+| [AsposePdfGetAllFonts](./metadata/asposepdfgetallfonts/) | PDFファイルからフォントの一覧を取得します。 |
+| [AsposePdfRemoveMetadata](./metadata/asposepdfremovemetadata/) | PDFファイルからメタデータを削除します。 |
+| [AsposePdfGetWordsCharactersCount](./metadata/asposepdfgetwordscharacterscount/) | PDFファイル内の単語数と文字数を取得します。 |
+| [AsposePdfGetPagesLayers](./metadata/asposepdfgetpageslayers/) | PDFファイルからレイヤーの一覧を取得します。 |
+
+
+## Security PDF functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposePdfEncrypt](./security/asposepdfencrypt/) | PDFファイルを暗号化します。 |
+| [AsposePdfDecrypt](./security/asposepdfdecrypt/) | PDFファイルを復号化します。 |
+| [AsposePdfSignPKCS7](./security/asposepdfsignpkcs7/) | PDFファイルにデジタル署名で署名します。 |
+| [AsposePdfSignPKCS7Detached](./security/asposepdfsignpkcs7detached/) | PDFファイルに分離型デジタル署名で署名します。 |
+| [AsposePdfChangePassword](./security/asposepdfchangepassword/) | PDFファイルのパスワードを変更します。 |
+
+## Miscellaneous
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfAbout](./misc/asposepdfabout/) | 製品に関する情報を取得します。 |

--- a/japanese/nodejs-cpp/convert/_index.md
+++ b/japanese/nodejs-cpp/convert/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PDF から変換する関数"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから変換するための関数です。"
+type: docs
+url: /ja/nodejs-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfPagesToJpg](./asposepdfpagestojpg/) | PDF ファイルを JPG に変換します。 |
+| [AsposePdfPagesToPng](./asposepdfpagestopng/) | PDF ファイルを PNG に変換します。 |
+| [AsposePdfPagesToTiff](./asposepdfpagestotiff/) | PDF ファイルを TIFF に変換します。 |
+| [AsposePdfPagesToBmp](./asposepdfpagestobmp/) | PDF ファイルを BMP に変換します。 |
+| [AsposePdfPagesToDICOM](./asposepdfpagestodicom/) | PDF ファイルを DICOM に変換します。 |
+| [AsposePdfPagesToSvg](./asposepdfpagestosvg/) | PDF ファイルを SVG に変換します。 |
+| [AsposePdfPagesToSvgZip](./asposepdfpagestosvgzip/) | PDF ファイルを SVG(zip) に変換します。 |
+| [AsposePdfToTeX](./asposepdftotex/) | PDF ファイルを TeX に変換します。 |
+| [AsposePdfToXps](./asposepdftoxps/) | PDF ファイルを Xps に変換します。 |
+| [AsposePdfTablesToCSV](./asposepdftablestocsv/) | PDF ファイルを CSV（テーブルを抽出）に変換します。 |
+| [AsposePdfToTxt](./asposepdftotxt/) | PDF ファイルを Txt に変換します。 |
+| [AsposePdfConvertToGrayscale](./asposepdfconverttograyscale/) | PDF ファイルをグレースケールに変換します。 |
+| [AsposePdfConvertToPDFA](./asposepdfconverttopdfa/) | PDF ファイルを PDF/A に変換します。 |
+| [AsposePdfAConvertToPDF](./asposepdfaconverttopdf/) | PDF/A ファイルを PDF に変換します。 |
+| [AsposePdfToDocX](./asposepdftodocx/) | PDF ファイルを DocX に変換します。 |
+| [AsposePdfToXlsX](./asposepdftoxlsx/) | PDF ファイルを XlsX に変換します。 |
+| [AsposePdfToEPUB](./asposepdftoepub/) | PDF ファイルを ePub に変換します。 |
+| [AsposePdfToDoc](./asposepdftodoc/) | PDF ファイルを Doc に変換します。 |
+| [AsposePdfToPptX](./asposepdftopptx/) | PDF ファイルを PptX に変換します。 |
+| [AsposePdfExtractText](./asposepdfextracttext/) | PDF ファイルからテキストを抽出します。 |
+| [AsposePdfExtractImage](./asposepdfextractimage/) | PDF ファイルから画像を抽出します。 |
+| [AsposePdfExportFdf](./asposepdfexportfdf/) | AcroForm を含む PDF ファイルを FDF にエクスポートします。 |
+| [AsposePdfExportXfdf](./asposepdfexportxfdf/) | AcroForm を含む PDF ファイルを XFDF にエクスポートします。 |
+| [AsposePdfExportXml](./asposepdfexportxml/) | AcroForm を含む PDF ファイルを XML にエクスポートします。 |
+| [AsposePdfPagesToPDF](./asposepdfpagestopdf/) | PDF ファイルを PDF（個別ページ）に変換します。 |
+| [AsposePdfToMarkdown](./asposepdftomarkdown/) | PDF ファイルを Markdown に変換します。 |
+| [AsposePdfToDocXEnhanced](./asposepdftodocxenhanced/) | PDF ファイルを拡張認識モードで DocX に変換します。 |
+
+
+## Detailed Description
+
+PDF ファイルから変換するための関数です。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfAConvertToPDF"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF/A ファイルを PDF に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfaconverttopdf/
+---
+
+_PDF/AファイルをPDFに変換します._
+
+```js
+function AsposePdfAConvertToPDF(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+    const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+    console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+/*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfConvertToGrayscale"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルをグレースケールに変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfconverttograyscale/
+---
+
+_PDFファイルをグレースケールに変換します._
+
+```js
+function AsposePdfConvertToGrayscale(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+    const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+    console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposePdfConvertToPDFA"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを PDF/A に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfconverttopdfa/
+---
+
+_PDFファイルをPDF/Aに変換します._
+
+```js
+function AsposePdfConvertToPDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult,
+    fileNameLogResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name
+* **fileNameLogResult** result Log (xml) file name
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+  * **fileNameLogResult** - result Log (xml) file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+    /*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+    console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+/*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfexportfdf/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfexportfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportFdf"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "AcroForm を含む PDF ファイルを FDF にエクスポートします。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfexportfdf/
+---
+
+_AcroForm を使用した PDF ファイルから FDF にエクスポートします._
+
+```js
+function AsposePdfExportFdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+    const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+    console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXfdf"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "AcroForm を含む PDF ファイルを XFDF にエクスポートします。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfexportxfdf/
+---
+
+_AcroForm を使用した PDF ファイルから XFDF にエクスポートします._
+
+```js
+function AsposePdfExportXfdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+    const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+    console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfexportxml/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfexportxml/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXml"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "AcroForm を含む PDF ファイルを XML にエクスポートします。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfexportxml/
+---
+
+_AcroForm を使用した PDF ファイルから XML にエクスポートします._
+
+```js
+function AsposePdfExportXml(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+    const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+    console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfextractimage/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfextractimage/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfExtractImage"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから画像を抽出します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfextractimage/
+---
+
+_PDFファイルから画像を抽出します._
+
+```js
+function AsposePdfExtractImage(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfExtractImage{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - image files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+    console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfextracttext/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfextracttext/_index.md
@@ -1,0 +1,48 @@
+---
+title: "AsposePdfExtractText"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからテキストを抽出します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfextracttext/
+---
+
+_PDF ファイルからテキストを抽出します。_
+
+```js
+function AsposePdfExtractText(
+    fileName 
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **extractText** - text from PDF
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract text from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+    console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract text from a PDF-file*/
+const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToBmp"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを BMP に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestobmp/
+---
+
+_PDF ファイルを BMP に変換します._
+
+```
+function AsposePdfPagesToBmp(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToBmp{0:D2}.bmp" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - bmp files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+    console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToDICOM"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを DICOM に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestodicom/
+---
+
+_PDFファイルをDICOMに変換します._
+
+```js
+function AsposePdfPagesToDICOM(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToDICOM{0:D2}.dcm" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - DICOM (.dcm) files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+    console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToJpg"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを JPG に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestojpg/
+---
+
+_PDF ファイルを JPG に変換します。_
+
+```js
+function AsposePdfPagesToJpg(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToJpg{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - jpg files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+    console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToPDF"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを PDF（個別ページ）に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestopdf/
+---
+
+_PDF ファイルを PDF に変換します（ページごとに分割）。_
+
+```
+function AsposePdfPagesToPDF(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfPagesToPDF{0:D2}.pdf" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - result files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+    console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestopng/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestopng/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToPng"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを PNG に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestopng/
+---
+
+_PDFファイルをPNGに変換します._
+
+```
+function AsposePdfPagesToPng(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToPng{0:D2}.png" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+    console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToSvg"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを SVG に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestosvg/
+---
+
+_PDF ファイルを SVG に変換します._
+
+```
+function AsposePdfPagesToSvg(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+    console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
@@ -1,0 +1,50 @@
+---
+title: "AsposePdfPagesToSvgZip"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを SVG(zip) に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestosvgzip/
+---
+
+_PDF ファイルを SVG（zip）に変換します._
+
+```
+function AsposePdfPagesToSvgZip(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG(zip) and save the "ResultPdfToSvgZip.zip"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+    console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*convert a PDF-file to SVG zip and save the "ResultPdfToSvgZip.zip"*/
+const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText)
+```

--- a/japanese/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToTiff"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを TIFF に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdfpagestotiff/
+---
+
+_PDFファイルをTIFFに変換します._
+
+```
+function AsposePdfPagesToTiff(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToTiff{0:D2}.tiff" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - tiff files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+    console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftablestocsv/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftablestocsv/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfTablesToCSV"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを CSV（テーブルを抽出）に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftablestocsv/
+---
+
+_PDFファイルをCSVに変換します（テーブルを抽出）。_
+
+```
+function AsposePdfTablesToCSV(
+    fileName,
+    fileNameResult,
+    delimiter
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfTablesToCSV{0:D2}.csv" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **delimiter** delimiter for csv (comma-separated value), default ";"
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - csv files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+    const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+    console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftodoc/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftodoc/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDoc"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを Doc に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftodoc/
+---
+
+_PDFファイルをDocに変換します._
+
+```js
+function AsposePdfToDoc(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+    const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+    console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftodocx/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftodocx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocX"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを DocX に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftodocx/
+---
+
+_PDFファイルをDocXに変換します._
+
+```js
+function AsposePdfToDocX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+    console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocXEnhanced"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを拡張認識モードで DocX に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftodocxenhanced/
+---
+
+_PDF ファイルを拡張認識モード（完全に編集可能な表と段落）で DocX に変換します。_
+
+```js
+function AsposePdfToDocXEnhanced(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+    console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftoepub/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftoepub/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToEPUB"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを ePub に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftoepub/
+---
+
+_PDFファイルをePubに変換します._
+
+```js
+function AsposePdfToEPUB(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+    const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+    console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftomarkdown/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftomarkdown/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToMarkdown"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを Markdown に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftomarkdown/
+---
+
+_PDFファイルをMarkdownに変換します._
+
+```js
+function AsposePdfToMarkdown(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+    const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+    console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftopptx/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftopptx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToPptX"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを PptX に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftopptx/
+---
+
+_PDF ファイルを PptX に変換します._
+
+```js
+function AsposePdfToPptX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+    const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+    console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftotex/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftotex/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTeX"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを TeX に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftotex/
+---
+
+_PDFファイルをTeXに変換します._
+
+```js
+function AsposePdfToTeX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+    const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+    console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftotxt/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftotxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTxt"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを Txt に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftotxt/
+---
+
+_PDF ファイルを Txt に変換します._
+
+```js
+function AsposePdfToTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+    const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+    console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftoxlsx/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftoxlsx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXlsX"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを XlsX に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftoxlsx/
+---
+
+_PDF ファイルを XlsX に変換します._
+
+```js
+function AsposePdfToXlsX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+    const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+    console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convert/asposepdftoxps/_index.md
+++ b/japanese/nodejs-cpp/convert/asposepdftoxps/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXps"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを Xps に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convert/asposepdftoxps/
+---
+
+_PDF ファイルを Xps に変換します._
+
+```js
+function AsposePdfToXps(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+    const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+    console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convertpdf/_index.md
+++ b/japanese/nodejs-cpp/convertpdf/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PDF 変換機能"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルに変換するための関数。"
+type: docs
+url: /ja/nodejs-cpp/convertpdf/
+---
+
+## Convert to PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfFromTxt](./asposepdffromtxt/) | TXT ファイルを PDF に変換します。 |
+| [AsposePdfFromImage](./asposepdffromimage/) | 画像ファイルを PDF に変換します。 |
+
+## Detailed Description
+
+PDF ファイルに変換するための関数。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
+++ b/japanese/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfFromImage"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "画像ファイルを PDF に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convertpdf/asposepdffromimage/
+---
+
+_画像ファイルをPDFに変換します._
+
+```js
+function AsposePdfFromImage(
+    fileName,
+    pdfPageSize,
+    margin,
+    isLandscape,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** image file name (support bmp, jpeg, png, tiff, gif formats)
+* **pdfPageSize**  page size:
+  * Module.PdfPageSize.A0
+  * Module.PdfPageSize.A1
+  * Module.PdfPageSize.A2
+  * Module.PdfPageSize.A3
+  * Module.PdfPageSize.A4
+  * Module.PdfPageSize.A5
+  * Module.PdfPageSize.A6
+  * Module.PdfPageSize.B5
+  * Module.PdfPageSize.PageLetter
+  * Module.PdfPageSize.PageLegal
+  * Module.PdfPageSize.PageLedger
+  * Module.PdfPageSize.P11x17
+  * Module.PdfPageSize.ImageSize
+* **margin** page margin
+* **isLandscape** page landscape mode (0 or 1)
+* **fileNameResult** result file name
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const aspose_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+    console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const aspose_file = 'Aspose.jpg';
+/*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
+++ b/japanese/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFromTxt"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "TXT ファイルを PDF に変換します。"
+type: docs
+url: /ja/nodejs-cpp/convertpdf/asposepdffromtxt/
+---
+
+_TXTファイルをPDFに変換します._
+
+```js
+function AsposePdfFromTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+    console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const txt_file = 'ReadMe.txt';
+/*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/_index.md
+++ b/japanese/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,35 @@
+---
+title: "メタデータ PDF 関数"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "メタデータ PDF ファイルを操作するための関数"
+type: docs
+url: /ja/nodejs-cpp/metadata/
+---
+
+## Metadata PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfSetInfo](./asposepdfsetinfo/) | PDFファイルに情報（メタデータ）を設定します。 |
+| [AsposePdfGetInfo](./asposepdfgetinfo/) | PDFファイルから情報（メタデータ）を取得します。 |
+| [AsposePdfGetAllFonts](./asposepdfgetallfonts/) | PDFファイルからフォントの一覧を取得します。 |
+| [AsposePdfRemoveMetadata](./asposepdfremovemetadata/) | PDFファイルからメタデータを削除します。 |
+| [AsposePdfGetWordsCharactersCount](./asposepdfgetwordscharacterscount/) | PDFファイル内の単語数と文字数を取得します。 |
+| [AsposePdfGetPagesLayers](./asposepdfgetpageslayers/) | PDFファイルからレイヤーの一覧を取得します。 |
+
+
+## Detailed Description
+
+メタデータ PDF ファイルを操作するための関数です。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePdfGetAllFonts"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルからフォントの一覧を取得します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfgetallfonts/
+---
+
+_PDF ファイルからフォントの一覧を取得します。_
+
+```js
+function AsposePdfGetAllFonts(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fonts** - array of : 
+  * fontName - font name
+  * isEmbedded - indicates whether the font is embedded
+  * isAccessible - indicating whether the font is present
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list fonts from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+    /*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+    console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list fonts from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+/*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
@@ -1,0 +1,123 @@
+---
+title: "AsposePdfGetInfo"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルから情報（メタデータ）を取得します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfgetinfo/
+---
+
+_PDF ファイルから情報 (メタデータ) を取得します。_
+
+```js
+function AsposePdfGetInfo(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **title** - title
+* **creator** - creator
+* **author** - author
+* **subject** - subject
+* **keywords** - keywords
+* **creation** - creation date
+* **mod** - modify date
+* **format** - PDF format
+* **version** - PDF version
+* **ispdfa** - PDF is PDF/A
+* **ispdfua** - PDF is PDF/UA
+* **islinearized** - PDF is linearized
+* **isencrypted** - PDF is encrypted
+* **permission** - PDF permission
+* **size** - PDF page size
+* **pagecount** - Page count
+* **annotationcount** - Annotation count
+* **bookmarkcount** - Bookmark count
+* **attachmentcount** - Attachment count
+* **metadatacount** - Metadata count
+* **javascriptcount** - JavaScript count
+* **imagecount** - Image count
+* **tablecount** - Table count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get info (metadata) from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+    /* JSON
+       Title             : json.title
+       Creator           : json.creator
+       Author            : json.author
+       Subject           : json.subject
+       Keywords          : json.keywords
+       Creation Date     : json.creation
+       Modify Date       : json.mod
+       PDF format        : json.format
+       PDF version       : json.version
+       PDF is PDF/A      : json.ispdfa
+       PDF is PDF/UA     : json.ispdfua
+       PDF is linearized : json.islinearized
+       PDF is encrypted  : json.isencrypted
+       PDF permission    : json.permission
+       PDF page size     : json.size
+       Page count        : json.pagecount
+       Annotation count  : json.annotationcount
+       Bookmark count    : json.bookmarkcount
+       Attachment count  : json.attachmentcount
+       Metadata count    : json.metadatacount
+       JavaScript count  : json.javascriptcount
+       Image count       : json.imagecount
+       Table count       : json.tablecount
+    */
+    console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get info (metadata) from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+/* JSON
+   Title             : json.title
+   Creator           : json.creator
+   Author            : json.author
+   Subject           : json.subject
+   Keywords          : json.keywords
+   Creation Date     : json.creation
+   Modify Date       : json.mod
+   PDF format        : json.format
+   PDF version       : json.version
+   PDF is PDF/A      : json.ispdfa
+   PDF is PDF/UA     : json.ispdfua
+   PDF is linearized : json.islinearized
+   PDF is encrypted  : json.isencrypted
+   PDF permission    : json.permission
+   PDF page size     : json.size
+   Page count        : json.pagecount
+   Annotation count  : json.annotationcount
+   Bookmark count    : json.bookmarkcount
+   Attachment count  : json.attachmentcount
+   Metadata count    : json.metadatacount
+   JavaScript count  : json.javascriptcount
+   Image count       : json.imagecount
+   Table count       : json.tablecount
+*/
+console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfGetPagesLayers"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルからレイヤーの一覧を取得します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfgetpageslayers/
+---
+
+_PDF ファイルからレイヤーの一覧を取得します。_
+
+```js
+function AsposePdfGetPagesLayers(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **pagesLayers[][]** - list of pages with lists of layers on each page
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list layers from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+    /*json.pagesLayers - list of pages with lists of layers on each page*/
+    console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list layers from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+/*json.pagesLayers - list of pages with lists of layers on each page*/
+console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposePdfGetWordsCharactersCount"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイル内の単語数と文字数を取得します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/
+---
+
+_PDF ファイル内の単語数と文字数を取得します。_
+
+```js
+function AsposePdfGetWordsCharactersCount(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **words** - words count
+* **characters** - characters count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get words and characters count in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+    /* JSON
+       Words count      : json.words
+       Characters count : json.characters
+    */
+    console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get words and characters count in a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+/* JSON
+   Words count      : json.words
+   Characters count : json.characters
+*/
+console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRemoveMetadata"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルからメタデータを削除します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfremovemetadata/
+---
+
+_PDF ファイルからメタデータを削除します。_
+
+```js
+function AsposePdfRemoveMetadata(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+    const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+    console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
+++ b/japanese/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfSetInfo"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルに情報（メタデータ）を設定します。"
+type: docs
+url: /ja/nodejs-cpp/metadata/asposepdfsetinfo/
+---
+
+_PDF ファイルに情報 (メタデータ) を設定します。_
+
+```js
+function AsposePdfSetInfo(
+    fileName,
+    title, 
+    creator, 
+    author,
+    subject,
+    keywords,
+    creation,
+    mod,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **title** title
+* **creator** creator
+* **author** author
+* **subject** subject
+* **keywords** list keywords
+* **creation** creation date
+* **mod** modify date
+* **fileNameResult** result file name
+
+「title」「creator」「author」「subject」「keywords」「creation」「mod」のいずれかの値を設定する必要がない場合は、undefined または ""（空文字列）を使用してください。
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+    /*If not need to set value, use undefined or "" (empty string)*/
+    /*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+    console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+/*If not need to set value, use undefined or "" (empty string)*/
+/*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/misc/_index.md
+++ b/japanese/nodejs-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "その他の関数"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを操作するための二次関数"
+type: docs
+url: /ja/nodejs-cpp/misc/
+---
+
+## Miscellaneous PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfAbout](./asposepdfabout/) | 製品に関する情報を取得します。 |
+
+## Detailed Description
+
+PDF ファイルの操作用の二次機能。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/misc/asposepdfabout/_index.md
+++ b/japanese/nodejs-cpp/misc/asposepdfabout/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposePdfAbout"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "製品に関する情報を取得します。"
+type: docs
+url: /ja/nodejs-cpp/misc/asposepdfabout/
+---
+
+_製品に関する情報を取得します。_
+
+```js
+function AsposePdfAbout()
+```
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **product** - Product name
+* **family** - Product family
+* **version** - Product version
+* **releasedate** - Date release
+* **producer** - Full name/producer
+* **islicensed** - Product is licensed
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+AsposePdf().then(AsposePdfModule => {
+    /*AsposePdfAbout - Get info about Product*/
+    const json = AsposePdfModule.AsposePdfAbout();
+    /* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+    */
+    console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+/*AsposePdfAbout - Get info about Product*/
+const json = AsposePdfModule.AsposePdfAbout();
+/* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+*/
+console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/_index.md
+++ b/japanese/nodejs-cpp/organize/_index.md
@@ -1,0 +1,75 @@
+---
+title: "PDF 整理機能"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを整理するための関数。"
+type: docs
+url: /ja/nodejs-cpp/organize/
+---
+
+## Organize PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfOptimize](./asposepdfoptimize/) | PDF ファイルを最適化します。 |
+| [AsposePdfMerge2Files](./asposepdfmerge2files/) | 2 つの PDF ファイルを結合します。 |
+| [AsposePdfSplit2Files](./asposepdfsplit2files/) | PDF を 2 つのファイルに分割します。 |
+| [AsposePdfRotateAllPages](./asposepdfrotateallpages/) | PDF ページを回転します。 |
+| [AsposePdfDeletePages](./asposepdfdeletepages/) | PDF ファイルからページを削除します。 |
+| [AsposePdfAddStamp](./asposepdfaddstamp/) | PDF ファイルにスタンプを追加します。 |
+| [AsposePdfAddStampPages](./asposepdfaddstamppages/) | PDF ファイルの特定ページにスタンプを追加します。 |
+| [AsposePdfAddImage](./asposepdfaddimage/) | PDF ファイルの末尾に画像を追加します。 |
+| [AsposePdfAddPageNum](./asposepdfaddpagenum/) | PDF ファイルにページ番号を追加します。 |
+| [AsposePdfAddBackgroundImage](./asposepdfaddbackgroundimage/) | PDF ファイルに背景画像を追加します。 |
+| [AsposePdfAddTextHeaderFooter](./asposepdfaddtextheaderfooter/) | PDF ファイルのヘッダー/フッターにテキストを追加します。 |
+| [AsposePdfRepair](./asposepdfrepair/) | PDF ファイルを修復します。 |
+| [AsposePdfOptimizeResource](./asposepdfoptimizeresource/) | PDF ファイルのリソースを最適化します。 |
+| [AsposePdfSetBackgroundColor](./asposepdfsetbackgroundcolor/) | PDF ファイルの背景色を設定します。 |
+| [AsposePdfDeleteAnnotations](./asposepdfdeleteannotations/) | PDF ファイルから注釈を削除します。 |
+| [AsposePdfDeleteBookmarks](./asposepdfdeletebookmarks/) | PDF ファイルからブックマークを削除します。 |
+| [AsposePdfDeleteAttachments](./asposepdfdeleteattachments/) | PDF ファイルから添付ファイルを削除します。 |
+| [AsposePdfDeleteImages](./asposepdfdeleteimages/) | PDF ファイルから画像を削除します。 |
+| [AsposePdfDeleteJavaScripts](./asposepdfdeletejavascripts/) | PDF ファイルから JavaScript を削除する。 |
+| [AsposePdfAddAttachment](./asposepdfaddattachment/) | PDF ファイルに添付ファイルを追加する。 |
+| [AsposePdfGetAttachment](./asposepdfgetattachment/) | PDF ファイルから添付ファイルを取得する。 |
+| [AsposePdfReplaceText](./asposepdfreplacetext/) | PDF ファイル内のテキストを置換する。 |
+| [AsposePdfReplaceTextPages](./asposepdfreplacetextpages/) | PDF ファイルのページ上のテキストを置換する。 |
+| [AsposePdfFindText](./asposepdffindtext/) | PDF ファイル内のテキストを検索する。 |
+| [AsposePdfReplaceFont](./asposepdfreplacefont/) | PDF ファイル内のフォントを置換する。 |
+| [AsposePdfValidatePDFA](./asposepdfvalidatepdfa/) | PDF ファイルの PDF/A 互換性を検証する。 |
+| [AsposePdfFindHiddenText](./asposepdffindhiddentext/) | PDF ファイル内の非表示テキストを検索する。 |
+| [AsposePdfDeleteHiddenText](./asposepdfdeletehiddentext/) | PDF ファイルから非表示テキストを削除する。 |
+| [AsposePdfAddWatermark](./asposepdfaddwatermark/) | PDF ファイルに透かしを追加する。 |
+| [AsposePdfDeleteWatermarks](./asposepdfdeletewatermarks/) | PDF ファイルから透かしを削除する。 |
+| [AsposePdfMergeLayers](./asposepdfmergelayers/) | PDF ファイルのレイヤーを結合する。 |
+| [AsposePdfFlatten](./asposepdfflatten/) | PDF ファイルをフラット化する。 |
+| [AsposePdfMakeBooklet](./asposepdfmakebooklet/) | PDF ファイルから小冊子を作成する。 |
+| [AsposePdfMakeNUp](./asposepdfmakenup/) | PDF ファイルから N-Up ドキュメントを作成する。 |
+| [AsposePdfDeleteBlankPages](./asposepdfdeleteblankpages/) | PDF ファイルから空白ページを削除する。 |
+| [AsposePdfEmbedFonts](./asposepdfembedfonts/) | PDF ファイルにフォントを埋め込む。 |
+| [AsposePdfUnembedFonts](./asposepdfunembedfonts/) | PDF ファイルからフォントの埋め込みを解除する。 |
+| [AsposePdfOptimizeFileSize](./asposepdfoptimizefilesize/) | 画像圧縮品質で PDF ファイルのサイズを最適化する。 |
+| [AsposePdfDeleteTables](./asposepdfdeletetables/) | PDF ファイルから表を削除する。 |
+| [AsposePdfCropPages](./asposepdfcroppages/) | PDF ページをトリミングする。 |
+| [AsposePdfDeleteTextHeaders](./asposepdfdeletetextheaders/) | PDF ファイルからテキストヘッダーを削除する。 |
+| [AsposePdfDeleteTextFooters](./asposepdfdeletetextfooters/) | PDF ファイルからテキストフッターを削除する。 |
+| [AsposePdfReplaceTextEx](./asposepdfreplacetextex/) | PDF ファイル内の複数のテキストフラグメントを配置制御付きで置換する。 |
+| [AsposePdfRecover](./asposepdfrecover/) | PDFファイルの構造を復元し、無効なデータをトリムします。 |
+| [AsposePdfRebuildXrefAndTrailer](./asposepdfrebuildxrefandtrailer/) | PDFファイルのクロスリファレンステーブルとトレーラ構造を再構築します。 |
+| [AsposePdfReversePages](./asposepdfreversepages/) | PDFファイルのページ順序を逆にします。 |
+
+
+## Detailed Description
+
+PDF ファイルを整理するための関数。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddattachment/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddattachment/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddAttachment"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルに添付ファイルを追加する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddattachment/
+---
+
+_PDFファイルに添付ファイルを追加します。_
+
+```js
+function AsposePdfAddAttachment(
+    fileName,
+    fileAttachment,
+    fileDescription,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **fileAttachment** attachment file name
+* **fileDescription** attachment description
+* **fileNameResult** result file name
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+    console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+/*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddBackgroundImage"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルに背景画像を追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddbackgroundimage/
+---
+
+_PDFファイルに背景画像を追加します。_
+
+```js
+function AsposePdfAddBackgroundImage(
+    fileName,
+    fileBackgroundImage,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileBackgroundImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+    console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+/*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddimage/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddimage/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfAddImage"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルの末尾に画像を追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddimage/
+---
+
+_PDFファイルの末尾に画像を追加します。_
+
+```js
+function AsposePdfAddImage(
+    fileName,
+    fileImage,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+    console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+/*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfAddPageNum"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルにページ番号を追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddpagenum/
+---
+
+_PDFファイルにページ番号を追加します。_
+
+```js
+function AsposePdfAddPageNum(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add page number to a PDF-file save the "ResultAddPageNum.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+    console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add page number to a PDF-file and save the "ResultAddPageNum.pdf"*/
+const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddstamp/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddstamp/_index.md
@@ -1,0 +1,75 @@
+---
+title: "AsposePdfAddStamp"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルにスタンプを追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddstamp/
+---
+
+_PDFファイルにスタンプを追加します。_
+
+```js
+function AsposePdfAddStamp(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+    console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
@@ -1,0 +1,80 @@
+---
+title: "AsposePdfAddStampPages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルの特定ページにスタンプを追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddstamppages/
+---
+
+_PDFファイルの特定ページにスタンプを追加します。_
+
+```js
+function AsposePdfAddStampPages(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file on page #1 and save the "ResultAddStampPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+    console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file page #1 and save the "ResultAddStampPages.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddTextHeaderFooter"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルのヘッダー/フッターにテキストを追加します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddtextheaderfooter/
+---
+
+_PDFファイルのヘッダー/フッターにテキストを追加します。_
+
+```js
+function AsposePdfAddTextHeaderFooter(
+    fileName,
+    header, 
+    footer,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **header** page header, if not need to set, use undefined or "" (empty string)
+* **footer** page footer, if not need to set, use undefined or "" (empty string)
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+    console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfAddWatermark"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルに透かしを追加する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfaddwatermark/
+---
+
+_PDFファイルに透かしを追加します._
+
+```js
+function AsposePdfAddWatermark(
+    fileName,
+    text,
+    fontName,
+    fontSize,
+    foregroundColor,
+    xPosition,
+    yPosition,
+    rotation,
+    isBackground,
+    opacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **text** watermark text
+* **fontName** font name
+* **fontSize** font size
+* **foregroundColor** text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **xPosition** x watermark position
+* **yPosition** y watermark position
+* **rotation** watermark rotation (0-360)
+* **isBackground** background (1 or 0)
+* **opacity** opacity (decimal)
+* **fileNameResult** result file name
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+    console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfcroppages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfcroppages/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfCropPages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ページをトリミングする。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfcroppages/
+---
+
+_PDFページをトリミングします。_
+
+```js
+function AsposePdfCropPages(
+    fileName,
+    margin,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **margin** page margin
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const margin = 1.5;
+    /*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+    console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const margin = 1.5;
+/*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAnnotations"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから注釈を削除します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeleteannotations/
+---
+
+_PDFファイルから注釈を削除します。_
+
+```js
+function AsposePdfDeleteAnnotations(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+    console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAttachments"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから添付ファイルを削除します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeleteattachments/
+---
+
+_PDFファイルから添付ファイルを削除します。_
+
+```js
+function AsposePdfDeleteAttachments(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+    console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBlankPages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから空白ページを削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeleteblankpages/
+---
+
+_PDFファイルから空白ページを削除します。_
+
+```js
+function AsposePdfDeleteBlankPages(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+    console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBookmarks"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからブックマークを削除します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletebookmarks/
+---
+
+_PDFファイルからブックマークを削除します。_
+
+```js
+function AsposePdfDeleteBookmarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+    console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteHiddenText"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから非表示テキストを削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletehiddentext/
+---
+
+_PDFファイルから隠しテキストを削除します。_
+
+```js
+function AsposePdfDeleteHiddenText(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+    console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteImages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから画像を削除します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeleteimages/
+---
+
+_PDFファイルから画像を削除します。_
+
+```js
+function AsposePdfDeleteImages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+    console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteJavaScripts"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから JavaScript を削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletejavascripts/
+---
+
+_PDFファイルからJavaScriptを削除します。_
+
+```js
+function AsposePdfDeleteJavaScripts(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+    console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletepages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletepages/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfDeletePages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからページを削除します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletepages/
+---
+
+_PDFファイルからページを削除します。_
+
+```js
+function AsposePdfDeletePages(
+    fileName,
+    fileNameResult,
+    numPages
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+    /*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+    console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+/*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletetables/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletetables/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTables"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから表を削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletetables/
+---
+
+_PDFファイルからテーブルを削除します。_
+
+```js
+function AsposePdfDeleteTables(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+    console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextFooters"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからテキストフッターを削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletetextfooters/
+---
+
+_PDFファイルからテキストフッターを削除します。_
+
+```js
+function AsposePdfDeleteTextFooters(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+    console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextHeaders"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからテキストヘッダーを削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletetextheaders/
+---
+
+_PDFファイルからテキストヘッダーを削除します。_
+
+```js
+function AsposePdfDeleteTextHeaders(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+    console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteWatermarks"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから透かしを削除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfdeletewatermarks/
+---
+
+_PDFファイルから透かしを削除します。_
+
+```js
+function AsposePdfDeleteWatermarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+    console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfembedfonts/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfEmbedFonts"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルにフォントを埋め込む。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfembedfonts/
+---
+
+_PDFファイルにフォントを埋め込みます。_
+
+```js
+function AsposePdfEmbedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+    console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AsposePdfFindHiddenText"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイル内の非表示テキストを検索する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdffindhiddentext/
+---
+
+_PDFファイル内の隠しテキストを検索します._
+
+```js
+function AsposePdfFindHiddenText(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Find hidden text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Find hidden text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdffindtext/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdffindtext/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfFindText"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイル内のテキストを検索する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdffindtext/
+---
+
+_PDFファイル内のテキストを検索します。_
+
+```js
+function AsposePdfFindText(
+    fileName,
+    findText
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **findText** text fragment to search
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    /*Find text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+/*Find text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfflatten/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfflatten/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFlatten"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルをフラット化する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfflatten/
+---
+
+_PDFファイルをフラット化します。_
+
+```js
+function AsposePdfFlatten(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+    const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+    console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfgetattachment/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfgetattachment/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfGetAttachment"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから添付ファイルを取得する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfgetattachment/
+---
+
+_PDFファイルから添付ファイルを取得します。_
+
+```js
+function AsposePdfGetAttachment(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfGetAttachment_{0}" where {0} - name of attachment) 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - attachment files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+    const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+    console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfMakeBooklet"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから小冊子を作成する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfmakebooklet/
+---
+
+_PDFファイルからブックレットを作成します。_
+
+```js
+function AsposePdfMakeBooklet(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+    console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfmakenup/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfmakenup/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfMakeNUp"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルから N-Up ドキュメントを作成する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfmakenup/
+---
+
+_PDFファイルからNアップ文書を作成します。_
+
+```js
+function AsposePdfMakeNUp(
+    fileName,
+    columns,
+    rows,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **columns** count of columns
+* **rows** count of rows
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const columns = 2
+    const rows = 2
+    /*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+    console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const columns = 2
+const rows = 2
+/*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfmerge2files/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfmerge2files/_index.md
@@ -1,0 +1,52 @@
+---
+title: "AsposePdfMerge2Files"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "2 つの PDF ファイルを結合します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfmerge2files/
+---
+
+_2つのPDFファイルを結合します。_
+
+```js
+function AsposePdfMerge2Files(
+    fileName1,
+    fileName2,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+  * **fileName1** file name #1 
+  * **fileName2** file name #2 
+  * **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Merge two PDF-files and save the "ResultMerge.pdf"*/
+    const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+    console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Merge two PDF-files and save the "ResultMerge.pdf"*/
+const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfmergelayers/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfmergelayers/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfMergeLayers"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルのレイヤーを結合する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfmergelayers/
+---
+
+_PDFファイルのレイヤーをマージします。_
+
+```js
+function AsposePdfMergeLayers(
+    fileName,
+    newLayerName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **newLayerName** merged layer name for each page
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const mergedLayerName = 'MergedLayer';
+    /*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+    const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+    console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const mergedLayerName = 'MergedLayer';
+/*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfoptimize/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfoptimize/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimize"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを最適化します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfoptimize/
+---
+
+_PDFファイルを最適化します。_
+
+```js
+function AsposePdfOptimize(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+    console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfOptimizeFileSize"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "画像圧縮品質で PDF ファイルのサイズを最適化する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfoptimizefilesize/
+---
+
+_PDFファイルのサイズを画像圧縮品質で最適化します。_
+
+```js
+function AsposePdfOptimizeFileSize(
+    fileName,
+    imageQuality,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **imageQuality** image compression quality
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const imageQuality = 50;
+    /*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+    console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const imageQuality = 50;
+/*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimizeResource"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルのリソースを最適化します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfoptimizeresource/
+---
+
+_PDFファイルのリソースを最適化します。_
+
+```js
+function AsposePdfOptimizeResource(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+    console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRebuildXrefAndTrailer"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルのクロスリファレンステーブルとトレーラ構造を再構築します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/
+---
+
+_PDFファイルのクロスリファレンステーブルとトレーラ構造を再構築します。_
+
+```js
+function AsposePdfRebuildXrefAndTrailer(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+    const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+    console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfrecover/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfrecover/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRecover"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルの構造を復元し、無効なデータをトリムします。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfrecover/
+---
+
+_PDFファイルの構造を復元し、無効なデータをトリムします._
+
+```js
+function AsposePdfRecover(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+    const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+    console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfrepair/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfrepair/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRepair"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルを修復します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfrepair/
+---
+
+_PDFファイルを修復します。_
+
+```js
+function AsposePdfRepair(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+    const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+    console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfreplacefont/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfreplacefont/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceFont"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイル内のフォントを置換する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfreplacefont/
+---
+
+_PDFファイル内のフォントを置換します。_
+
+```js
+function AsposePdfReplaceFont(
+    fileName,
+    findFont,
+    replaceFont,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findFont** name font to be replaced
+* **replaceFont** replacement font name
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findFont = 'Helvetica';
+    const replaceFont = 'Times';
+    /*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+    console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findFont = 'Helvetica';
+const replaceFont = 'Times';
+/*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfreplacetext/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfreplacetext/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceText"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイル内のテキストを置換する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfreplacetext/
+---
+
+_PDFファイル内のテキストを置換します。_
+
+```js
+function AsposePdfReplaceText(
+    fileName,
+    findText,
+    replaceText,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+    /*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+    console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+/*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
@@ -1,0 +1,105 @@
+---
+title: "AsposePdfReplaceTextEx"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイル内の複数のテキストフラグメントを配置制御付きで置換する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfreplacetextex/
+---
+
+_PDFファイル内の複数のテキストフラグメントを配置制御付きで置換します。_
+
+```js
+function AsposePdfReplaceTextEx(
+    fileName,
+    findReplaceSpec,
+    options,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findReplaceSpec** Array, replacement specification:
+  * Array of objects describing replacements:
+    ```js
+    [
+      { findText: "text1", replaceText: "value1" },
+      { findText: "text2", replaceText: "value2" }
+    ]
+    ```
+  * Each object must contain `findText` and `replaceText` string properties
+* **options** object, settings for text replacement:
+  * `alignment` (string), text alignment (e.g., "left", "right", "auto")
+    * When `"auto"` is used, text direction is detected automatically.
+Direction can also be explicitly forced by prefixing `replaceText`
+特別なUnicode文字を使用して:
+`\u200F` (RTL) または `\u200E` (LTR)、できれば最初の文字として使用してください
+  * `numPages` (string|number|Array), target pages to process:
+    * number, page number as 2
+    * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+    * Array, array of page numbers, such as [1,3]
+  * empty object `{}` for default behavior
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+    ];
+    const optionsText = {numPages: 1, alignment: "auto"};
+    /*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+    console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+];
+const optionsText = {numPages: 1, alignment: "auto"};
+/*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfReplaceTextPages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルのページ上のテキストを置換する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfreplacetextpages/
+---
+
+_PDFファイルのページ上のテキストを置換します。_
+
+```js
+function AsposePdfReplaceTextPages(
+    fileName,
+    findText,
+    replaceText,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+
+    /*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+    console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+
+/*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfreversepages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfreversepages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfReversePages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルのページ順序を逆にします。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfreversepages/
+---
+
+_PDFファイルのページ順序を逆にします._
+
+```js
+function AsposePdfReversePages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+    console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfRotateAllPages"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ページを回転します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfrotateallpages/
+---
+
+_PDFページを回転します。_
+
+```js
+function AsposePdfRotateAllPages(
+    fileName,
+    rotation,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **rotation** pages rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+    const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+    console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfSetBackgroundColor"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルの背景色を設定します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfsetbackgroundcolor/
+---
+
+_PDFファイルの背景色を設定します。_
+
+```js
+function AsposePdfSetBackgroundColor(
+    fileName,
+    backgroundColor,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **backgroundColor** PDF background color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+    console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfsplit2files/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfsplit2files/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfSplit2Files"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF を 2 つのファイルに分割します。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfsplit2files/
+---
+
+_PDFファイルを2つに分割します。_
+
+```js
+function AsposePdfSplit2Files(
+    fileName,
+    pageToSplit,
+    fileNameResult1,
+    fileNameResult2 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pageToSplit** number page for split 
+* **fileNameResult1** result file name #1 
+* **fileNameResult2** result file name #2 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult1** - result file name #1
+* **fileNameResult2** - result file name #2
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set number a page to split*/
+    const pageToSplit = 1;
+    /*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+    const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+    console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set number a page to split*/
+const pageToSplit = 1;
+/*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfUnembedFonts"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルからフォントの埋め込みを解除する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfunembedfonts/
+---
+
+_PDFファイルからフォントの埋め込みを解除します。_
+
+```js
+function AsposePdfUnembedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+    console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
+++ b/japanese/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfValidatePDFA"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルの PDF/A 互換性を検証する。"
+type: docs
+url: /ja/nodejs-cpp/organize/asposepdfvalidatepdfa/
+---
+
+_PDFファイルのPDF/A互換性を検証します。_
+
+```js
+function AsposePdfValidatePDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name where verification comments will be stored (xml format)
+
+**Return**:
+ 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+    console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/security/_index.md
+++ b/japanese/nodejs-cpp/security/_index.md
@@ -1,0 +1,33 @@
+---
+title: "PDF のセキュリティ機能"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDF ファイルのセキュリティ機能を操作するための関数。"
+type: docs
+url: /ja/nodejs-cpp/security/
+---
+
+## Security PDF functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePdfEncrypt](./asposepdfencrypt/) | PDFファイルを暗号化します。 |
+| [AsposePdfDecrypt](./asposepdfdecrypt/) | PDFファイルを復号化します。 |
+| [AsposePdfSignPKCS7](./asposepdfsignpkcs7/) | PDFファイルにデジタル署名で署名します。 |
+| [AsposePdfSignPKCS7Detached](./asposepdfsignpkcs7detached/) | PDFファイルに分離型デジタル署名で署名します。 |
+| [AsposePdfChangePassword](./asposepdfchangepassword/) | PDFファイルのパスワードを変更します。 |
+
+## Detailed Description
+
+PDF ファイルのセキュリティ機能を操作するための関数。
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/japanese/nodejs-cpp/security/asposepdfchangepassword/_index.md
+++ b/japanese/nodejs-cpp/security/asposepdfchangepassword/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfChangePassword"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルのパスワードを変更します。"
+type: docs
+url: /ja/nodejs-cpp/security/asposepdfchangepassword/
+---
+
+_PDFファイルのパスワードを変更します。_
+
+```js
+function AsposePdfChangePassword(
+    fileName,
+    ownerPassword,
+    newUserPassword,
+    newOwnerPassword,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **ownerPassword** owner password
+* **newUserPassword** new user password
+* **newOwnerPassword** new owner password
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+    const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+    console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/security/asposepdfdecrypt/_index.md
+++ b/japanese/nodejs-cpp/security/asposepdfdecrypt/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfDecrypt"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルを復号化します。"
+type: docs
+url: /ja/nodejs-cpp/security/asposepdfdecrypt/
+---
+
+_PDFファイルを復号化します。_
+
+```js
+function AsposePdfDecrypt(
+    fileName,
+    password,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **password** user password 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+    console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/security/asposepdfencrypt/_index.md
+++ b/japanese/nodejs-cpp/security/asposepdfencrypt/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfEncrypt"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルを暗号化します。"
+type: docs
+url: /ja/nodejs-cpp/security/asposepdfencrypt/
+---
+
+_PDFファイルを暗号化します。_
+
+```js
+function AsposePdfEncrypt(
+    fileName,
+    passwordUser,
+    passwordOwner,
+    permissions,
+    cryptoAlgorithm,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **passwordUser** user password 
+* **passwordOwner** owner password 
+* **permissions** encrypt permissions:
+  * Module.Permissions.PrintDocument
+  * Module.Permissions.ModifyContent
+  * Module.Permissions.ExtractContent
+  * Module.Permissions.ModifyTextAnnotations
+  * Module.Permissions.FillForm
+  * Module.Permissions.ExtractContentWithDisabilities
+  * Module.Permissions.AssembleDocument
+  * Module.Permissions.PrintingQuality 
+* **cryptoAlgorithm** encrypt algorithm:
+  * Module.CryptoAlgorithm.RC4x40
+  * Module.CryptoAlgorithm.RC4x128
+  * Module.CryptoAlgorithm.AESx128
+  * Module.CryptoAlgorithm.AESx256 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+    console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
+++ b/japanese/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルにデジタル署名で署名します。"
+type: docs
+url: /ja/nodejs-cpp/security/asposepdfsignpkcs7/
+---
+
+_PDFファイルにデジタル署名で署名します。_
+
+```js
+function AsposePdfSignPKCS7(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'test.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'Aspose.jpg';
+    /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+    console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'test.pfx';
+/*Signature appearance*/
+const sign_img_file = 'Aspose.jpg';
+/*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/japanese/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
+++ b/japanese/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7Detached"
+second_title: "C++ 経由で Node.js 用 Aspose.PDF"
+description: "PDFファイルに分離型デジタル署名で署名します。"
+type: docs
+url: /ja/nodejs-cpp/security/asposepdfsignpkcs7detached/
+---
+
+_PDFファイルに分離型デジタル署名で署名します。_
+
+```js
+function AsposePdfSignPKCS7Detached(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON オブジェクト
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'sign.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'sign.png';
+    /*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+    console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'sign.pfx';
+/*Signature appearance*/
+const sign_img_file = 'sign.png';
+/*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 94/94
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `japanese/nodejs-cpp`

🤖 Generated by RDA