### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Korean

### DIFF
--- a/korean/nodejs-cpp/_index.md
+++ b/korean/nodejs-cpp/_index.md
@@ -1,0 +1,134 @@
+---
+title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "C++를 통해 Node.js용 Aspose.PDF"
+keywords:  "Node.js, Node, JavaScript, JS, PDF, PDF toolkit"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /ko/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Node.js via C++ allows developers manipulate them PDF files directly in the Node.js.
+
+
+## Convert from PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposePdfPagesToJpg](./convert/asposepdfpagestojpg/) | PDF 파일을 JPG로 변환합니다. |
+| [AsposePdfPagesToPng](./convert/asposepdfpagestopng/) | PDF 파일을 PNG로 변환합니다. |
+| [AsposePdfPagesToTiff](./convert/asposepdfpagestotiff/) | PDF 파일을 TIFF로 변환합니다. |
+| [AsposePdfPagesToBmp](./convert/asposepdfpagestobmp/) | PDF 파일을 BMP로 변환합니다. |
+| [AsposePdfPagesToDICOM](./convert/asposepdfpagestodicom/) | PDF 파일을 DICOM으로 변환합니다. |
+| [AsposePdfPagesToSvg](./convert/asposepdfpagestosvg/) | PDF 파일을 SVG로 변환합니다. |
+| [AsposePdfPagesToSvgZip](./convert/asposepdfpagestosvgzip/) | PDF 파일을 SVG(zip)으로 변환합니다. |
+| [AsposePdfToTeX](./convert/asposepdftotex/) | PDF 파일을 TeX로 변환합니다. |
+| [AsposePdfToXps](./convert/asposepdftoxps/) | PDF 파일을 Xps로 변환합니다. |
+| [AsposePdfTablesToCSV](./convert/asposepdftablestocsv/) | PDF 파일을 CSV(테이블 추출)로 변환합니다. |
+| [AsposePdfToTxt](./convert/asposepdftotxt/) | PDF 파일을 Txt로 변환합니다. |
+| [AsposePdfConvertToGrayscale](./convert/asposepdfconverttograyscale/) | PDF 파일을 그레이스케일로 변환합니다. |
+| [AsposePdfConvertToPDFA](./convert/asposepdfconverttopdfa/) | PDF 파일을 PDF/A로 변환합니다. |
+| [AsposePdfAConvertToPDF](./convert/asposepdfaconverttopdf/) | PDF/A 파일을 PDF로 변환합니다. |
+| [AsposePdfToDocX](./convert/asposepdftodocx/) | PDF 파일을 DocX로 변환합니다. |
+| [AsposePdfToXlsX](./convert/asposepdftoxlsx/) | PDF 파일을 XlsX로 변환합니다. |
+| [AsposePdfToEPUB](./convert/asposepdftoepub/) | PDF 파일을 ePub으로 변환합니다. |
+| [AsposePdfToDoc](./convert/asposepdftodoc/) | PDF 파일을 Doc으로 변환합니다. |
+| [AsposePdfToPptX](./convert/asposepdftopptx/) | PDF 파일을 PptX로 변환합니다. |
+| [AsposePdfExtractText](./convert/asposepdfextracttext/) | PDF 파일에서 텍스트를 추출합니다. |
+| [AsposePdfExtractImage](./convert/asposepdfextractimage/) | PDF 파일에서 이미지를 추출합니다. |
+| [AsposePdfExportFdf](./convert/asposepdfexportfdf/) | AcroForm이 포함된 PDF 파일을 FDF로 내보냅니다. |
+| [AsposePdfExportXfdf](./convert/asposepdfexportxfdf/) | AcroForm이 포함된 PDF 파일을 XFDF로 내보냅니다. |
+| [AsposePdfExportXml](./convert/asposepdfexportxml/) | AcroForm이 포함된 PDF 파일을 XML로 내보냅니다. |
+| [AsposePdfPagesToPDF](./convert/asposepdfpagestopdf/) | PDF 파일을 PDF(개별 페이지)로 변환합니다. |
+| [AsposePdfToMarkdown](./convert/asposepdftomarkdown/) | PDF 파일을 Markdown으로 변환합니다. |
+| [AsposePdfToDocXEnhanced](./convert/asposepdftodocxenhanced/) | PDF 파일을 향상된 인식 모드로 DocX로 변환합니다. |
+
+
+## Convert to PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposePdfFromTxt](./convertpdf/asposepdffromtxt/) | TXT 파일을 PDF로 변환합니다. |
+| [AsposePdfFromImage](./convertpdf/asposepdffromimage/) | 이미지 파일을 PDF로 변환합니다. |
+
+
+## Organize PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposePdfOptimize](./organize/asposepdfoptimize/) | PDF 파일을 최적화합니다. |
+| [AsposePdfMerge2Files](./organize/asposepdfmerge2files/) | 두 개의 PDF 파일을 병합합니다. |
+| [AsposePdfSplit2Files](./organize/asposepdfsplit2files/) | PDF 파일을 두 개로 분할합니다. |
+| [AsposePdfRotateAllPages](./organize/asposepdfrotateallpages/) | PDF 페이지를 회전합니다. |
+| [AsposePdfDeletePages](./organize/asposepdfdeletepages/) | PDF 파일에서 페이지를 삭제합니다. |
+| [AsposePdfAddStamp](./organize/asposepdfaddstamp/) | PDF 파일에 스탬프를 추가합니다. |
+| [AsposePdfAddStampPages](./organize/asposepdfaddstamppages/) | PDF 파일의 특정 페이지에 스탬프를 추가합니다. |
+| [AsposePdfAddImage](./organize/asposepdfaddimage/) | PDF 파일의 끝에 이미지를 추가합니다. |
+| [AsposePdfAddPageNum](./organize/asposepdfaddpagenum/) | PDF 파일에 페이지 번호를 추가합니다. |
+| [AsposePdfAddBackgroundImage](./organize/asposepdfaddbackgroundimage/) | PDF 파일에 배경 이미지를 추가합니다. |
+| [AsposePdfAddTextHeaderFooter](./organize/asposepdfaddtextheaderfooter/) | PDF 파일의 머리글/바닥글에 텍스트를 추가합니다. |
+| [AsposePdfRepair](./organize/asposepdfrepair/) | PDF 파일을 복구합니다. |
+| [AsposePdfOptimizeResource](./organize/asposepdfoptimizeresource/) | PDF 파일의 리소스를 최적화합니다. |
+| [AsposePdfSetBackgroundColor](./organize/asposepdfsetbackgroundcolor/) | PDF 파일의 배경 색을 설정합니다. |
+| [AsposePdfDeleteAnnotations](./organize/asposepdfdeleteannotations/) | PDF 파일에서 주석을 삭제합니다. |
+| [AsposePdfDeleteBookmarks](./organize/asposepdfdeletebookmarks/) | PDF 파일에서 책갈피를 삭제합니다. |
+| [AsposePdfDeleteAttachments](./organize/asposepdfdeleteattachments/) | PDF 파일에서 첨부 파일을 삭제합니다. |
+| [AsposePdfDeleteImages](./organize/asposepdfdeleteimages/) | PDF 파일에서 이미지를 삭제합니다. |
+| [AsposePdfDeleteJavaScripts](./organize/asposepdfdeletejavascripts/) | PDF 파일에서 JavaScript를 삭제합니다. |
+| [AsposePdfAddAttachment](./organize/asposepdfaddattachment/) | PDF 파일에 첨부 파일을 추가합니다. |
+| [AsposePdfGetAttachment](./organize/asposepdfgetattachment/) | PDF 파일에서 첨부 파일을 가져옵니다. |
+| [AsposePdfReplaceText](./organize/asposepdfreplacetext/) | PDF 파일의 텍스트를 교체합니다. |
+| [AsposePdfReplaceTextPages](./organize/asposepdfreplacetextpages/) | PDF 파일 페이지의 텍스트를 교체합니다. |
+| [AsposePdfFindText](./organize/asposepdffindtext/) | PDF 파일에서 텍스트를 찾습니다. |
+| [AsposePdfReplaceFont](./organize/asposepdfreplacefont/) | PDF 파일의 글꼴을 교체합니다. |
+| [AsposePdfValidatePDFA](./organize/asposepdfvalidatepdfa/) | PDF 파일의 PDF/A 호환성을 검증합니다. |
+| [AsposePdfFindHiddenText](./organize/asposepdffindhiddentext/) | PDF 파일에서 숨겨진 텍스트를 찾습니다. |
+| [AsposePdfDeleteHiddenText](./organize/asposepdfdeletehiddentext/) | PDF 파일에서 숨겨진 텍스트를 삭제합니다. |
+| [AsposePdfAddWatermark](./organize/asposepdfaddwatermark/) | PDF 파일에 워터마크를 추가합니다. |
+| [AsposePdfDeleteWatermarks](./organize/asposepdfdeletewatermarks/) | PDF 파일에서 워터마크를 삭제합니다. |
+| [AsposePdfMergeLayers](./organize/asposepdfmergelayers/) | PDF 파일의 레이어를 병합합니다. |
+| [AsposePdfFlatten](./organize/asposepdfflatten/) | PDF 파일을 평탄화합니다. |
+| [AsposePdfMakeBooklet](./organize/asposepdfmakebooklet/) | PDF 파일에서 소책자를 만듭니다. |
+| [AsposePdfMakeNUp](./organize/asposepdfmakenup/) | PDF 파일에서 N-Up 문서를 만듭니다. |
+| [AsposePdfDeleteBlankPages](./organize/asposepdfdeleteblankpages/) | PDF 파일에서 빈 페이지를 삭제합니다. |
+| [AsposePdfEmbedFonts](./organize/asposepdfembedfonts/) | PDF 파일에 글꼴을 포함합니다. |
+| [AsposePdfUnembedFonts](./organize/asposepdfunembedfonts/) | PDF 파일에서 글꼴 포함을 해제합니다. |
+| [AsposePdfOptimizeFileSize](./organize/asposepdfoptimizefilesize/) | 이미지 압축 품질로 PDF 파일의 크기를 최적화합니다. |
+| [AsposePdfDeleteTables](./organize/asposepdfdeletetables/) | PDF 파일에서 표를 삭제합니다. |
+| [AsposePdfCropPages](./organize/asposepdfcroppages/) | PDF 페이지를 자릅니다. |
+| [AsposePdfDeleteTextHeaders](./organize/asposepdfdeletetextheaders/) | PDF 파일에서 텍스트 헤더를 삭제합니다. |
+| [AsposePdfDeleteTextFooters](./organize/asposepdfdeletetextfooters/) | PDF 파일에서 텍스트 푸터를 삭제합니다. |
+| [AsposePdfReplaceTextEx](./organize/asposepdfreplacetextex/) | 정렬 제어와 함께 PDF 파일의 여러 텍스트 조각을 교체합니다. |
+| [AsposePdfRecover](./organize/asposepdfrecover/) | PDF 파일 구조를 복구하고 잘못된 데이터를 정리합니다. |
+| [AsposePdfRebuildXrefAndTrailer](./organize/asposepdfrebuildxrefandtrailer/) | PDF 파일 교차 참조 테이블과 트레일러 구조를 재구성합니다. |
+| [AsposePdfReversePages](./organize/asposepdfreversepages/) | PDF 파일의 페이지 순서를 반전시킵니다. |
+
+
+## Metadata PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposePdfSetInfo](./metadata/asposepdfsetinfo/) | PDF 파일에 정보(메타데이터)를 설정합니다. |
+| [AsposePdfGetInfo](./metadata/asposepdfgetinfo/) | PDF 파일에서 정보(메타데이터)를 가져옵니다. |
+| [AsposePdfGetAllFonts](./metadata/asposepdfgetallfonts/) | PDF 파일에서 폰트 목록을 가져옵니다. |
+| [AsposePdfRemoveMetadata](./metadata/asposepdfremovemetadata/) | PDF 파일에서 메타데이터를 제거합니다. |
+| [AsposePdfGetWordsCharactersCount](./metadata/asposepdfgetwordscharacterscount/) | PDF 파일에서 단어 및 문자 수를 가져옵니다. |
+| [AsposePdfGetPagesLayers](./metadata/asposepdfgetpageslayers/) | PDF 파일에서 레이어 목록을 가져옵니다. |
+
+
+## Security PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposePdfEncrypt](./security/asposepdfencrypt/) | PDF 파일을 암호화합니다. |
+| [AsposePdfDecrypt](./security/asposepdfdecrypt/) | PDF 파일을 복호화합니다. |
+| [AsposePdfSignPKCS7](./security/asposepdfsignpkcs7/) | PDF 파일에 디지털 서명을 추가합니다. |
+| [AsposePdfSignPKCS7Detached](./security/asposepdfsignpkcs7detached/) | PDF 파일에 분리된 디지털 서명을 추가합니다. |
+| [AsposePdfChangePassword](./security/asposepdfchangepassword/) | PDF 파일의 비밀번호를 변경합니다. |
+
+## Miscellaneous
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfAbout](./misc/asposepdfabout/) | 제품에 대한 정보를 가져옵니다. |

--- a/korean/nodejs-cpp/convert/_index.md
+++ b/korean/nodejs-cpp/convert/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PDF 변환 함수"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 변환하기 위한 기능."
+type: docs
+url: /ko/nodejs-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfPagesToJpg](./asposepdfpagestojpg/) | PDF 파일을 JPG로 변환합니다. |
+| [AsposePdfPagesToPng](./asposepdfpagestopng/) | PDF 파일을 PNG로 변환합니다. |
+| [AsposePdfPagesToTiff](./asposepdfpagestotiff/) | PDF 파일을 TIFF로 변환합니다. |
+| [AsposePdfPagesToBmp](./asposepdfpagestobmp/) | PDF 파일을 BMP로 변환합니다. |
+| [AsposePdfPagesToDICOM](./asposepdfpagestodicom/) | PDF 파일을 DICOM으로 변환합니다. |
+| [AsposePdfPagesToSvg](./asposepdfpagestosvg/) | PDF 파일을 SVG로 변환합니다. |
+| [AsposePdfPagesToSvgZip](./asposepdfpagestosvgzip/) | PDF 파일을 SVG(zip)으로 변환합니다. |
+| [AsposePdfToTeX](./asposepdftotex/) | PDF 파일을 TeX로 변환합니다. |
+| [AsposePdfToXps](./asposepdftoxps/) | PDF 파일을 Xps로 변환합니다. |
+| [AsposePdfTablesToCSV](./asposepdftablestocsv/) | PDF 파일을 CSV(테이블 추출)로 변환합니다. |
+| [AsposePdfToTxt](./asposepdftotxt/) | PDF 파일을 Txt로 변환합니다. |
+| [AsposePdfConvertToGrayscale](./asposepdfconverttograyscale/) | PDF 파일을 그레이스케일로 변환합니다. |
+| [AsposePdfConvertToPDFA](./asposepdfconverttopdfa/) | PDF 파일을 PDF/A로 변환합니다. |
+| [AsposePdfAConvertToPDF](./asposepdfaconverttopdf/) | PDF/A 파일을 PDF로 변환합니다. |
+| [AsposePdfToDocX](./asposepdftodocx/) | PDF 파일을 DocX로 변환합니다. |
+| [AsposePdfToXlsX](./asposepdftoxlsx/) | PDF 파일을 XlsX로 변환합니다. |
+| [AsposePdfToEPUB](./asposepdftoepub/) | PDF 파일을 ePub으로 변환합니다. |
+| [AsposePdfToDoc](./asposepdftodoc/) | PDF 파일을 Doc으로 변환합니다. |
+| [AsposePdfToPptX](./asposepdftopptx/) | PDF 파일을 PptX로 변환합니다. |
+| [AsposePdfExtractText](./asposepdfextracttext/) | PDF 파일에서 텍스트를 추출합니다. |
+| [AsposePdfExtractImage](./asposepdfextractimage/) | PDF 파일에서 이미지를 추출합니다. |
+| [AsposePdfExportFdf](./asposepdfexportfdf/) | AcroForm이 포함된 PDF 파일을 FDF로 내보냅니다. |
+| [AsposePdfExportXfdf](./asposepdfexportxfdf/) | AcroForm이 포함된 PDF 파일을 XFDF로 내보냅니다. |
+| [AsposePdfExportXml](./asposepdfexportxml/) | AcroForm이 포함된 PDF 파일을 XML로 내보냅니다. |
+| [AsposePdfPagesToPDF](./asposepdfpagestopdf/) | PDF 파일을 PDF(개별 페이지)로 변환합니다. |
+| [AsposePdfToMarkdown](./asposepdftomarkdown/) | PDF 파일을 Markdown으로 변환합니다. |
+| [AsposePdfToDocXEnhanced](./asposepdftodocxenhanced/) | PDF 파일을 향상된 인식 모드로 DocX로 변환합니다. |
+
+
+## Detailed Description
+
+PDF 파일을 변환하기 위한 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfAConvertToPDF"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF/A 파일을 PDF로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfaconverttopdf/
+---
+
+_PDF/A 파일을 PDF로 변환합니다._
+
+```js
+function AsposePdfAConvertToPDF(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+    const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+    console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+/*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfConvertToGrayscale"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 그레이스케일로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfconverttograyscale/
+---
+
+_PDF 파일을 그레이스케일로 변환합니다._
+
+```js
+function AsposePdfConvertToGrayscale(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+    const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+    console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposePdfConvertToPDFA"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 PDF/A로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfconverttopdfa/
+---
+
+_PDF 파일을 PDF/A로 변환합니다._
+
+```js
+function AsposePdfConvertToPDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult,
+    fileNameLogResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name
+* **fileNameLogResult** result Log (xml) file name
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+  * **fileNameLogResult** - result Log (xml) file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+    /*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+    console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+/*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfexportfdf/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfexportfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportFdf"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "AcroForm이 포함된 PDF 파일을 FDF로 내보냅니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfexportfdf/
+---
+
+_AcroForm이 포함된 PDF 파일을 FDF로 내보냅니다._
+
+```js
+function AsposePdfExportFdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+    const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+    console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXfdf"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "AcroForm이 포함된 PDF 파일을 XFDF로 내보냅니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfexportxfdf/
+---
+
+_AcroForm이 포함된 PDF 파일을 XFDF로 내보냅니다._
+
+```js
+function AsposePdfExportXfdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+    const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+    console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfexportxml/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfexportxml/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXml"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "AcroForm이 포함된 PDF 파일을 XML로 내보냅니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfexportxml/
+---
+
+_AcroForm이 포함된 PDF 파일을 XML로 내보냅니다._
+
+```js
+function AsposePdfExportXml(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+    const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+    console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfextractimage/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfextractimage/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfExtractImage"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 이미지를 추출합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfextractimage/
+---
+
+_PDF 파일에서 이미지를 추출합니다._
+
+```js
+function AsposePdfExtractImage(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfExtractImage{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - image files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+    console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfextracttext/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfextracttext/_index.md
@@ -1,0 +1,48 @@
+---
+title: "AsposePdfExtractText"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 텍스트를 추출합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfextracttext/
+---
+
+_PDF 파일에서 텍스트를 추출합니다._
+
+```js
+function AsposePdfExtractText(
+    fileName 
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **extractText** - text from PDF
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract text from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+    console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract text from a PDF-file*/
+const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToBmp"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 BMP로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestobmp/
+---
+
+_PDF 파일을 BMP로 변환합니다._
+
+```
+function AsposePdfPagesToBmp(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToBmp{0:D2}.bmp" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - bmp files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+    console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToDICOM"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 DICOM으로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestodicom/
+---
+
+_PDF 파일을 DICOM으로 변환합니다._
+
+```js
+function AsposePdfPagesToDICOM(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToDICOM{0:D2}.dcm" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - DICOM (.dcm) files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+    console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToJpg"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 JPG로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestojpg/
+---
+
+_PDF 파일을 JPG로 변환합니다._
+
+```js
+function AsposePdfPagesToJpg(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToJpg{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - jpg files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+    console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToPDF"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 PDF(개별 페이지)로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestopdf/
+---
+
+_PDF 파일을 PDF(별도 페이지)로 변환합니다._
+
+```
+function AsposePdfPagesToPDF(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfPagesToPDF{0:D2}.pdf" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - result files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+    console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestopng/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestopng/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToPng"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 PNG로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestopng/
+---
+
+_PDF 파일을 PNG로 변환합니다._
+
+```
+function AsposePdfPagesToPng(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToPng{0:D2}.png" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+    console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToSvg"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 SVG로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestosvg/
+---
+
+_PDF 파일을 SVG로 변환합니다._
+
+```
+function AsposePdfPagesToSvg(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+    console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
@@ -1,0 +1,50 @@
+---
+title: "AsposePdfPagesToSvgZip"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 SVG(zip)으로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestosvgzip/
+---
+
+_PDF 파일을 SVG(zip)으로 변환합니다._
+
+```
+function AsposePdfPagesToSvgZip(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG(zip) and save the "ResultPdfToSvgZip.zip"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+    console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*convert a PDF-file to SVG zip and save the "ResultPdfToSvgZip.zip"*/
+const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText)
+```

--- a/korean/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToTiff"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 TIFF로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdfpagestotiff/
+---
+
+_PDF 파일을 TIFF로 변환합니다._
+
+```
+function AsposePdfPagesToTiff(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToTiff{0:D2}.tiff" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - tiff files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+    console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftablestocsv/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftablestocsv/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfTablesToCSV"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 CSV(테이블 추출)로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftablestocsv/
+---
+
+_PDF 파일을 CSV (테이블 추출)로 변환합니다._
+
+```
+function AsposePdfTablesToCSV(
+    fileName,
+    fileNameResult,
+    delimiter
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfTablesToCSV{0:D2}.csv" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **delimiter** delimiter for csv (comma-separated value), default ";"
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - csv files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+    const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+    console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftodoc/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftodoc/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDoc"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 Doc으로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftodoc/
+---
+
+_PDF 파일을 Doc으로 변환합니다._
+
+```js
+function AsposePdfToDoc(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+    const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+    console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftodocx/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftodocx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocX"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 DocX로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftodocx/
+---
+
+_PDF 파일을 DocX로 변환합니다._
+
+```js
+function AsposePdfToDocX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+    console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocXEnhanced"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 향상된 인식 모드로 DocX로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftodocxenhanced/
+---
+
+_PDF 파일을 향상된 인식 모드가 적용된 DocX로 변환합니다 (완전 편집 가능한 표와 단락)._
+
+```js
+function AsposePdfToDocXEnhanced(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+    console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftoepub/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftoepub/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToEPUB"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 ePub으로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftoepub/
+---
+
+_PDF 파일을 ePub으로 변환합니다._
+
+```js
+function AsposePdfToEPUB(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+    const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+    console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftomarkdown/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftomarkdown/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToMarkdown"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 Markdown으로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftomarkdown/
+---
+
+_PDF 파일을 Markdown으로 변환합니다._
+
+```js
+function AsposePdfToMarkdown(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+    const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+    console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftopptx/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftopptx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToPptX"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 PptX로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftopptx/
+---
+
+_PDF 파일을 PptX로 변환합니다._
+
+```js
+function AsposePdfToPptX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+    const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+    console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftotex/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftotex/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTeX"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 TeX로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftotex/
+---
+
+_PDF 파일을 TeX로 변환합니다._
+
+```js
+function AsposePdfToTeX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+    const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+    console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftotxt/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftotxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTxt"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 Txt로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftotxt/
+---
+
+_PDF 파일을 Txt로 변환합니다._
+
+```js
+function AsposePdfToTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+    const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+    console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftoxlsx/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftoxlsx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXlsX"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 XlsX로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftoxlsx/
+---
+
+_PDF 파일을 XlsX로 변환합니다._
+
+```js
+function AsposePdfToXlsX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+    const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+    console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convert/asposepdftoxps/_index.md
+++ b/korean/nodejs-cpp/convert/asposepdftoxps/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXps"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 Xps로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convert/asposepdftoxps/
+---
+
+_PDF 파일을 Xps로 변환합니다._
+
+```js
+function AsposePdfToXps(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+    const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+    console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convertpdf/_index.md
+++ b/korean/nodejs-cpp/convertpdf/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PDF 변환 기능"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일로 변환하기 위한 기능."
+type: docs
+url: /ko/nodejs-cpp/convertpdf/
+---
+
+## Convert to PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfFromTxt](./asposepdffromtxt/) | TXT 파일을 PDF로 변환합니다. |
+| [AsposePdfFromImage](./asposepdffromimage/) | 이미지 파일을 PDF로 변환합니다. |
+
+## Detailed Description
+
+PDF 파일로 변환하기 위한 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
+++ b/korean/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfFromImage"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "이미지 파일을 PDF로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convertpdf/asposepdffromimage/
+---
+
+_Image-file을 PDF로 변환합니다._
+
+```js
+function AsposePdfFromImage(
+    fileName,
+    pdfPageSize,
+    margin,
+    isLandscape,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** image file name (support bmp, jpeg, png, tiff, gif formats)
+* **pdfPageSize**  page size:
+  * Module.PdfPageSize.A0
+  * Module.PdfPageSize.A1
+  * Module.PdfPageSize.A2
+  * Module.PdfPageSize.A3
+  * Module.PdfPageSize.A4
+  * Module.PdfPageSize.A5
+  * Module.PdfPageSize.A6
+  * Module.PdfPageSize.B5
+  * Module.PdfPageSize.PageLetter
+  * Module.PdfPageSize.PageLegal
+  * Module.PdfPageSize.PageLedger
+  * Module.PdfPageSize.P11x17
+  * Module.PdfPageSize.ImageSize
+* **margin** page margin
+* **isLandscape** page landscape mode (0 or 1)
+* **fileNameResult** result file name
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const aspose_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+    console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const aspose_file = 'Aspose.jpg';
+/*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
+++ b/korean/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFromTxt"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "TXT 파일을 PDF로 변환합니다."
+type: docs
+url: /ko/nodejs-cpp/convertpdf/asposepdffromtxt/
+---
+
+_TXT-file을 PDF로 변환합니다._
+
+```js
+function AsposePdfFromTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+    console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const txt_file = 'ReadMe.txt';
+/*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/_index.md
+++ b/korean/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,35 @@
+---
+title: "메타데이터 PDF 기능"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "메타데이터 PDF 파일 작업을 위한 기능"
+type: docs
+url: /ko/nodejs-cpp/metadata/
+---
+
+## Metadata PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfSetInfo](./asposepdfsetinfo/) | PDF 파일에 정보(메타데이터)를 설정합니다. |
+| [AsposePdfGetInfo](./asposepdfgetinfo/) | PDF 파일에서 정보(메타데이터)를 가져옵니다. |
+| [AsposePdfGetAllFonts](./asposepdfgetallfonts/) | PDF 파일에서 폰트 목록을 가져옵니다. |
+| [AsposePdfRemoveMetadata](./asposepdfremovemetadata/) | PDF 파일에서 메타데이터를 제거합니다. |
+| [AsposePdfGetWordsCharactersCount](./asposepdfgetwordscharacterscount/) | PDF 파일에서 단어 및 문자 수를 가져옵니다. |
+| [AsposePdfGetPagesLayers](./asposepdfgetpageslayers/) | PDF 파일에서 레이어 목록을 가져옵니다. |
+
+
+## Detailed Description
+
+메타데이터 PDF 파일 작업을 위한 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePdfGetAllFonts"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 폰트 목록을 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfgetallfonts/
+---
+
+_PDF 파일에서 글꼴 목록을 가져옵니다._
+
+```js
+function AsposePdfGetAllFonts(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fonts** - array of : 
+  * fontName - font name
+  * isEmbedded - indicates whether the font is embedded
+  * isAccessible - indicating whether the font is present
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list fonts from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+    /*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+    console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list fonts from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+/*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
@@ -1,0 +1,123 @@
+---
+title: "AsposePdfGetInfo"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 정보(메타데이터)를 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfgetinfo/
+---
+
+_PDF 파일에서 정보(메타데이터)를 가져옵니다._
+
+```js
+function AsposePdfGetInfo(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **title** - title
+* **creator** - creator
+* **author** - author
+* **subject** - subject
+* **keywords** - keywords
+* **creation** - creation date
+* **mod** - modify date
+* **format** - PDF format
+* **version** - PDF version
+* **ispdfa** - PDF is PDF/A
+* **ispdfua** - PDF is PDF/UA
+* **islinearized** - PDF is linearized
+* **isencrypted** - PDF is encrypted
+* **permission** - PDF permission
+* **size** - PDF page size
+* **pagecount** - Page count
+* **annotationcount** - Annotation count
+* **bookmarkcount** - Bookmark count
+* **attachmentcount** - Attachment count
+* **metadatacount** - Metadata count
+* **javascriptcount** - JavaScript count
+* **imagecount** - Image count
+* **tablecount** - Table count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get info (metadata) from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+    /* JSON
+       Title             : json.title
+       Creator           : json.creator
+       Author            : json.author
+       Subject           : json.subject
+       Keywords          : json.keywords
+       Creation Date     : json.creation
+       Modify Date       : json.mod
+       PDF format        : json.format
+       PDF version       : json.version
+       PDF is PDF/A      : json.ispdfa
+       PDF is PDF/UA     : json.ispdfua
+       PDF is linearized : json.islinearized
+       PDF is encrypted  : json.isencrypted
+       PDF permission    : json.permission
+       PDF page size     : json.size
+       Page count        : json.pagecount
+       Annotation count  : json.annotationcount
+       Bookmark count    : json.bookmarkcount
+       Attachment count  : json.attachmentcount
+       Metadata count    : json.metadatacount
+       JavaScript count  : json.javascriptcount
+       Image count       : json.imagecount
+       Table count       : json.tablecount
+    */
+    console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get info (metadata) from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+/* JSON
+   Title             : json.title
+   Creator           : json.creator
+   Author            : json.author
+   Subject           : json.subject
+   Keywords          : json.keywords
+   Creation Date     : json.creation
+   Modify Date       : json.mod
+   PDF format        : json.format
+   PDF version       : json.version
+   PDF is PDF/A      : json.ispdfa
+   PDF is PDF/UA     : json.ispdfua
+   PDF is linearized : json.islinearized
+   PDF is encrypted  : json.isencrypted
+   PDF permission    : json.permission
+   PDF page size     : json.size
+   Page count        : json.pagecount
+   Annotation count  : json.annotationcount
+   Bookmark count    : json.bookmarkcount
+   Attachment count  : json.attachmentcount
+   Metadata count    : json.metadatacount
+   JavaScript count  : json.javascriptcount
+   Image count       : json.imagecount
+   Table count       : json.tablecount
+*/
+console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfGetPagesLayers"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 레이어 목록을 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfgetpageslayers/
+---
+
+_PDF 파일에서 레이어 목록을 가져옵니다._
+
+```js
+function AsposePdfGetPagesLayers(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **pagesLayers[][]** - list of pages with lists of layers on each page
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list layers from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+    /*json.pagesLayers - list of pages with lists of layers on each page*/
+    console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list layers from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+/*json.pagesLayers - list of pages with lists of layers on each page*/
+console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposePdfGetWordsCharactersCount"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 단어 및 문자 수를 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/
+---
+
+_PDF 파일에서 단어 및 문자 수를 가져옵니다._
+
+```js
+function AsposePdfGetWordsCharactersCount(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **words** - words count
+* **characters** - characters count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get words and characters count in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+    /* JSON
+       Words count      : json.words
+       Characters count : json.characters
+    */
+    console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get words and characters count in a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+/* JSON
+   Words count      : json.words
+   Characters count : json.characters
+*/
+console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRemoveMetadata"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 메타데이터를 제거합니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfremovemetadata/
+---
+
+_PDF 파일에서 메타데이터를 제거합니다._
+
+```js
+function AsposePdfRemoveMetadata(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+    const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+    console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
+++ b/korean/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfSetInfo"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 정보(메타데이터)를 설정합니다."
+type: docs
+url: /ko/nodejs-cpp/metadata/asposepdfsetinfo/
+---
+
+_PDF 파일에 정보(메타데이터)를 설정합니다._
+
+```js
+function AsposePdfSetInfo(
+    fileName,
+    title, 
+    creator, 
+    author,
+    subject,
+    keywords,
+    creation,
+    mod,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **title** title
+* **creator** creator
+* **author** author
+* **subject** subject
+* **keywords** list keywords
+* **creation** creation date
+* **mod** modify date
+* **fileNameResult** result file name
+
+'title', 'creator', 'author', 'subject', 'keywords', 'creation' 및 'mod'에 대해 값을 설정할 필요가 없으면 undefined 또는 ""(빈 문자열)을 사용하십시오.
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+    /*If not need to set value, use undefined or "" (empty string)*/
+    /*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+    console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+/*If not need to set value, use undefined or "" (empty string)*/
+/*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/misc/_index.md
+++ b/korean/nodejs-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "기타 기능"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일 작업을 위한 보조 기능"
+type: docs
+url: /ko/nodejs-cpp/misc/
+---
+
+## Miscellaneous PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfAbout](./asposepdfabout/) | 제품에 대한 정보를 가져옵니다. |
+
+## Detailed Description
+
+PDF 파일 작업을 위한 보조 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/misc/asposepdfabout/_index.md
+++ b/korean/nodejs-cpp/misc/asposepdfabout/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposePdfAbout"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "제품에 대한 정보를 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/misc/asposepdfabout/
+---
+
+_제품에 대한 정보를 가져옵니다._
+
+```js
+function AsposePdfAbout()
+```
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **product** - Product name
+* **family** - Product family
+* **version** - Product version
+* **releasedate** - Date release
+* **producer** - Full name/producer
+* **islicensed** - Product is licensed
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+AsposePdf().then(AsposePdfModule => {
+    /*AsposePdfAbout - Get info about Product*/
+    const json = AsposePdfModule.AsposePdfAbout();
+    /* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+    */
+    console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+/*AsposePdfAbout - Get info about Product*/
+const json = AsposePdfModule.AsposePdfAbout();
+/* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+*/
+console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/_index.md
+++ b/korean/nodejs-cpp/organize/_index.md
@@ -1,0 +1,75 @@
+---
+title: "PDF 정리 기능"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 정리하기 위한 기능."
+type: docs
+url: /ko/nodejs-cpp/organize/
+---
+
+## Organize PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfOptimize](./asposepdfoptimize/) | PDF 파일을 최적화합니다. |
+| [AsposePdfMerge2Files](./asposepdfmerge2files/) | 두 개의 PDF 파일을 병합합니다. |
+| [AsposePdfSplit2Files](./asposepdfsplit2files/) | PDF 파일을 두 개로 분할합니다. |
+| [AsposePdfRotateAllPages](./asposepdfrotateallpages/) | PDF 페이지를 회전합니다. |
+| [AsposePdfDeletePages](./asposepdfdeletepages/) | PDF 파일에서 페이지를 삭제합니다. |
+| [AsposePdfAddStamp](./asposepdfaddstamp/) | PDF 파일에 스탬프를 추가합니다. |
+| [AsposePdfAddStampPages](./asposepdfaddstamppages/) | PDF 파일의 특정 페이지에 스탬프를 추가합니다. |
+| [AsposePdfAddImage](./asposepdfaddimage/) | PDF 파일의 끝에 이미지를 추가합니다. |
+| [AsposePdfAddPageNum](./asposepdfaddpagenum/) | PDF 파일에 페이지 번호를 추가합니다. |
+| [AsposePdfAddBackgroundImage](./asposepdfaddbackgroundimage/) | PDF 파일에 배경 이미지를 추가합니다. |
+| [AsposePdfAddTextHeaderFooter](./asposepdfaddtextheaderfooter/) | PDF 파일의 머리글/바닥글에 텍스트를 추가합니다. |
+| [AsposePdfRepair](./asposepdfrepair/) | PDF 파일을 복구합니다. |
+| [AsposePdfOptimizeResource](./asposepdfoptimizeresource/) | PDF 파일의 리소스를 최적화합니다. |
+| [AsposePdfSetBackgroundColor](./asposepdfsetbackgroundcolor/) | PDF 파일의 배경 색을 설정합니다. |
+| [AsposePdfDeleteAnnotations](./asposepdfdeleteannotations/) | PDF 파일에서 주석을 삭제합니다. |
+| [AsposePdfDeleteBookmarks](./asposepdfdeletebookmarks/) | PDF 파일에서 책갈피를 삭제합니다. |
+| [AsposePdfDeleteAttachments](./asposepdfdeleteattachments/) | PDF 파일에서 첨부 파일을 삭제합니다. |
+| [AsposePdfDeleteImages](./asposepdfdeleteimages/) | PDF 파일에서 이미지를 삭제합니다. |
+| [AsposePdfDeleteJavaScripts](./asposepdfdeletejavascripts/) | PDF 파일에서 JavaScript를 삭제합니다. |
+| [AsposePdfAddAttachment](./asposepdfaddattachment/) | PDF 파일에 첨부 파일을 추가합니다. |
+| [AsposePdfGetAttachment](./asposepdfgetattachment/) | PDF 파일에서 첨부 파일을 가져옵니다. |
+| [AsposePdfReplaceText](./asposepdfreplacetext/) | PDF 파일의 텍스트를 교체합니다. |
+| [AsposePdfReplaceTextPages](./asposepdfreplacetextpages/) | PDF 파일 페이지의 텍스트를 교체합니다. |
+| [AsposePdfFindText](./asposepdffindtext/) | PDF 파일에서 텍스트를 찾습니다. |
+| [AsposePdfReplaceFont](./asposepdfreplacefont/) | PDF 파일의 글꼴을 교체합니다. |
+| [AsposePdfValidatePDFA](./asposepdfvalidatepdfa/) | PDF 파일의 PDF/A 호환성을 검증합니다. |
+| [AsposePdfFindHiddenText](./asposepdffindhiddentext/) | PDF 파일에서 숨겨진 텍스트를 찾습니다. |
+| [AsposePdfDeleteHiddenText](./asposepdfdeletehiddentext/) | PDF 파일에서 숨겨진 텍스트를 삭제합니다. |
+| [AsposePdfAddWatermark](./asposepdfaddwatermark/) | PDF 파일에 워터마크를 추가합니다. |
+| [AsposePdfDeleteWatermarks](./asposepdfdeletewatermarks/) | PDF 파일에서 워터마크를 삭제합니다. |
+| [AsposePdfMergeLayers](./asposepdfmergelayers/) | PDF 파일의 레이어를 병합합니다. |
+| [AsposePdfFlatten](./asposepdfflatten/) | PDF 파일을 평탄화합니다. |
+| [AsposePdfMakeBooklet](./asposepdfmakebooklet/) | PDF 파일에서 소책자를 만듭니다. |
+| [AsposePdfMakeNUp](./asposepdfmakenup/) | PDF 파일에서 N-Up 문서를 만듭니다. |
+| [AsposePdfDeleteBlankPages](./asposepdfdeleteblankpages/) | PDF 파일에서 빈 페이지를 삭제합니다. |
+| [AsposePdfEmbedFonts](./asposepdfembedfonts/) | PDF 파일에 글꼴을 포함합니다. |
+| [AsposePdfUnembedFonts](./asposepdfunembedfonts/) | PDF 파일에서 글꼴 포함을 해제합니다. |
+| [AsposePdfOptimizeFileSize](./asposepdfoptimizefilesize/) | 이미지 압축 품질로 PDF 파일의 크기를 최적화합니다. |
+| [AsposePdfDeleteTables](./asposepdfdeletetables/) | PDF 파일에서 표를 삭제합니다. |
+| [AsposePdfCropPages](./asposepdfcroppages/) | PDF 페이지를 자릅니다. |
+| [AsposePdfDeleteTextHeaders](./asposepdfdeletetextheaders/) | PDF 파일에서 텍스트 헤더를 삭제합니다. |
+| [AsposePdfDeleteTextFooters](./asposepdfdeletetextfooters/) | PDF 파일에서 텍스트 푸터를 삭제합니다. |
+| [AsposePdfReplaceTextEx](./asposepdfreplacetextex/) | 정렬 제어와 함께 PDF 파일의 여러 텍스트 조각을 교체합니다. |
+| [AsposePdfRecover](./asposepdfrecover/) | PDF 파일 구조를 복구하고 잘못된 데이터를 정리합니다. |
+| [AsposePdfRebuildXrefAndTrailer](./asposepdfrebuildxrefandtrailer/) | PDF 파일 교차 참조 테이블과 트레일러 구조를 재구성합니다. |
+| [AsposePdfReversePages](./asposepdfreversepages/) | PDF 파일의 페이지 순서를 반전시킵니다. |
+
+
+## Detailed Description
+
+PDF 파일을 정리하기 위한 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddattachment/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddattachment/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddAttachment"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 첨부 파일을 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddattachment/
+---
+
+_PDF 파일에 첨부 파일을 추가합니다._
+
+```js
+function AsposePdfAddAttachment(
+    fileName,
+    fileAttachment,
+    fileDescription,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **fileAttachment** attachment file name
+* **fileDescription** attachment description
+* **fileNameResult** result file name
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+    console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+/*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddBackgroundImage"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 배경 이미지를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddbackgroundimage/
+---
+
+_PDF 파일에 배경 이미지를 추가합니다._
+
+```js
+function AsposePdfAddBackgroundImage(
+    fileName,
+    fileBackgroundImage,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileBackgroundImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+    console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+/*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddimage/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddimage/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfAddImage"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 끝에 이미지를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddimage/
+---
+
+_PDF 파일 끝에 이미지를 추가합니다._
+
+```js
+function AsposePdfAddImage(
+    fileName,
+    fileImage,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+    console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+/*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfAddPageNum"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 페이지 번호를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddpagenum/
+---
+
+_PDF 파일에 페이지 번호를 추가합니다._
+
+```js
+function AsposePdfAddPageNum(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add page number to a PDF-file save the "ResultAddPageNum.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+    console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add page number to a PDF-file and save the "ResultAddPageNum.pdf"*/
+const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddstamp/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddstamp/_index.md
@@ -1,0 +1,75 @@
+---
+title: "AsposePdfAddStamp"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 스탬프를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddstamp/
+---
+
+_PDF 파일에 스탬프를 추가합니다._
+
+```js
+function AsposePdfAddStamp(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+    console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
@@ -1,0 +1,80 @@
+---
+title: "AsposePdfAddStampPages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 특정 페이지에 스탬프를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddstamppages/
+---
+
+_PDF 파일의 특정 페이지에 스탬프를 추가합니다._
+
+```js
+function AsposePdfAddStampPages(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file on page #1 and save the "ResultAddStampPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+    console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file page #1 and save the "ResultAddStampPages.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddTextHeaderFooter"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 머리글/바닥글에 텍스트를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddtextheaderfooter/
+---
+
+_PDF 파일의 헤더/푸터에 텍스트를 추가합니다._
+
+```js
+function AsposePdfAddTextHeaderFooter(
+    fileName,
+    header, 
+    footer,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **header** page header, if not need to set, use undefined or "" (empty string)
+* **footer** page footer, if not need to set, use undefined or "" (empty string)
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+    console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfAddWatermark"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 워터마크를 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfaddwatermark/
+---
+
+_PDF-file에 워터마크를 추가합니다._
+
+```js
+function AsposePdfAddWatermark(
+    fileName,
+    text,
+    fontName,
+    fontSize,
+    foregroundColor,
+    xPosition,
+    yPosition,
+    rotation,
+    isBackground,
+    opacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **text** watermark text
+* **fontName** font name
+* **fontSize** font size
+* **foregroundColor** text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **xPosition** x watermark position
+* **yPosition** y watermark position
+* **rotation** watermark rotation (0-360)
+* **isBackground** background (1 or 0)
+* **opacity** opacity (decimal)
+* **fileNameResult** result file name
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+    console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfcroppages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfcroppages/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfCropPages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 페이지를 자릅니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfcroppages/
+---
+
+_PDF 페이지를 자릅니다._
+
+```js
+function AsposePdfCropPages(
+    fileName,
+    margin,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **margin** page margin
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const margin = 1.5;
+    /*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+    console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const margin = 1.5;
+/*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAnnotations"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 주석을 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeleteannotations/
+---
+
+_PDF 파일에서 주석을 삭제합니다._
+
+```js
+function AsposePdfDeleteAnnotations(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+    console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAttachments"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 첨부 파일을 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeleteattachments/
+---
+
+_PDF 파일에서 첨부 파일을 삭제합니다._
+
+```js
+function AsposePdfDeleteAttachments(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+    console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBlankPages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 빈 페이지를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeleteblankpages/
+---
+
+_PDF 파일에서 빈 페이지를 삭제합니다._
+
+```js
+function AsposePdfDeleteBlankPages(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+    console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBookmarks"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 책갈피를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletebookmarks/
+---
+
+_PDF 파일에서 북마크를 삭제합니다._
+
+```js
+function AsposePdfDeleteBookmarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+    console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteHiddenText"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 숨겨진 텍스트를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletehiddentext/
+---
+
+_PDF 파일에서 숨겨진 텍스트를 삭제합니다._
+
+```js
+function AsposePdfDeleteHiddenText(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+    console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteImages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 이미지를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeleteimages/
+---
+
+_PDF 파일에서 이미지를 삭제합니다._
+
+```js
+function AsposePdfDeleteImages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+    console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteJavaScripts"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 JavaScript를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletejavascripts/
+---
+
+_PDF 파일에서 JavaScript를 삭제합니다._
+
+```js
+function AsposePdfDeleteJavaScripts(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+    console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletepages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletepages/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfDeletePages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 페이지를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletepages/
+---
+
+_PDF 파일에서 페이지를 삭제합니다._
+
+```js
+function AsposePdfDeletePages(
+    fileName,
+    fileNameResult,
+    numPages
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+    /*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+    console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+/*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletetables/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletetables/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTables"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 표를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletetables/
+---
+
+_PDF 파일에서 표를 삭제합니다._
+
+```js
+function AsposePdfDeleteTables(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+    console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextFooters"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 텍스트 푸터를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletetextfooters/
+---
+
+_PDF 파일에서 텍스트 푸터를 삭제합니다._
+
+```js
+function AsposePdfDeleteTextFooters(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+    console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextHeaders"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 텍스트 헤더를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletetextheaders/
+---
+
+_PDF 파일에서 텍스트 헤더를 삭제합니다._
+
+```js
+function AsposePdfDeleteTextHeaders(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+    console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteWatermarks"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 워터마크를 삭제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfdeletewatermarks/
+---
+
+_PDF 파일에서 워터마크를 삭제합니다._
+
+```js
+function AsposePdfDeleteWatermarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+    console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfembedfonts/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfEmbedFonts"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 글꼴을 포함합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfembedfonts/
+---
+
+_PDF 파일에 글꼴을 삽입합니다._
+
+```js
+function AsposePdfEmbedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+    console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AsposePdfFindHiddenText"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 숨겨진 텍스트를 찾습니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdffindhiddentext/
+---
+
+_PDF-file에서 숨겨진 텍스트를 찾습니다._
+
+```js
+function AsposePdfFindHiddenText(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Find hidden text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Find hidden text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdffindtext/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdffindtext/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfFindText"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 텍스트를 찾습니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdffindtext/
+---
+
+_PDF 파일에서 텍스트를 찾습니다._
+
+```js
+function AsposePdfFindText(
+    fileName,
+    findText
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **findText** text fragment to search
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    /*Find text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+/*Find text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfflatten/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfflatten/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFlatten"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 평탄화합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfflatten/
+---
+
+_PDF 파일을 평면화합니다._
+
+```js
+function AsposePdfFlatten(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+    const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+    console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfgetattachment/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfgetattachment/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfGetAttachment"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 첨부 파일을 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfgetattachment/
+---
+
+_PDF 파일에서 첨부 파일을 가져옵니다._
+
+```js
+function AsposePdfGetAttachment(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfGetAttachment_{0}" where {0} - name of attachment) 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - attachment files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+    const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+    console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfMakeBooklet"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 소책자를 만듭니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfmakebooklet/
+---
+
+_PDF 파일로 소책자를 만듭니다._
+
+```js
+function AsposePdfMakeBooklet(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+    console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfmakenup/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfmakenup/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfMakeNUp"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 N-Up 문서를 만듭니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfmakenup/
+---
+
+_PDF 파일에서 N-Up 문서를 만듭니다._
+
+```js
+function AsposePdfMakeNUp(
+    fileName,
+    columns,
+    rows,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **columns** count of columns
+* **rows** count of rows
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const columns = 2
+    const rows = 2
+    /*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+    console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const columns = 2
+const rows = 2
+/*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfmerge2files/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfmerge2files/_index.md
@@ -1,0 +1,52 @@
+---
+title: "AsposePdfMerge2Files"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "두 개의 PDF 파일을 병합합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfmerge2files/
+---
+
+_두 개의 PDF 파일을 병합합니다._
+
+```js
+function AsposePdfMerge2Files(
+    fileName1,
+    fileName2,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+  * **fileName1** file name #1 
+  * **fileName2** file name #2 
+  * **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Merge two PDF-files and save the "ResultMerge.pdf"*/
+    const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+    console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Merge two PDF-files and save the "ResultMerge.pdf"*/
+const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfmergelayers/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfmergelayers/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfMergeLayers"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 레이어를 병합합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfmergelayers/
+---
+
+_PDF 파일의 레이어를 병합합니다._
+
+```js
+function AsposePdfMergeLayers(
+    fileName,
+    newLayerName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **newLayerName** merged layer name for each page
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const mergedLayerName = 'MergedLayer';
+    /*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+    const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+    console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const mergedLayerName = 'MergedLayer';
+/*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfoptimize/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfoptimize/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimize"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 최적화합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfoptimize/
+---
+
+_PDF 파일을 최적화합니다._
+
+```js
+function AsposePdfOptimize(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+    console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfOptimizeFileSize"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "이미지 압축 품질로 PDF 파일의 크기를 최적화합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfoptimizefilesize/
+---
+
+_이미지 압축 품질로 PDF 파일의 크기를 최적화합니다._
+
+```js
+function AsposePdfOptimizeFileSize(
+    fileName,
+    imageQuality,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **imageQuality** image compression quality
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const imageQuality = 50;
+    /*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+    console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const imageQuality = 50;
+/*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimizeResource"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 리소스를 최적화합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfoptimizeresource/
+---
+
+_PDF 파일의 리소스를 최적화합니다._
+
+```js
+function AsposePdfOptimizeResource(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+    console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRebuildXrefAndTrailer"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일 교차 참조 테이블과 트레일러 구조를 재구성합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/
+---
+
+_PDF 파일의 교차 참조 테이블 및 트레일러 구조를 재구성합니다._
+
+```js
+function AsposePdfRebuildXrefAndTrailer(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+    const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+    console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfrecover/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfrecover/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRecover"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일 구조를 복구하고 잘못된 데이터를 정리합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfrecover/
+---
+
+_PDF-file 구조를 복구하고 잘못된 데이터를 정리합니다._
+
+```js
+function AsposePdfRecover(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+    const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+    console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfrepair/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfrepair/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRepair"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 복구합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfrepair/
+---
+
+_PDF 파일을 복구합니다._
+
+```js
+function AsposePdfRepair(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+    const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+    console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfreplacefont/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfreplacefont/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceFont"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 글꼴을 교체합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfreplacefont/
+---
+
+_PDF 파일의 글꼴을 교체합니다._
+
+```js
+function AsposePdfReplaceFont(
+    fileName,
+    findFont,
+    replaceFont,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findFont** name font to be replaced
+* **replaceFont** replacement font name
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findFont = 'Helvetica';
+    const replaceFont = 'Times';
+    /*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+    console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findFont = 'Helvetica';
+const replaceFont = 'Times';
+/*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfreplacetext/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfreplacetext/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceText"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 텍스트를 교체합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfreplacetext/
+---
+
+_PDF 파일의 텍스트를 교체합니다._
+
+```js
+function AsposePdfReplaceText(
+    fileName,
+    findText,
+    replaceText,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+    /*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+    console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+/*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
@@ -1,0 +1,105 @@
+---
+title: "AsposePdfReplaceTextEx"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "정렬 제어와 함께 PDF 파일의 여러 텍스트 조각을 교체합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfreplacetextex/
+---
+
+_정렬 제어와 함께 PDF 파일의 여러 텍스트 조각을 교체합니다._
+
+```js
+function AsposePdfReplaceTextEx(
+    fileName,
+    findReplaceSpec,
+    options,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findReplaceSpec** Array, replacement specification:
+  * Array of objects describing replacements:
+    ```js
+    [
+      { findText: "text1", replaceText: "value1" },
+      { findText: "text2", replaceText: "value2" }
+    ]
+    ```
+  * Each object must contain `findText` and `replaceText` string properties
+* **options** object, settings for text replacement:
+  * `alignment` (string), text alignment (e.g., "left", "right", "auto")
+    * When `"auto"` is used, text direction is detected automatically.
+접두사 `replaceText`를 사용하여 방향을 명시적으로 강제할 수도 있습니다.
+특수 유니코드 문자와 함께:
+`\u200F` (RTL) 또는 `\u200E` (LTR), 가능한 경우 첫 번째 문자로 사용합니다.
+  * `numPages` (string|number|Array), target pages to process:
+    * number, page number as 2
+    * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+    * Array, array of page numbers, such as [1,3]
+  * empty object `{}` for default behavior
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+    ];
+    const optionsText = {numPages: 1, alignment: "auto"};
+    /*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+    console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+];
+const optionsText = {numPages: 1, alignment: "auto"};
+/*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfReplaceTextPages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일 페이지의 텍스트를 교체합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfreplacetextpages/
+---
+
+_PDF 파일의 페이지에서 텍스트를 교체합니다._
+
+```js
+function AsposePdfReplaceTextPages(
+    fileName,
+    findText,
+    replaceText,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+
+    /*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+    console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+
+/*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfreversepages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfreversepages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfReversePages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 페이지 순서를 반전시킵니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfreversepages/
+---
+
+_PDF-file의 페이지 순서를 반전시킵니다._
+
+```js
+function AsposePdfReversePages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+    console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfRotateAllPages"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 페이지를 회전합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfrotateallpages/
+---
+
+_PDF 페이지를 회전합니다._
+
+```js
+function AsposePdfRotateAllPages(
+    fileName,
+    rotation,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **rotation** pages rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+    const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+    console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfSetBackgroundColor"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 배경 색을 설정합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfsetbackgroundcolor/
+---
+
+_PDF 파일의 배경 색을 설정합니다._
+
+```js
+function AsposePdfSetBackgroundColor(
+    fileName,
+    backgroundColor,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **backgroundColor** PDF background color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+    console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfsplit2files/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfsplit2files/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfSplit2Files"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 두 개로 분할합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfsplit2files/
+---
+
+_두 개의 PDF 파일로 분할합니다._
+
+```js
+function AsposePdfSplit2Files(
+    fileName,
+    pageToSplit,
+    fileNameResult1,
+    fileNameResult2 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pageToSplit** number page for split 
+* **fileNameResult1** result file name #1 
+* **fileNameResult2** result file name #2 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult1** - result file name #1
+* **fileNameResult2** - result file name #2
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set number a page to split*/
+    const pageToSplit = 1;
+    /*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+    const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+    console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set number a page to split*/
+const pageToSplit = 1;
+/*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfUnembedFonts"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에서 글꼴 포함을 해제합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfunembedfonts/
+---
+
+_PDF 파일에서 글꼴을 삽입 해제합니다._
+
+```js
+function AsposePdfUnembedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+    console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
+++ b/korean/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfValidatePDFA"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 PDF/A 호환성을 검증합니다."
+type: docs
+url: /ko/nodejs-cpp/organize/asposepdfvalidatepdfa/
+---
+
+_PDF 파일의 PDF/A 호환성을 검증합니다._
+
+```js
+function AsposePdfValidatePDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name where verification comments will be stored (xml format)
+
+**Return**:
+ 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+    console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/security/_index.md
+++ b/korean/nodejs-cpp/security/_index.md
@@ -1,0 +1,33 @@
+---
+title: "보안 PDF 기능"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "보안 기능이 포함된 PDF 파일 작업을 위한 기능."
+type: docs
+url: /ko/nodejs-cpp/security/
+---
+
+## Security PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePdfEncrypt](./asposepdfencrypt/) | PDF 파일을 암호화합니다. |
+| [AsposePdfDecrypt](./asposepdfdecrypt/) | PDF 파일을 복호화합니다. |
+| [AsposePdfSignPKCS7](./asposepdfsignpkcs7/) | PDF 파일에 디지털 서명을 추가합니다. |
+| [AsposePdfSignPKCS7Detached](./asposepdfsignpkcs7detached/) | PDF 파일에 분리된 디지털 서명을 추가합니다. |
+| [AsposePdfChangePassword](./asposepdfchangepassword/) | PDF 파일의 비밀번호를 변경합니다. |
+
+## Detailed Description
+
+보안 기능이 포함된 PDF 파일 작업을 위한 기능.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/korean/nodejs-cpp/security/asposepdfchangepassword/_index.md
+++ b/korean/nodejs-cpp/security/asposepdfchangepassword/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfChangePassword"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일의 비밀번호를 변경합니다."
+type: docs
+url: /ko/nodejs-cpp/security/asposepdfchangepassword/
+---
+
+_PDF 파일의 비밀번호를 변경합니다._
+
+```js
+function AsposePdfChangePassword(
+    fileName,
+    ownerPassword,
+    newUserPassword,
+    newOwnerPassword,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **ownerPassword** owner password
+* **newUserPassword** new user password
+* **newOwnerPassword** new owner password
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+    const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+    console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/security/asposepdfdecrypt/_index.md
+++ b/korean/nodejs-cpp/security/asposepdfdecrypt/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfDecrypt"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 복호화합니다."
+type: docs
+url: /ko/nodejs-cpp/security/asposepdfdecrypt/
+---
+
+_PDF 파일을 복호화합니다._
+
+```js
+function AsposePdfDecrypt(
+    fileName,
+    password,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **password** user password 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+    console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/security/asposepdfencrypt/_index.md
+++ b/korean/nodejs-cpp/security/asposepdfencrypt/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfEncrypt"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일을 암호화합니다."
+type: docs
+url: /ko/nodejs-cpp/security/asposepdfencrypt/
+---
+
+_PDF 파일을 암호화합니다._
+
+```js
+function AsposePdfEncrypt(
+    fileName,
+    passwordUser,
+    passwordOwner,
+    permissions,
+    cryptoAlgorithm,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **passwordUser** user password 
+* **passwordOwner** owner password 
+* **permissions** encrypt permissions:
+  * Module.Permissions.PrintDocument
+  * Module.Permissions.ModifyContent
+  * Module.Permissions.ExtractContent
+  * Module.Permissions.ModifyTextAnnotations
+  * Module.Permissions.FillForm
+  * Module.Permissions.ExtractContentWithDisabilities
+  * Module.Permissions.AssembleDocument
+  * Module.Permissions.PrintingQuality 
+* **cryptoAlgorithm** encrypt algorithm:
+  * Module.CryptoAlgorithm.RC4x40
+  * Module.CryptoAlgorithm.RC4x128
+  * Module.CryptoAlgorithm.AESx128
+  * Module.CryptoAlgorithm.AESx256 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+    console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
+++ b/korean/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 디지털 서명을 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/security/asposepdfsignpkcs7/
+---
+
+_PDF 파일에 디지털 서명을 사용하여 서명합니다._
+
+```js
+function AsposePdfSignPKCS7(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'test.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'Aspose.jpg';
+    /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+    console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'test.pfx';
+/*Signature appearance*/
+const sign_img_file = 'Aspose.jpg';
+/*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/korean/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
+++ b/korean/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7Detached"
+second_title: "C++를 통해 Node.js용 Aspose.PDF"
+description: "PDF 파일에 분리된 디지털 서명을 추가합니다."
+type: docs
+url: /ko/nodejs-cpp/security/asposepdfsignpkcs7detached/
+---
+
+_PDF 파일에 분리된 디지털 서명을 사용하여 서명합니다._
+
+```js
+function AsposePdfSignPKCS7Detached(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON 객체
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'sign.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'sign.png';
+    /*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+    console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'sign.pfx';
+/*Signature appearance*/
+const sign_img_file = 'sign.png';
+/*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 94/94
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `korean/nodejs-cpp`

🤖 Generated by RDA