### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Swedish

### DIFF
--- a/swedish/nodejs-cpp/_index.md
+++ b/swedish/nodejs-cpp/_index.md
@@ -1,0 +1,134 @@
+---
+title: "Aspose.PDF för Node.js via C++"
+description: "Aspose.PDF för Node.js via C++"
+keywords:  "Node.js, Node, JavaScript, JS, PDF, PDF toolkit"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /sv/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Node.js via C++ allows developers manipulate them PDF files directly in the Node.js.
+
+
+## Convert from PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfPagesToJpg](./convert/asposepdfpagestojpg/) | Konvertera en PDF-fil till JPG. |
+| [AsposePdfPagesToPng](./convert/asposepdfpagestopng/) | Konvertera en PDF-fil till PNG. |
+| [AsposePdfPagesToTiff](./convert/asposepdfpagestotiff/) | Konvertera en PDF-fil till TIFF. |
+| [AsposePdfPagesToBmp](./convert/asposepdfpagestobmp/) | Konvertera en PDF-fil till BMP. |
+| [AsposePdfPagesToDICOM](./convert/asposepdfpagestodicom/) | Konvertera en PDF-fil till DICOM. |
+| [AsposePdfPagesToSvg](./convert/asposepdfpagestosvg/) | Konvertera en PDF-fil till SVG. |
+| [AsposePdfPagesToSvgZip](./convert/asposepdfpagestosvgzip/) | Konvertera en PDF-fil till SVG(zip). |
+| [AsposePdfToTeX](./convert/asposepdftotex/) | Konvertera en PDF-fil till TeX. |
+| [AsposePdfToXps](./convert/asposepdftoxps/) | Konvertera en PDF-fil till Xps. |
+| [AsposePdfTablesToCSV](./convert/asposepdftablestocsv/) | Konvertera en PDF-fil till CSV (extrahera tabeller). |
+| [AsposePdfToTxt](./convert/asposepdftotxt/) | Konvertera en PDF-fil till Txt. |
+| [AsposePdfConvertToGrayscale](./convert/asposepdfconverttograyscale/) | Konvertera en PDF-fil till gråskala. |
+| [AsposePdfConvertToPDFA](./convert/asposepdfconverttopdfa/) | Konvertera en PDF-fil till PDF/A. |
+| [AsposePdfAConvertToPDF](./convert/asposepdfaconverttopdf/) | Konvertera en PDF/A-fil till PDF. |
+| [AsposePdfToDocX](./convert/asposepdftodocx/) | Konvertera en PDF-fil till DocX. |
+| [AsposePdfToXlsX](./convert/asposepdftoxlsx/) | Konvertera en PDF-fil till XlsX. |
+| [AsposePdfToEPUB](./convert/asposepdftoepub/) | Konvertera en PDF-fil till ePub. |
+| [AsposePdfToDoc](./convert/asposepdftodoc/) | Konvertera en PDF-fil till Doc. |
+| [AsposePdfToPptX](./convert/asposepdftopptx/) | Konvertera en PDF-fil till PptX. |
+| [AsposePdfExtractText](./convert/asposepdfextracttext/) | Extrahera text från en PDF-fil. |
+| [AsposePdfExtractImage](./convert/asposepdfextractimage/) | Extrahera bild från en PDF-fil. |
+| [AsposePdfExportFdf](./convert/asposepdfexportfdf/) | Exportera från en PDF-fil med AcroForm till FDF. |
+| [AsposePdfExportXfdf](./convert/asposepdfexportxfdf/) | Exportera från en PDF-fil med AcroForm till XFDF. |
+| [AsposePdfExportXml](./convert/asposepdfexportxml/) | Exportera från en PDF-fil med AcroForm till XML. |
+| [AsposePdfPagesToPDF](./convert/asposepdfpagestopdf/) | Konvertera en PDF-fil till PDF (separata sidor). |
+| [AsposePdfToMarkdown](./convert/asposepdftomarkdown/) | Konvertera en PDF-fil till Markdown. |
+| [AsposePdfToDocXEnhanced](./convert/asposepdftodocxenhanced/) | Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge. |
+
+
+## Convert to PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfFromTxt](./convertpdf/asposepdffromtxt/) | Konvertera en TXT-fil till PDF. |
+| [AsposePdfFromImage](./convertpdf/asposepdffromimage/) | Konvertera en bildfil till PDF. |
+
+
+## Organize PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfOptimize](./organize/asposepdfoptimize/) | Optimera en PDF-fil. |
+| [AsposePdfMerge2Files](./organize/asposepdfmerge2files/) | Slå ihop två PDF-filer. |
+| [AsposePdfSplit2Files](./organize/asposepdfsplit2files/) | Dela upp i två PDF-filer. |
+| [AsposePdfRotateAllPages](./organize/asposepdfrotateallpages/) | Rotera PDF-sidor. |
+| [AsposePdfDeletePages](./organize/asposepdfdeletepages/) | Ta bort sidor från en PDF-fil. |
+| [AsposePdfAddStamp](./organize/asposepdfaddstamp/) | Lägg till stämpel i en PDF-fil. |
+| [AsposePdfAddStampPages](./organize/asposepdfaddstamppages/) | Lägg till stämpel på specifika sidor i en PDF-fil. |
+| [AsposePdfAddImage](./organize/asposepdfaddimage/) | Lägg till en bild i slutet av en PDF-fil. |
+| [AsposePdfAddPageNum](./organize/asposepdfaddpagenum/) | Lägg till sidnummer i en PDF-fil. |
+| [AsposePdfAddBackgroundImage](./organize/asposepdfaddbackgroundimage/) | Lägg till bakgrundsbild i en PDF-fil. |
+| [AsposePdfAddTextHeaderFooter](./organize/asposepdfaddtextheaderfooter/) | Lägg till text i sidhuvud/sidföt i en PDF-fil. |
+| [AsposePdfRepair](./organize/asposepdfrepair/) | Reparera en PDF-fil. |
+| [AsposePdfOptimizeResource](./organize/asposepdfoptimizeresource/) | Optimera resurser i PDF-filen. |
+| [AsposePdfSetBackgroundColor](./organize/asposepdfsetbackgroundcolor/) | Ställ in bakgrundsfärgen för PDF-filen. |
+| [AsposePdfDeleteAnnotations](./organize/asposepdfdeleteannotations/) | Ta bort annotationer från en PDF-fil. |
+| [AsposePdfDeleteBookmarks](./organize/asposepdfdeletebookmarks/) | Ta bort bokmärken från en PDF-fil. |
+| [AsposePdfDeleteAttachments](./organize/asposepdfdeleteattachments/) | Ta bort bilagor från en PDF-fil. |
+| [AsposePdfDeleteImages](./organize/asposepdfdeleteimages/) | Ta bort bilder från en PDF-fil. |
+| [AsposePdfDeleteJavaScripts](./organize/asposepdfdeletejavascripts/) | Ta bort JavaScript från en PDF-fil. |
+| [AsposePdfAddAttachment](./organize/asposepdfaddattachment/) | Lägg till bilaga i en PDF-fil. |
+| [AsposePdfGetAttachment](./organize/asposepdfgetattachment/) | Hämta bilaga från en PDF-fil. |
+| [AsposePdfReplaceText](./organize/asposepdfreplacetext/) | Ersätt text i en PDF-fil. |
+| [AsposePdfReplaceTextPages](./organize/asposepdfreplacetextpages/) | Ersätt text på sidor i en PDF-fil. |
+| [AsposePdfFindText](./organize/asposepdffindtext/) | Sök efter text i en PDF-fil. |
+| [AsposePdfReplaceFont](./organize/asposepdfreplacefont/) | Ersätt teckensnitt i en PDF-fil. |
+| [AsposePdfValidatePDFA](./organize/asposepdfvalidatepdfa/) | Validera PDF/A-kompatibilitet för en PDF-fil. |
+| [AsposePdfFindHiddenText](./organize/asposepdffindhiddentext/) | Sök efter dold text i en PDF-fil. |
+| [AsposePdfDeleteHiddenText](./organize/asposepdfdeletehiddentext/) | Ta bort dold text från en PDF-fil. |
+| [AsposePdfAddWatermark](./organize/asposepdfaddwatermark/) | Lägg till vattenstämpel i en PDF-fil. |
+| [AsposePdfDeleteWatermarks](./organize/asposepdfdeletewatermarks/) | Ta bort vattenstämplar från en PDF-fil. |
+| [AsposePdfMergeLayers](./organize/asposepdfmergelayers/) | Slå ihop lager i en PDF-fil. |
+| [AsposePdfFlatten](./organize/asposepdfflatten/) | Platta till en PDF-fil. |
+| [AsposePdfMakeBooklet](./organize/asposepdfmakebooklet/) | Skapa häfte från en PDF-fil. |
+| [AsposePdfMakeNUp](./organize/asposepdfmakenup/) | Skapa N‑Up-dokument från en PDF-fil. |
+| [AsposePdfDeleteBlankPages](./organize/asposepdfdeleteblankpages/) | Ta bort tomma sidor från en PDF-fil. |
+| [AsposePdfEmbedFonts](./organize/asposepdfembedfonts/) | Bädda in teckensnitt i en PDF-fil. |
+| [AsposePdfUnembedFonts](./organize/asposepdfunembedfonts/) | Ta bort inbäddade teckensnitt från en PDF-fil. |
+| [AsposePdfOptimizeFileSize](./organize/asposepdfoptimizefilesize/) | Optimera storleken på PDF-filen med bildkomprimeringskvalitet. |
+| [AsposePdfDeleteTables](./organize/asposepdfdeletetables/) | Ta bort tabeller från en PDF-fil. |
+| [AsposePdfCropPages](./organize/asposepdfcroppages/) | Beskär PDF-sidor. |
+| [AsposePdfDeleteTextHeaders](./organize/asposepdfdeletetextheaders/) | Ta bort textrubriker från en PDF-fil. |
+| [AsposePdfDeleteTextFooters](./organize/asposepdfdeletetextfooters/) | Ta bort textfot från en PDF-fil. |
+| [AsposePdfReplaceTextEx](./organize/asposepdfreplacetextex/) | Ersätt flera textfragment i en PDF-fil med justeringskontroll. |
+| [AsposePdfRecover](./organize/asposepdfrecover/) | Återställ en PDF-filstruktur och rensa ogiltiga data. |
+| [AsposePdfRebuildXrefAndTrailer](./organize/asposepdfrebuildxrefandtrailer/) | Bygg om en PDF-filens korsreferenstabell och trailerstrukturer. |
+| [AsposePdfReversePages](./organize/asposepdfreversepages/) | Vänd på sidordningen i en PDF-fil. |
+
+
+## Metadata PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfSetInfo](./metadata/asposepdfsetinfo/) | Ställ in information (metadata) i en PDF-fil. |
+| [AsposePdfGetInfo](./metadata/asposepdfgetinfo/) | Hämta information (metadata) från en PDF-fil. |
+| [AsposePdfGetAllFonts](./metadata/asposepdfgetallfonts/) | Hämta lista över teckensnitt från en PDF-fil. |
+| [AsposePdfRemoveMetadata](./metadata/asposepdfremovemetadata/) | Ta bort metadata från en PDF-fil. |
+| [AsposePdfGetWordsCharactersCount](./metadata/asposepdfgetwordscharacterscount/) | Hämta antal ord och tecken i en PDF-fil. |
+| [AsposePdfGetPagesLayers](./metadata/asposepdfgetpageslayers/) | Hämta lista över lager från en PDF-fil. |
+
+
+## Security PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposePdfEncrypt](./security/asposepdfencrypt/) | Kryptera en PDF-fil. |
+| [AsposePdfDecrypt](./security/asposepdfdecrypt/) | Dekryptera en PDF-fil. |
+| [AsposePdfSignPKCS7](./security/asposepdfsignpkcs7/) | Signera en PDF-fil med digitala signaturer. |
+| [AsposePdfSignPKCS7Detached](./security/asposepdfsignpkcs7detached/) | Signera en PDF-fil med fristående digitala signaturer. |
+| [AsposePdfChangePassword](./security/asposepdfchangepassword/) | Ändra lösenord för PDF-filen. |
+
+## Miscellaneous
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfAbout](./misc/asposepdfabout/) | Hämta information om produkten. |

--- a/swedish/nodejs-cpp/convert/_index.md
+++ b/swedish/nodejs-cpp/convert/_index.md
@@ -1,0 +1,56 @@
+---
+title: "Konvertera från PDF-funktioner"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Funktioner för konvertering från PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfPagesToJpg](./asposepdfpagestojpg/) | Konvertera en PDF-fil till JPG. |
+| [AsposePdfPagesToPng](./asposepdfpagestopng/) | Konvertera en PDF-fil till PNG. |
+| [AsposePdfPagesToTiff](./asposepdfpagestotiff/) | Konvertera en PDF-fil till TIFF. |
+| [AsposePdfPagesToBmp](./asposepdfpagestobmp/) | Konvertera en PDF-fil till BMP. |
+| [AsposePdfPagesToDICOM](./asposepdfpagestodicom/) | Konvertera en PDF-fil till DICOM. |
+| [AsposePdfPagesToSvg](./asposepdfpagestosvg/) | Konvertera en PDF-fil till SVG. |
+| [AsposePdfPagesToSvgZip](./asposepdfpagestosvgzip/) | Konvertera en PDF-fil till SVG(zip). |
+| [AsposePdfToTeX](./asposepdftotex/) | Konvertera en PDF-fil till TeX. |
+| [AsposePdfToXps](./asposepdftoxps/) | Konvertera en PDF-fil till Xps. |
+| [AsposePdfTablesToCSV](./asposepdftablestocsv/) | Konvertera en PDF-fil till CSV (extrahera tabeller). |
+| [AsposePdfToTxt](./asposepdftotxt/) | Konvertera en PDF-fil till Txt. |
+| [AsposePdfConvertToGrayscale](./asposepdfconverttograyscale/) | Konvertera en PDF-fil till gråskala. |
+| [AsposePdfConvertToPDFA](./asposepdfconverttopdfa/) | Konvertera en PDF-fil till PDF/A. |
+| [AsposePdfAConvertToPDF](./asposepdfaconverttopdf/) | Konvertera en PDF/A-fil till PDF. |
+| [AsposePdfToDocX](./asposepdftodocx/) | Konvertera en PDF-fil till DocX. |
+| [AsposePdfToXlsX](./asposepdftoxlsx/) | Konvertera en PDF-fil till XlsX. |
+| [AsposePdfToEPUB](./asposepdftoepub/) | Konvertera en PDF-fil till ePub. |
+| [AsposePdfToDoc](./asposepdftodoc/) | Konvertera en PDF-fil till Doc. |
+| [AsposePdfToPptX](./asposepdftopptx/) | Konvertera en PDF-fil till PptX. |
+| [AsposePdfExtractText](./asposepdfextracttext/) | Extrahera text från en PDF-fil. |
+| [AsposePdfExtractImage](./asposepdfextractimage/) | Extrahera bild från en PDF-fil. |
+| [AsposePdfExportFdf](./asposepdfexportfdf/) | Exportera från en PDF-fil med AcroForm till FDF. |
+| [AsposePdfExportXfdf](./asposepdfexportxfdf/) | Exportera från en PDF-fil med AcroForm till XFDF. |
+| [AsposePdfExportXml](./asposepdfexportxml/) | Exportera från en PDF-fil med AcroForm till XML. |
+| [AsposePdfPagesToPDF](./asposepdfpagestopdf/) | Konvertera en PDF-fil till PDF (separata sidor). |
+| [AsposePdfToMarkdown](./asposepdftomarkdown/) | Konvertera en PDF-fil till Markdown. |
+| [AsposePdfToDocXEnhanced](./asposepdftodocxenhanced/) | Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge. |
+
+
+## Detailed Description
+
+Funktioner för konvertering från PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfaconverttopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfAConvertToPDF"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF/A-fil till PDF."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfaconverttopdf/
+---
+
+_Konvertera en PDF/A-fil till PDF._
+
+```js
+function AsposePdfAConvertToPDF(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+    const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+    console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_PDFA_file = 'ResultConvertToPDFA.pdf';
+/*Convert a PDF/A-file to PDF and save the "ResultConvertToPDF.pdf"*/
+const json = AsposePdfModule.AsposePdfAConvertToPDF(pdf_PDFA_file, "ResultConvertToPDF.pdf");
+console.log("AsposePdfAConvertToPDF => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfconverttograyscale/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfConvertToGrayscale"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till gråskala."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfconverttograyscale/
+---
+
+_Konvertera en PDF-fil till gråskala._
+
+```js
+function AsposePdfConvertToGrayscale(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+    const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+    console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to grayscale and save the "ResultConvertToGrayscale.pdf"*/
+const json = AsposePdfModule.AsposePdfConvertToGrayscale(pdf_file, "ResultConvertToGrayscale.pdf");
+console.log("AsposePdfConvertToGrayscale => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfconverttopdfa/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposePdfConvertToPDFA"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till PDF/A."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfconverttopdfa/
+---
+
+_Konvertera en PDF-fil till PDF/A._
+
+```js
+function AsposePdfConvertToPDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult,
+    fileNameLogResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name
+* **fileNameLogResult** result Log (xml) file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+  * **fileNameLogResult** - result Log (xml) file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+    /*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+    console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PDF/A(1A) and save the "ResultConvertToPDFA.pdf"*/
+/*During conversion process, the validation is also performed, "ResultConvertToPDFA.xml"*/
+const json = AsposePdfModule.AsposePdfConvertToPDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultConvertToPDFA.pdf", "ResultConvertToPDFALog.xml");
+console.log("AsposePdfConvertToPDFA => %O", json.errorCode == 0 ? [json.fileNameResult, json.fileNameLogResult] : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfexportfdf/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfexportfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportFdf"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Exportera från en PDF-fil med AcroForm till FDF."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfexportfdf/
+---
+
+_Exportera från en PDF-fil med AcroForm till FDF._
+
+```js
+function AsposePdfExportFdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+    const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+    console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to FDF and save the "ResultPdfExportFdf.fdf"*/
+const json = AsposePdfModule.AsposePdfExportFdf(pdf_file, "ResultPdfExportFdf.fdf");
+console.log("AsposePdfExportFdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfexportxfdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXfdf"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Exportera från en PDF-fil med AcroForm till XFDF."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfexportxfdf/
+---
+
+_Exportera från en PDF-fil med AcroForm till XFDF._
+
+```js
+function AsposePdfExportXfdf(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+    const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+    console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XFDF and save the "ResultPdfExportXfdf.xfdf"*/
+const json = AsposePdfModule.AsposePdfExportXfdf(pdf_file, "ResultPdfExportXfdf.xfdf");
+console.log("AsposePdfExportXfdf => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfexportxml/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfexportxml/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfExportXml"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Exportera från en PDF-fil med AcroForm till XML."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfexportxml/
+---
+
+_Exportera från en PDF-fil med AcroForm till XML._
+
+```js
+function AsposePdfExportXml(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+    const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+    console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Export from a PDF-file with AcroForm to XML and save the "ResultPdfExportXml.xml"*/
+const json = AsposePdfModule.AsposePdfExportXml(pdf_file, "ResultPdfExportXml.xml");
+console.log("AsposePdfExportXml => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfextractimage/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfextractimage/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfExtractImage"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Extrahera bild från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfextractimage/
+---
+
+_Extrahera bild från en PDF-fil._
+
+```js
+function AsposePdfExtractImage(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfExtractImage{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - image files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+    console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract image from a PDF-file with template "ResultPdfExtractImage{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfExtractImage(pdf_file, "ResultPdfExtractImage{0:D2}.jpg", 150);
+console.log("AsposePdfExtractImage => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfextracttext/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfextracttext/_index.md
@@ -1,0 +1,48 @@
+---
+title: "AsposePdfExtractText"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Extrahera text från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfextracttext/
+---
+
+_Extrahera text från en PDF-fil._
+
+```js
+function AsposePdfExtractText(
+    fileName 
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **extractText** - text from PDF
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Extract text from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+    console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Extract text from a PDF-file*/
+const json = AsposePdfModule.AsposePdfExtractText(pdf_file);
+console.log("AsposePdfExtractText => %O", json.errorCode == 0 ? json.extractText : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestobmp/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToBmp"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till BMP."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestobmp/
+---
+
+_Konvertera en PDF-fil till BMP._
+
+```
+function AsposePdfPagesToBmp(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToBmp{0:D2}.bmp" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - bmp files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+    console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to BMP with template "ResultPdfToBmp{0:D2}.bmp" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToBmp(pdf_file, "ResultPdfToBmp{0:D2}.bmp", 150);
+console.log("AsposePdfPagesToBmp => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestodicom/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToDICOM"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till DICOM."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestodicom/
+---
+
+_Konvertera en PDF-fil till DICOM._
+
+```js
+function AsposePdfPagesToDICOM(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToDICOM{0:D2}.dcm" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - DICOM (.dcm) files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+    console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DICOM with template "ResultPdfToDICOM{0:D2}.dcm" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToDICOM(pdf_file, "ResultPdfToDICOM{0:D2}.dcm", 150);
+console.log("AsposePdfPagesToDICOM => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestojpg/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToJpg"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till JPG."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestojpg/
+---
+
+_Konvertera en PDF-fil till JPG._
+
+```js
+function AsposePdfPagesToJpg(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToJpg{0:D2}.jpg" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - jpg files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+    console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to JPG with template "ResultPdfToJpg{0:D2}.jpg" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToJpg(pdf_file, "ResultPdfToJpg{0:D2}.jpg", 150);
+console.log("AsposePdfPagesToJpg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestopdf/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToPDF"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till PDF (separata sidor)."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestopdf/
+---
+
+_Konvertera en PDF-fil till PDF (separata sidor)._
+
+```
+function AsposePdfPagesToPDF(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfPagesToPDF{0:D2}.pdf" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - result files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+    console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to separate PDF pages with template "ResultPdfToPDF{0:D2}.pdf" ({0}, {0:D2}, {0:D3}, ... format page number) and save*/
+const json = AsposePdfModule.AsposePdfPagesToPDF(pdf_file, "ResultPdfToPDF{0:D2}.pdf");
+console.log("AsposePdfPagesToPDF => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestopng/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestopng/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToPng"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till PNG."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestopng/
+---
+
+_Konvertera en PDF-fil till PNG._
+
+```
+function AsposePdfPagesToPng(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToPng{0:D2}.png" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+    console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PNG with template "ResultPdfToPng{0:D2}.png" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToPng(pdf_file, "ResultPdfToPng{0:D2}.png", 150);
+console.log("AsposePdfPagesToPng => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestosvg/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfPagesToSvg"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till SVG."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestosvg/
+---
+
+_Konvertera en PDF-fil till SVG._
+
+```
+function AsposePdfPagesToSvg(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - png files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+    console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to SVG and save the "ResultPdfToSvg.svg"*/
+const json = AsposePdfModule.AsposePdfPagesToSvg(pdf_file, "ResultPdfToSvg.svg");
+console.log("AsposePdfPagesToSvg => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestosvgzip/_index.md
@@ -1,0 +1,50 @@
+---
+title: "AsposePdfPagesToSvgZip"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till SVG(zip)."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestosvgzip/
+---
+
+_Konvertera en PDF-fil till SVG(zip)._
+
+```
+function AsposePdfPagesToSvgZip(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to SVG(zip) and save the "ResultPdfToSvgZip.zip"*/
+    const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+    console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*convert a PDF-file to SVG zip and save the "ResultPdfToSvgZip.zip"*/
+const json = AsposePdfModule.AsposePdfPagesToSvgZip(pdf_file, "ResultPdfToSvgZip.zip");
+console.log("AsposePdfPagesToSvgZip => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText)
+```

--- a/swedish/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdfpagestotiff/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfPagesToTiff"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till TIFF."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdfpagestotiff/
+---
+
+_Konvertera en PDF-fil till TIFF._
+
+```
+function AsposePdfPagesToTiff(
+    fileName,
+    fileNameResult,
+    resolution
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfToTiff{0:D2}.tiff" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **resolution** image resolution, default 300 dpi
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - tiff files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+    const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+    console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TIFF with template "ResultPdfToTiff{0:D2}.tiff" ({0}, {0:D2}, {0:D3}, ... format page number), resolution 150 DPI and save*/
+const json = AsposePdfModule.AsposePdfPagesToTiff(pdf_file, "ResultPdfToTiff{0:D2}.tiff", 150);
+console.log("AsposePdfPagesToTiff => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftablestocsv/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftablestocsv/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfTablesToCSV"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till CSV (extrahera tabeller)."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftablestocsv/
+---
+
+_Konvertera en PDF-fil till CSV (extrahera tabeller)._
+
+```
+function AsposePdfTablesToCSV(
+    fileName,
+    fileNameResult,
+    delimiter
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfTablesToCSV{0:D2}.csv" where {0}, {0:D2}, {0:D3}, {0:Dn} - format page number) 
+  * **delimiter** delimiter for csv (comma-separated value), default ";"
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - csv files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+    const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+    console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to CSV (extract tables) with template "ResultPdfTablesToCSV{0:D2}.csv" ({0}, {0:D2}, {0:D3}, ... format page number), TAB as delimiter and save*/
+const json = AsposePdfModule.AsposePdfTablesToCSV(pdf_file, "ResultPdfTablesToCSV{0:D2}.csv", "\t");
+console.log("AsposePdfTablesToCSV => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftodoc/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftodoc/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDoc"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till Doc."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftodoc/
+---
+
+_Konvertera en PDF-fil till Doc._
+
+```js
+function AsposePdfToDoc(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+    const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+    console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Doc and save the "ResultPDFtoDoc.doc"*/
+const json = AsposePdfModule.AsposePdfToDoc(pdf_file, "ResultPDFtoDoc.doc");
+console.log("AsposePdfToDoc => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftodocx/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftodocx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocX"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till DocX."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftodocx/
+---
+
+_Konvertera en PDF-fil till DocX._
+
+```js
+function AsposePdfToDocX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+    console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX and save the "ResultPDFtoDocX.docx"*/
+const json = AsposePdfModule.AsposePdfToDocX(pdf_file, "ResultPDFtoDocX.docx");
+console.log("AsposePdfToDocX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftodocxenhanced/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToDocXEnhanced"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftodocxenhanced/
+---
+
+_Konvertera en PDF-fil till DocX med förbättrat igenkänningsläge (fullt redigerbara tabeller och stycken)._
+
+```js
+function AsposePdfToDocXEnhanced(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+    const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+    console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to DocX with Enhanced Recognition Mode (fully editable tables and paragraphs) and save the "ResultPDFtoDocXEnhanced.docx"*/
+const json = AsposePdfModule.AsposePdfToDocXEnhanced(pdf_file, "ResultPDFtoDocXEnhanced.docx");
+console.log("AsposePdfToDocXEnhanced => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftoepub/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftoepub/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToEPUB"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till ePub."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftoepub/
+---
+
+_Konvertera en PDF-fil till ePub._
+
+```js
+function AsposePdfToEPUB(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+    const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+    console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to ePub and save the "ResultPDFtoEPUB.epub"*/
+const json = AsposePdfModule.AsposePdfToEPUB(pdf_file, "ResultPDFtoEPUB.epub");
+console.log("AsposePdfToEPUB => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftomarkdown/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftomarkdown/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToMarkdown"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till Markdown."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftomarkdown/
+---
+
+_Konvertera en PDF-fil till Markdown._
+
+```js
+function AsposePdfToMarkdown(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+    const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+    console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Markdown and save the "ResultPDFtoMarkdown.md"*/
+const json = AsposePdfModule.AsposePdfToMarkdown(pdf_file, "ResultPDFtoMarkdown.md");
+console.log("AsposePdfToMarkdown => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftopptx/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftopptx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToPptX"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till PptX."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftopptx/
+---
+
+_Konvertera en PDF-fil till PptX._
+
+```js
+function AsposePdfToPptX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+    const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+    console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to PptX and save the "ResultPDFtoPptX.pptx"*/
+const json = AsposePdfModule.AsposePdfToPptX(pdf_file, "ResultPDFtoPptX.pptx");
+console.log("AsposePdfToPptX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftotex/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftotex/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTeX"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till TeX."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftotex/
+---
+
+_Konvertera en PDF-fil till TeX._
+
+```js
+function AsposePdfToTeX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+    const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+    console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to TeX and save the "ResultPDFtoTeX.tex"*/
+const json = AsposePdfModule.AsposePdfToTeX(pdf_file, "ResultPDFtoTeX.tex");
+console.log("AsposePdfToTeX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftotxt/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftotxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToTxt"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till Txt."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftotxt/
+---
+
+_Konvertera en PDF-fil till Txt._
+
+```js
+function AsposePdfToTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+    const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+    console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Txt and save the "ResultPDFtoTxt.txt"*/
+const json = AsposePdfModule.AsposePdfToTxt(pdf_file, "ResultPDFtoTxt.txt");
+console.log("AsposePdfToTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftoxlsx/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftoxlsx/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXlsX"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till XlsX."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftoxlsx/
+---
+
+_Konvertera en PDF-fil till XlsX._
+
+```js
+function AsposePdfToXlsX(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+    const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+    console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to XlsX and save the "ResultPDFtoXlsX.xlsx"*/
+const json = AsposePdfModule.AsposePdfToXlsX(pdf_file, "ResultPDFtoXlsX.xlsx");
+console.log("AsposePdfToXlsX => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convert/asposepdftoxps/_index.md
+++ b/swedish/nodejs-cpp/convert/asposepdftoxps/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfToXps"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en PDF-fil till Xps."
+type: docs
+url: /sv/nodejs-cpp/convert/asposepdftoxps/
+---
+
+_Konvertera en PDF-fil till Xps._
+
+```js
+function AsposePdfToXps(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+    const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+    console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Convert a PDF-file to Xps and save the "ResultPDFtoXps.xps"*/
+const json = AsposePdfModule.AsposePdfToXps(pdf_file, "ResultPDFtoXps.xps");
+console.log("AsposePdfToXps => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convertpdf/_index.md
+++ b/swedish/nodejs-cpp/convertpdf/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Konvertera till PDF-funktioner"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Funktioner för att konvertera till PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/convertpdf/
+---
+
+## Convert to PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfFromTxt](./asposepdffromtxt/) | Konvertera en TXT-fil till PDF. |
+| [AsposePdfFromImage](./asposepdffromimage/) | Konvertera en bildfil till PDF. |
+
+## Detailed Description
+
+Funktioner för att konvertera till PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
+++ b/swedish/nodejs-cpp/convertpdf/asposepdffromimage/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfFromImage"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en bildfil till PDF."
+type: docs
+url: /sv/nodejs-cpp/convertpdf/asposepdffromimage/
+---
+
+_Konvertera en bildfil till PDF._
+
+```js
+function AsposePdfFromImage(
+    fileName,
+    pdfPageSize,
+    margin,
+    isLandscape,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** image file name (support bmp, jpeg, png, tiff, gif formats)
+* **pdfPageSize**  page size:
+  * Module.PdfPageSize.A0
+  * Module.PdfPageSize.A1
+  * Module.PdfPageSize.A2
+  * Module.PdfPageSize.A3
+  * Module.PdfPageSize.A4
+  * Module.PdfPageSize.A5
+  * Module.PdfPageSize.A6
+  * Module.PdfPageSize.B5
+  * Module.PdfPageSize.PageLetter
+  * Module.PdfPageSize.PageLegal
+  * Module.PdfPageSize.PageLedger
+  * Module.PdfPageSize.P11x17
+  * Module.PdfPageSize.ImageSize
+* **margin** page margin
+* **isLandscape** page landscape mode (0 or 1)
+* **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const aspose_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+    console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const aspose_file = 'Aspose.jpg';
+/*Convert a Image-file to PDF and save the "ResultPDFFromImage.pdf"*/
+const json = AsposePdfModule.AsposePdfFromImage(aspose_file, AsposePdfModule.PdfPageSize.A4, 10, false, "ResultPdfFromImage.pdf");
+console.log("AsposePdfFromImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
+++ b/swedish/nodejs-cpp/convertpdf/asposepdffromtxt/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFromTxt"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Konvertera en TXT-fil till PDF."
+type: docs
+url: /sv/nodejs-cpp/convertpdf/asposepdffromtxt/
+---
+
+_Konvertera en TXT-fil till PDF._
+
+```js
+function AsposePdfFromTxt(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+    const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+    console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const txt_file = 'ReadMe.txt';
+/*Convert a TXT-file to PDF and save the "ResultPDFFromTxt.pdf"*/
+const json = AsposePdfModule.AsposePdfFromTxt(txt_file, "ResultPDFFromTxt.pdf");
+console.log("AsposePdfFromTxt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/_index.md
+++ b/swedish/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,35 @@
+---
+title: "Metadata PDF-funktioner"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Funktioner för att arbeta med Metadata PDF-filer"
+type: docs
+url: /sv/nodejs-cpp/metadata/
+---
+
+## Metadata PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfSetInfo](./asposepdfsetinfo/) | Ställ in information (metadata) i en PDF-fil. |
+| [AsposePdfGetInfo](./asposepdfgetinfo/) | Hämta information (metadata) från en PDF-fil. |
+| [AsposePdfGetAllFonts](./asposepdfgetallfonts/) | Hämta lista över teckensnitt från en PDF-fil. |
+| [AsposePdfRemoveMetadata](./asposepdfremovemetadata/) | Ta bort metadata från en PDF-fil. |
+| [AsposePdfGetWordsCharactersCount](./asposepdfgetwordscharacterscount/) | Hämta antal ord och tecken i en PDF-fil. |
+| [AsposePdfGetPagesLayers](./asposepdfgetpageslayers/) | Hämta lista över lager från en PDF-fil. |
+
+
+## Detailed Description
+
+Funktioner för att arbeta med Metadata PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfgetallfonts/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePdfGetAllFonts"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta lista över teckensnitt från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfgetallfonts/
+---
+
+_Hämta lista med teckensnitt från en PDF-fil._
+
+```js
+function AsposePdfGetAllFonts(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fonts** - array of : 
+  * fontName - font name
+  * isEmbedded - indicates whether the font is embedded
+  * isAccessible - indicating whether the font is present
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list fonts from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+    /*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+    console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list fonts from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetAllFonts(pdf_file);
+/*json.fonts - array of fonts: { fontName: <string>, isEmbedded: <boolean>, isAccessible: <boolean> }*/
+console.log("AsposePdfGetAllFonts => fonts: %O", json.errorCode == 0 ? json.fonts : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfgetinfo/_index.md
@@ -1,0 +1,123 @@
+---
+title: "AsposePdfGetInfo"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta information (metadata) från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfgetinfo/
+---
+
+_Hämta information (metadata) från en PDF-fil._
+
+```js
+function AsposePdfGetInfo(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **title** - title
+* **creator** - creator
+* **author** - author
+* **subject** - subject
+* **keywords** - keywords
+* **creation** - creation date
+* **mod** - modify date
+* **format** - PDF format
+* **version** - PDF version
+* **ispdfa** - PDF is PDF/A
+* **ispdfua** - PDF is PDF/UA
+* **islinearized** - PDF is linearized
+* **isencrypted** - PDF is encrypted
+* **permission** - PDF permission
+* **size** - PDF page size
+* **pagecount** - Page count
+* **annotationcount** - Annotation count
+* **bookmarkcount** - Bookmark count
+* **attachmentcount** - Attachment count
+* **metadatacount** - Metadata count
+* **javascriptcount** - JavaScript count
+* **imagecount** - Image count
+* **tablecount** - Table count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get info (metadata) from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+    /* JSON
+       Title             : json.title
+       Creator           : json.creator
+       Author            : json.author
+       Subject           : json.subject
+       Keywords          : json.keywords
+       Creation Date     : json.creation
+       Modify Date       : json.mod
+       PDF format        : json.format
+       PDF version       : json.version
+       PDF is PDF/A      : json.ispdfa
+       PDF is PDF/UA     : json.ispdfua
+       PDF is linearized : json.islinearized
+       PDF is encrypted  : json.isencrypted
+       PDF permission    : json.permission
+       PDF page size     : json.size
+       Page count        : json.pagecount
+       Annotation count  : json.annotationcount
+       Bookmark count    : json.bookmarkcount
+       Attachment count  : json.attachmentcount
+       Metadata count    : json.metadatacount
+       JavaScript count  : json.javascriptcount
+       Image count       : json.imagecount
+       Table count       : json.tablecount
+    */
+    console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get info (metadata) from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetInfo(pdf_file);
+/* JSON
+   Title             : json.title
+   Creator           : json.creator
+   Author            : json.author
+   Subject           : json.subject
+   Keywords          : json.keywords
+   Creation Date     : json.creation
+   Modify Date       : json.mod
+   PDF format        : json.format
+   PDF version       : json.version
+   PDF is PDF/A      : json.ispdfa
+   PDF is PDF/UA     : json.ispdfua
+   PDF is linearized : json.islinearized
+   PDF is encrypted  : json.isencrypted
+   PDF permission    : json.permission
+   PDF page size     : json.size
+   Page count        : json.pagecount
+   Annotation count  : json.annotationcount
+   Bookmark count    : json.bookmarkcount
+   Attachment count  : json.attachmentcount
+   Metadata count    : json.metadatacount
+   JavaScript count  : json.javascriptcount
+   Image count       : json.imagecount
+   Table count       : json.tablecount
+*/
+console.log("AsposePdfGetInfo => %O", json.errorCode == 0 ? 'Title: ' + json.title : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfgetpageslayers/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfGetPagesLayers"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta lista över lager från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfgetpageslayers/
+---
+
+_Hämta lista med lager från en PDF-fil._
+
+```js
+function AsposePdfGetPagesLayers(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **pagesLayers[][]** - list of pages with lists of layers on each page
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get list layers from a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+    /*json.pagesLayers - list of pages with lists of layers on each page*/
+    console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get list layers from a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetPagesLayers(pdf_file);
+/*json.pagesLayers - list of pages with lists of layers on each page*/
+console.log("AsposePdfGetPagesLayers => layers: %O", json.errorCode == 0 ? json.pagesLayers : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposePdfGetWordsCharactersCount"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta antal ord och tecken i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfgetwordscharacterscount/
+---
+
+_Hämta antal ord och tecken i en PDF-fil._
+
+```js
+function AsposePdfGetWordsCharactersCount(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **words** - words count
+* **characters** - characters count
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get words and characters count in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+    /* JSON
+       Words count      : json.words
+       Characters count : json.characters
+    */
+    console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get words and characters count in a PDF-file*/
+const json = AsposePdfModule.AsposePdfGetWordsCharactersCount(pdf_file);
+/* JSON
+   Words count      : json.words
+   Characters count : json.characters
+*/
+console.log("AsposePdfGetWordsCharactersCount => %O", json.errorCode == 0 ? 'Words count: ' + json.words : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfremovemetadata/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRemoveMetadata"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort metadata från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfremovemetadata/
+---
+
+_Ta bort metadata från en PDF-fil._
+
+```js
+function AsposePdfRemoveMetadata(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+    const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+    console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Remove metadata from a PDF-file and save the "ResultPdfRemoveMetadata.pdf"*/
+const json = AsposePdfModule.AsposePdfRemoveMetadata(pdf_file, "ResultPdfRemoveMetadata.pdf");
+console.log("AsposePdfRemoveMetadata => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposepdfsetinfo/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfSetInfo"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ställ in information (metadata) i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposepdfsetinfo/
+---
+
+_Ställ in information (metadata) i en PDF-fil._
+
+```js
+function AsposePdfSetInfo(
+    fileName,
+    title, 
+    creator, 
+    author,
+    subject,
+    keywords,
+    creation,
+    mod,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **title** title
+* **creator** creator
+* **author** author
+* **subject** subject
+* **keywords** list keywords
+* **creation** creation date
+* **mod** modify date
+* **fileNameResult** result file name
+
+För 'title', 'creator', 'author', 'subject', 'keywords', 'creation' och 'mod', om du inte behöver ange ett värde, använd undefined eller "" (tom sträng)
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+    /*If not need to set value, use undefined or "" (empty string)*/
+    /*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+    console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set PDF info: title, creator, author, subject, keywords, creation (date), mod (date modify)*/
+/*If not need to set value, use undefined or "" (empty string)*/
+/*Set info (metadata) in a PDF-file and save the "ResultSetInfo.pdf"*/
+const json = AsposePdfModule.AsposePdfSetInfo(pdf_file, "Setting PDF Document Information", "", "Aspose", undefined, "Aspose.Pdf, DOM, API", undefined, "05/05/2023 11:55 PM", "ResultSetInfo.pdf");
+console.log("AsposePdfSetInfo => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/misc/_index.md
+++ b/swedish/nodejs-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Övriga funktioner"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Sekundära funktioner för att arbeta med PDF-filer"
+type: docs
+url: /sv/nodejs-cpp/misc/
+---
+
+## Miscellaneous PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfAbout](./asposepdfabout/) | Hämta information om produkten. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/misc/asposepdfabout/_index.md
+++ b/swedish/nodejs-cpp/misc/asposepdfabout/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposePdfAbout"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta information om produkten."
+type: docs
+url: /sv/nodejs-cpp/misc/asposepdfabout/
+---
+
+_Hämta information om produkten._
+
+```js
+function AsposePdfAbout()
+```
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **product** - Product name
+* **family** - Product family
+* **version** - Product version
+* **releasedate** - Date release
+* **producer** - Full name/producer
+* **islicensed** - Product is licensed
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+AsposePdf().then(AsposePdfModule => {
+    /*AsposePdfAbout - Get info about Product*/
+    const json = AsposePdfModule.AsposePdfAbout();
+    /* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+    */
+    console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+/*AsposePdfAbout - Get info about Product*/
+const json = AsposePdfModule.AsposePdfAbout();
+/* JSON
+    Product name       : json.product
+    Product family     : json.family
+    Product version    : json.version
+    Date release       : json.releasedate
+    Full name/producer : json.producer
+    Product is licensed: json.islicensed
+*/
+console.log("AsposePdfAbout => %O", json.errorCode == 0 ? 'Full name/producer: ' + json.producer : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/_index.md
+++ b/swedish/nodejs-cpp/organize/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Organisera PDF-funktioner"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Funktioner för att organisera PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfOptimize](./asposepdfoptimize/) | Optimera en PDF-fil. |
+| [AsposePdfMerge2Files](./asposepdfmerge2files/) | Slå ihop två PDF-filer. |
+| [AsposePdfSplit2Files](./asposepdfsplit2files/) | Dela upp i två PDF-filer. |
+| [AsposePdfRotateAllPages](./asposepdfrotateallpages/) | Rotera PDF-sidor. |
+| [AsposePdfDeletePages](./asposepdfdeletepages/) | Ta bort sidor från en PDF-fil. |
+| [AsposePdfAddStamp](./asposepdfaddstamp/) | Lägg till stämpel i en PDF-fil. |
+| [AsposePdfAddStampPages](./asposepdfaddstamppages/) | Lägg till stämpel på specifika sidor i en PDF-fil. |
+| [AsposePdfAddImage](./asposepdfaddimage/) | Lägg till en bild i slutet av en PDF-fil. |
+| [AsposePdfAddPageNum](./asposepdfaddpagenum/) | Lägg till sidnummer i en PDF-fil. |
+| [AsposePdfAddBackgroundImage](./asposepdfaddbackgroundimage/) | Lägg till bakgrundsbild i en PDF-fil. |
+| [AsposePdfAddTextHeaderFooter](./asposepdfaddtextheaderfooter/) | Lägg till text i sidhuvud/sidföt i en PDF-fil. |
+| [AsposePdfRepair](./asposepdfrepair/) | Reparera en PDF-fil. |
+| [AsposePdfOptimizeResource](./asposepdfoptimizeresource/) | Optimera resurser i PDF-filen. |
+| [AsposePdfSetBackgroundColor](./asposepdfsetbackgroundcolor/) | Ställ in bakgrundsfärgen för PDF-filen. |
+| [AsposePdfDeleteAnnotations](./asposepdfdeleteannotations/) | Ta bort annotationer från en PDF-fil. |
+| [AsposePdfDeleteBookmarks](./asposepdfdeletebookmarks/) | Ta bort bokmärken från en PDF-fil. |
+| [AsposePdfDeleteAttachments](./asposepdfdeleteattachments/) | Ta bort bilagor från en PDF-fil. |
+| [AsposePdfDeleteImages](./asposepdfdeleteimages/) | Ta bort bilder från en PDF-fil. |
+| [AsposePdfDeleteJavaScripts](./asposepdfdeletejavascripts/) | Ta bort JavaScript från en PDF-fil. |
+| [AsposePdfAddAttachment](./asposepdfaddattachment/) | Lägg till bilaga i en PDF-fil. |
+| [AsposePdfGetAttachment](./asposepdfgetattachment/) | Hämta bilaga från en PDF-fil. |
+| [AsposePdfReplaceText](./asposepdfreplacetext/) | Ersätt text i en PDF-fil. |
+| [AsposePdfReplaceTextPages](./asposepdfreplacetextpages/) | Ersätt text på sidor i en PDF-fil. |
+| [AsposePdfFindText](./asposepdffindtext/) | Sök efter text i en PDF-fil. |
+| [AsposePdfReplaceFont](./asposepdfreplacefont/) | Ersätt teckensnitt i en PDF-fil. |
+| [AsposePdfValidatePDFA](./asposepdfvalidatepdfa/) | Validera PDF/A-kompatibilitet för en PDF-fil. |
+| [AsposePdfFindHiddenText](./asposepdffindhiddentext/) | Sök efter dold text i en PDF-fil. |
+| [AsposePdfDeleteHiddenText](./asposepdfdeletehiddentext/) | Ta bort dold text från en PDF-fil. |
+| [AsposePdfAddWatermark](./asposepdfaddwatermark/) | Lägg till vattenstämpel i en PDF-fil. |
+| [AsposePdfDeleteWatermarks](./asposepdfdeletewatermarks/) | Ta bort vattenstämplar från en PDF-fil. |
+| [AsposePdfMergeLayers](./asposepdfmergelayers/) | Slå ihop lager i en PDF-fil. |
+| [AsposePdfFlatten](./asposepdfflatten/) | Platta till en PDF-fil. |
+| [AsposePdfMakeBooklet](./asposepdfmakebooklet/) | Skapa häfte från en PDF-fil. |
+| [AsposePdfMakeNUp](./asposepdfmakenup/) | Skapa N‑Up-dokument från en PDF-fil. |
+| [AsposePdfDeleteBlankPages](./asposepdfdeleteblankpages/) | Ta bort tomma sidor från en PDF-fil. |
+| [AsposePdfEmbedFonts](./asposepdfembedfonts/) | Bädda in teckensnitt i en PDF-fil. |
+| [AsposePdfUnembedFonts](./asposepdfunembedfonts/) | Ta bort inbäddade teckensnitt från en PDF-fil. |
+| [AsposePdfOptimizeFileSize](./asposepdfoptimizefilesize/) | Optimera storleken på PDF-filen med bildkomprimeringskvalitet. |
+| [AsposePdfDeleteTables](./asposepdfdeletetables/) | Ta bort tabeller från en PDF-fil. |
+| [AsposePdfCropPages](./asposepdfcroppages/) | Beskär PDF-sidor. |
+| [AsposePdfDeleteTextHeaders](./asposepdfdeletetextheaders/) | Ta bort textrubriker från en PDF-fil. |
+| [AsposePdfDeleteTextFooters](./asposepdfdeletetextfooters/) | Ta bort textfot från en PDF-fil. |
+| [AsposePdfReplaceTextEx](./asposepdfreplacetextex/) | Ersätt flera textfragment i en PDF-fil med justeringskontroll. |
+| [AsposePdfRecover](./asposepdfrecover/) | Återställ en PDF-filstruktur och rensa ogiltiga data. |
+| [AsposePdfRebuildXrefAndTrailer](./asposepdfrebuildxrefandtrailer/) | Bygg om en PDF-filens korsreferenstabell och trailerstrukturer. |
+| [AsposePdfReversePages](./asposepdfreversepages/) | Vänd på sidordningen i en PDF-fil. |
+
+
+## Detailed Description
+
+Funktioner för att organisera PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddattachment/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddattachment/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddAttachment"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till bilaga i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddattachment/
+---
+
+_Lägg till en bilaga till en PDF-fil._
+
+```js
+function AsposePdfAddAttachment(
+    fileName,
+    fileAttachment,
+    fileDescription,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **fileAttachment** attachment file name
+* **fileDescription** attachment description
+* **fileNameResult** result file name
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+AsposePdf().then(AsposePdfModule => {
+    /*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+    console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const txt_file = 'ReadMe.txt';
+/*Add attachment to a PDF-file and save the "ResultPdfAddAttachment.pdf"*/
+const json = AsposePdfModule.AsposePdfAddAttachment(pdf_file, txt_file, 'Description', "ResultPdfAddAttachment.pdf");
+console.log("AsposePdfAddAttachment => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddbackgroundimage/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddBackgroundImage"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till bakgrundsbild i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddbackgroundimage/
+---
+
+_Lägg till bakgrundsbild i en PDF-fil._
+
+```js
+function AsposePdfAddBackgroundImage(
+    fileName,
+    fileBackgroundImage,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileBackgroundImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+    console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const background_file = 'Aspose.jpg';
+/*Add background image to a PDF-file and save the "ResultBackgroundImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddBackgroundImage(pdf_file, background_file, "ResultAddBackgroundImage.pdf");
+console.log("AsposePdfAddBackgroundImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddimage/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddimage/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfAddImage"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till en bild i slutet av en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddimage/
+---
+
+_Lägg till en bild i slutet av en PDF-fil._
+
+```js
+function AsposePdfAddImage(
+    fileName,
+    fileImage,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileImage** image file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+    console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const image_file = 'Aspose.jpg';
+/*Add an image to end a PDF-file and save the "ResultImage.pdf"*/
+const json = AsposePdfModule.AsposePdfAddImage(pdf_file, image_file, "ResultAddImage.pdf");
+console.log("AsposePdfAddImage => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddpagenum/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfAddPageNum"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till sidnummer i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddpagenum/
+---
+
+_Lägg till sidnummer i en PDF-fil._
+
+```js
+function AsposePdfAddPageNum(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add page number to a PDF-file save the "ResultAddPageNum.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+    console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add page number to a PDF-file and save the "ResultAddPageNum.pdf"*/
+const json = AsposePdfModule.AsposePdfAddPageNum(pdf_file, "ResultAddPageNum.pdf");
+console.log("AsposePdfAddPageNum => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddstamp/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddstamp/_index.md
@@ -1,0 +1,75 @@
+---
+title: "AsposePdfAddStamp"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till stämpel i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddstamp/
+---
+
+_Lägg till stämpel i en PDF-fil._
+
+```js
+function AsposePdfAddStamp(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+    console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file and save the "ResultAddStamp.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStamp(pdf_file, stamp_file, 0, 5, 5, 40, 40, AsposePdfModule.Rotation.on270, 0.5, "ResultAddStamp.pdf");
+console.log("AsposePdfAddStamp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddstamppages/_index.md
@@ -1,0 +1,80 @@
+---
+title: "AsposePdfAddStampPages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till stämpel på specifika sidor i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddstamppages/
+---
+
+_Lägg till stämpel på specifika sidor i en PDF-fil._
+
+```js
+function AsposePdfAddStampPages(
+    fileName,
+    fileStamp,
+    setBackground,
+    setXIndent,
+    setYIndent,
+    setHeight,
+    setWidth,
+    rotation,
+    setOpacity,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **fileStamp** stamp (image) file name 
+* **setBackground** background (1 or 0) 
+* **setXIndent** x indent stamp 
+* **setYIndent** y indent stamp 
+* **setHeight** height stamp 
+* **setWidth** width stamp 
+* **rotation** stamp rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **setOpacity** opacity stamp (decimal) 
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+AsposePdf().then(AsposePdfModule => {
+    /*Add stamp to a PDF-file on page #1 and save the "ResultAddStampPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+    console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const stamp_file = 'Aspose.jpg';
+/*Add stamp to a PDF-file page #1 and save the "ResultAddStampPages.pdf"*/
+const json = AsposePdfModule.AsposePdfAddStampPages(pdf_file, stamp_file, 0, 15, 15, 50, 50, AsposePdfModule.Rotation.on90, 0.7, 1, "ResultAddStampPages.pdf");
+console.log("AsposePdfAddStampPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddtextheaderfooter/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfAddTextHeaderFooter"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till text i sidhuvud/sidföt i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddtextheaderfooter/
+---
+
+_Lägg till text i sidhuvud/sidfot i en PDF-fil._
+
+```js
+function AsposePdfAddTextHeaderFooter(
+    fileName,
+    header, 
+    footer,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **header** page header, if not need to set, use undefined or "" (empty string)
+* **footer** page footer, if not need to set, use undefined or "" (empty string)
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+    console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add text in Header/Footer of a PDF-file and save the "ResultAddHeaderFooter.pdf"*/
+const json = AsposePdfModule.AsposePdfAddTextHeaderFooter(pdf_file, "Aspose.PDF for Node.js via C++ via C++", "ASPOSE", "ResultAddHeaderFooter.pdf");
+console.log("AsposePdfAddTextHeaderFooter => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfaddwatermark/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposePdfAddWatermark"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Lägg till vattenstämpel i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfaddwatermark/
+---
+
+_Lägg till vattenstämpel i en PDF-fil._
+
+```js
+function AsposePdfAddWatermark(
+    fileName,
+    text,
+    fontName,
+    fontSize,
+    foregroundColor,
+    xPosition,
+    yPosition,
+    rotation,
+    isBackground,
+    opacity,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **text** watermark text
+* **fontName** font name
+* **fontSize** font size
+* **foregroundColor** text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **xPosition** x watermark position
+* **yPosition** y watermark position
+* **rotation** watermark rotation (0-360)
+* **isBackground** background (1 or 0)
+* **opacity** opacity (decimal)
+* **fileNameResult** result file name
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+    const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+    console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Add watermark to a PDF-file and save the "ResultWatermark.pdf"*/
+const json = AsposePdfModule.AsposePdfAddWatermark(pdf_file, "Aspose PDF", "Arial", 32, "#010101", 100, 100, 45, 1, 0.5, "ResultAddWatermark.pdf");
+console.log("AsposePdfAddWatermark => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfcroppages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfcroppages/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfCropPages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Beskär PDF-sidor."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfcroppages/
+---
+
+_Beskär PDF-sidor._
+
+```js
+function AsposePdfCropPages(
+    fileName,
+    margin,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **margin** page margin
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const margin = 1.5;
+    /*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+    console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const margin = 1.5;
+/*Crop PDF-pages and save the "ResultPdfCropPages.pdf"*/
+const json = AsposePdfModule.AsposePdfCropPages(pdf_file, margin, "ResultPdfCropPages.pdf");
+console.log("AsposePdfCropPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeleteannotations/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAnnotations"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort annotationer från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeleteannotations/
+---
+
+_Ta bort annotationer från en PDF-fil._
+
+```js
+function AsposePdfDeleteAnnotations(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+    console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete annotations from a PDF-file and save the "ResultPdfDeleteAnnotations.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAnnotations(pdf_file, "ResultPdfDeleteAnnotations.pdf");
+console.log("AsposePdfDeleteAnnotations => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeleteattachments/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteAttachments"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort bilagor från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeleteattachments/
+---
+
+_Ta bort bilagor från en PDF-fil._
+
+```js
+function AsposePdfDeleteAttachments(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+    console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete attachments from a PDF-file and save the "ResultPdfDeleteAttachments.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteAttachments(pdf_file, "ResultPdfDeleteAttachments.pdf");
+console.log("AsposePdfDeleteAttachments => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeleteblankpages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBlankPages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort tomma sidor från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeleteblankpages/
+---
+
+_Ta bort tomma sidor från en PDF-fil._
+
+```js
+function AsposePdfDeleteBlankPages(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+    console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete blank pages from a PDF-file and save the "ResultDeleteBlankPages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBlankPages(pdf_file, "ResultDeleteBlankPages.pdf");
+console.log("AsposePdfDeleteBlankPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletebookmarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteBookmarks"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort bokmärken från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletebookmarks/
+---
+
+_Ta bort bokmärken från en PDF-fil._
+
+```js
+function AsposePdfDeleteBookmarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+    console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete bookmarks from a PDF-file and save the "ResultPdfDeleteBookmarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteBookmarks(pdf_file, "ResultPdfDeleteBookmarks.pdf");
+console.log("AsposePdfDeleteBookmarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletehiddentext/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteHiddenText"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort dold text från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletehiddentext/
+---
+
+_Ta bort dold text från en PDF-fil._
+
+```js
+function AsposePdfDeleteHiddenText(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+    console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete hidden text from a PDF-file and save the "ResultPdfDeleteHiddenText.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteHiddenText(pdf_file, "ResultPdfDeleteHiddenText.pdf");
+console.log("AsposePdfDeleteHiddenText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeleteimages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteImages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort bilder från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeleteimages/
+---
+
+_Ta bort bilder från en PDF-fil._
+
+```js
+function AsposePdfDeleteImages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+    console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete images from a PDF-file and save the "ResultPdfDeleteImages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteImages(pdf_file, "ResultPdfDeleteImages.pdf");
+console.log("AsposePdfDeleteImages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletejavascripts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteJavaScripts"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort JavaScript från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletejavascripts/
+---
+
+_Ta bort JavaScript från en PDF-fil._
+
+```js
+function AsposePdfDeleteJavaScripts(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+    console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete JavaScripts from a PDF-file and save the "ResultPdfDeleteJavaScripts.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteJavaScripts(pdf_file, "ResultPdfDeleteJavaScripts.pdf");
+console.log("AsposePdfDeleteJavaScripts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletepages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletepages/_index.md
@@ -1,0 +1,70 @@
+---
+title: "AsposePdfDeletePages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort sidor från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletepages/
+---
+
+_Ta bort sidor från en PDF-fil._
+
+```js
+function AsposePdfDeletePages(
+    fileName,
+    fileNameResult,
+    numPages
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+    /*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+    console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+/*Delete pages from a PDF-file and save the "ResultDeletePages.pdf"*/
+const json = AsposePdfModule.AsposePdfDeletePages(pdf_file, "ResultDeletePages.pdf", numPages);
+console.log("AsposePdfDeletePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletetables/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletetables/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTables"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort tabeller från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletetables/
+---
+
+_Ta bort tabeller från en PDF-fil._
+
+```js
+function AsposePdfDeleteTables(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+    console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete tables from a PDF-file and save the "ResultPdfDeleteTables.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTables(pdf_file, "ResultPdfDeleteTables.pdf");
+console.log("AsposePdfDeleteTables => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletetextfooters/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextFooters"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort textfot från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletetextfooters/
+---
+
+_Ta bort textfotnoter från en PDF-fil._
+
+```js
+function AsposePdfDeleteTextFooters(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+    console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text footers from a PDF-file and save the "ResultPdfDeleteTextFooters.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextFooters(pdf_file, "ResultPdfDeleteTextFooters.pdf");
+console.log("AsposePdfDeleteTextFooters => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletetextheaders/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteTextHeaders"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort textrubriker från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletetextheaders/
+---
+
+_Ta bort textrubriker från en PDF-fil._
+
+```js
+function AsposePdfDeleteTextHeaders(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+    console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete text headers from a PDF-file and save the "ResultPdfDeleteTextHeaders.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteTextHeaders(pdf_file, "ResultPdfDeleteTextHeaders.pdf");
+console.log("AsposePdfDeleteTextHeaders => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfdeletewatermarks/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfDeleteWatermarks"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort vattenstämplar från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfdeletewatermarks/
+---
+
+_Ta bort vattenstämplar från en PDF-fil._
+
+```js
+function AsposePdfDeleteWatermarks(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+    const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+    console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Delete watermarks from a PDF-file and save the "ResultPdfDeleteWatermarks.pdf"*/
+const json = AsposePdfModule.AsposePdfDeleteWatermarks(pdf_file, "ResultPdfDeleteWatermarks.pdf");
+console.log("AsposePdfDeleteWatermarks => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfembedfonts/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfEmbedFonts"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Bädda in teckensnitt i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfembedfonts/
+---
+
+_Bädda in teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfEmbedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+    console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Embed fonts a PDF-file and save the "ResultEmbedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfEmbedFonts(pdf_file, "ResultEmbedFonts.pdf");
+console.log("AsposePdfEmbedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdffindhiddentext/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AsposePdfFindHiddenText"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Sök efter dold text i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdffindhiddentext/
+---
+
+_Hitta dold text i en PDF-fil._
+
+```js
+function AsposePdfFindHiddenText(
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Find hidden text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Find hidden text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindHiddenText(pdf_file);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindHiddenText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdffindtext/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdffindtext/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfFindText"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Sök efter text i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdffindtext/
+---
+
+_Hitta text i en PDF-fil._
+
+```js
+function AsposePdfFindText(
+    fileName,
+    findText
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name
+* **findText** text fragment to search
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **textFragments** - array of :
+  * text - text fragment
+  * xIndent - X coordinate
+  * yIndent - Y coordinate
+  * fontName - font name
+  * fontSize - font size
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    /*Find text in a PDF-file*/
+    const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+    /*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+    console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+/*Find text in a PDF-file*/
+const json = AsposePdfModule.AsposePdfFindText(pdf_file, findText);
+/*json.textFragments - array of text fragments: { text: <string>, xIndent: <number>, yIndent: <number>, fontName: <string>, fontSize: <number> }*/
+console.log("AsposePdfFindText => textFragments: %O", json.errorCode == 0 ? json.textFragments : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfflatten/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfflatten/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfFlatten"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Platta till en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfflatten/
+---
+
+_Platta till en PDF-fil._
+
+```js
+function AsposePdfFlatten(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+    const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+    console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Flatten a PDF-file and save the "ResultFlatten.pdf"*/
+const json = AsposePdfModule.AsposePdfFlatten(pdf_file, "ResultFlatten.pdf");
+console.log("AsposePdfFlatten => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfgetattachment/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfgetattachment/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfGetAttachment"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Hämta bilaga från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfgetattachment/
+---
+
+_Hämta bilaga från en PDF-fil._
+
+```js
+function AsposePdfGetAttachment(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+  * **fileName** file name 
+  * **fileNameResult** result file name template (for sample: "ResultPdfGetAttachment_{0}" where {0} - name of attachment) 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **filesCount** - attachment files count
+  * **filesNameResult** - array of result filenames
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+    const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+    console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Get attachment from a PDF-file and save with template "ResultPdfGetAttachment_{0}" ({0} - name of attachment)*/
+const json = AsposePdfModule.AsposePdfGetAttachment(pdf_file, "ResultPdfGetAttachment_{0}");
+console.log("AsposePdfGetAttachment => %O", json.errorCode == 0 ? json.filesNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfmakebooklet/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfMakeBooklet"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Skapa häfte från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfmakebooklet/
+---
+
+_Skapa häfte från en PDF-fil._
+
+```js
+function AsposePdfMakeBooklet(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+    console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Make booklet from a PDF-file and save the "ResultMakeBooklet.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeBooklet(pdf_file, "ResultMakeBooklet.pdf");
+console.log("AsposePdfMakeBooklet => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfmakenup/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfmakenup/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfMakeNUp"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Skapa N‑Up-dokument från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfmakenup/
+---
+
+_Skapa N-Up-dokument från en PDF-fil._
+
+```js
+function AsposePdfMakeNUp(
+    fileName,
+    columns,
+    rows,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **columns** count of columns
+* **rows** count of rows
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const columns = 2
+    const rows = 2
+    /*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+    const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+    console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const columns = 2
+const rows = 2
+/*Make N-Up document from a PDF-file and save the "ResultMakeNUp.pdf"*/
+const json = AsposePdfModule.AsposePdfMakeNUp(pdf_file, columns, rows, "ResultMakeNUp.pdf");
+console.log("AsposePdfMakeNUp => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfmerge2files/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfmerge2files/_index.md
@@ -1,0 +1,52 @@
+---
+title: "AsposePdfMerge2Files"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Slå ihop två PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfmerge2files/
+---
+
+_Slå samman två PDF-filer._
+
+```js
+function AsposePdfMerge2Files(
+    fileName1,
+    fileName2,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+  * **fileName1** file name #1 
+  * **fileName2** file name #2 
+  * **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Merge two PDF-files and save the "ResultMerge.pdf"*/
+    const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+    console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Merge two PDF-files and save the "ResultMerge.pdf"*/
+const json = AsposePdfModule.AsposePdfMerge2Files(pdf_file, pdf_file, "ResultMerge.pdf");
+console.log("AsposePdfMerge2Files => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfmergelayers/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfmergelayers/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfMergeLayers"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Slå ihop lager i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfmergelayers/
+---
+
+_Sammanfoga lager i en PDF-fil._
+
+```js
+function AsposePdfMergeLayers(
+    fileName,
+    newLayerName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **newLayerName** merged layer name for each page
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const mergedLayerName = 'MergedLayer';
+    /*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+    const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+    console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const mergedLayerName = 'MergedLayer';
+/*Merge layers a PDF-file and save the "ResultPdfMergeLayers.pdf"*/
+const json = AsposePdfModule.AsposePdfMergeLayers(pdf_file, mergedLayerName, "ResultPdfMergeLayers.pdf");
+console.log("AsposePdfMergeLayers => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfoptimize/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfoptimize/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimize"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Optimera en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfoptimize/
+---
+
+_Optimera en PDF-fil._
+
+```js
+function AsposePdfOptimize(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+    console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize a PDF-file and save the "ResultOptimize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimize(pdf_file, "ResultOptimize.pdf");
+console.log("AsposePdfOptimize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfoptimizefilesize/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfOptimizeFileSize"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Optimera storleken på PDF-filen med bildkomprimeringskvalitet."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfoptimizefilesize/
+---
+
+_Optimera storleken på PDF-filen med bildkomprimeringskvalitet._
+
+```js
+function AsposePdfOptimizeFileSize(
+    fileName,
+    imageQuality,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **imageQuality** image compression quality
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const imageQuality = 50;
+    /*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+    console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const imageQuality = 50;
+/*Optimize size of PDF-file with image compression quality and save the "ResultPdfOptimizeFileSize.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeFileSize(pdf_file, imageQuality, "ResultPdfOptimizeFileSize.pdf");
+console.log("AsposePdfOptimizeFileSize => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfoptimizeresource/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfOptimizeResource"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Optimera resurser i PDF-filen."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfoptimizeresource/
+---
+
+_Optimera resurser i en PDF-fil._
+
+```js
+function AsposePdfOptimizeResource(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+    const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+    console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Optimize resources of PDF-file and save the "ResultPdfOptimizeResource.pdf"*/
+const json = AsposePdfModule.AsposePdfOptimizeResource(pdf_file, "ResultPdfOptimizeResource.pdf");
+console.log("AsposePdfOptimizeResource => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRebuildXrefAndTrailer"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Bygg om en PDF-filens korsreferenstabell och trailerstrukturer."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfrebuildxrefandtrailer/
+---
+
+_Bygg om en PDF-fils korsreferenstabell och trailerstrukturer._
+
+```js
+function AsposePdfRebuildXrefAndTrailer(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+    const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+    console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rebuild a PDF-file cross-reference table and trailer structures and save the "ResultPdfRebuildXrefAndTrailer.pdf"*/
+const json = AsposePdfModule.AsposePdfRebuildXrefAndTrailer(pdf_file, "ResultPdfRebuildXrefAndTrailer.pdf");
+console.log("AsposePdfRebuildXrefAndTrailer => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfrecover/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfrecover/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRecover"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Återställ en PDF-filstruktur och rensa ogiltiga data."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfrecover/
+---
+
+_Återställ en PDF-filstruktur och trimma ogiltiga data._
+
+```js
+function AsposePdfRecover(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+    const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+    console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Recover a PDF-file structure and trims invalid data and save the "ResultPdfRecover.pdf"*/
+const json = AsposePdfModule.AsposePdfRecover(pdf_file, "ResultPdfRecover.pdf");
+console.log("AsposePdfRecover => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfrepair/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfrepair/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfRepair"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Reparera en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfrepair/
+---
+
+_Reparera en PDF-fil._
+
+```js
+function AsposePdfRepair(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+    const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+    console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Repair a PDF-file and save the "ResultPdfRepair.pdf"*/
+const json = AsposePdfModule.AsposePdfRepair(pdf_file, "ResultPdfRepair.pdf");
+console.log("AsposePdfRepair => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfreplacefont/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfreplacefont/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceFont"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ersätt teckensnitt i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfreplacefont/
+---
+
+_Ersätt teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfReplaceFont(
+    fileName,
+    findFont,
+    replaceFont,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findFont** name font to be replaced
+* **replaceFont** replacement font name
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findFont = 'Helvetica';
+    const replaceFont = 'Times';
+    /*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+    console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findFont = 'Helvetica';
+const replaceFont = 'Times';
+/*Replace font Helvetica to Times in a PDF-file and save the "ResultPdfReplaceFont.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceFont(pdf_file, findFont, replaceFont, "ResultPdfReplaceFont.pdf");
+console.log("AsposePdfReplaceFont => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfreplacetext/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfreplacetext/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfReplaceText"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ersätt text i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfreplacetext/
+---
+
+_Ersätt text i en PDF-fil._
+
+```js
+function AsposePdfReplaceText(
+    fileName,
+    findText,
+    replaceText,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+    /*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+    console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+/*Replace text in a PDF-file and save the "ResultPdfReplaceText.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceText(pdf_file, findText, replaceText, "ResultPdfReplaceText.pdf");
+console.log("AsposePdfReplaceText => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfreplacetextex/_index.md
@@ -1,0 +1,105 @@
+---
+title: "AsposePdfReplaceTextEx"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ersätt flera textfragment i en PDF-fil med justeringskontroll."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfreplacetextex/
+---
+
+_Ersätt flera textfragment i en PDF-fil med justeringskontroll._
+
+```js
+function AsposePdfReplaceTextEx(
+    fileName,
+    findReplaceSpec,
+    options,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findReplaceSpec** Array, replacement specification:
+  * Array of objects describing replacements:
+    ```js
+    [
+      { findText: "text1", replaceText: "value1" },
+      { findText: "text2", replaceText: "value2" }
+    ]
+    ```
+  * Each object must contain `findText` and `replaceText` string properties
+* **options** object, settings for text replacement:
+  * `alignment` (string), text alignment (e.g., "left", "right", "auto")
+    * When `"auto"` is used, text direction is detected automatically.
+Riktning kan också tvingas explicit genom att prefixa `replaceText`
+med speciella Unicode-tecken:
+`\u200F` (RTL) eller `\u200E` (LTR), helst som det första tecknet
+  * `numPages` (string|number|Array), target pages to process:
+    * number, page number as 2
+    * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+    * Array, array of page numbers, such as [1,3]
+  * empty object `{}` for default behavior
+* **fileNameResult** result file name 
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+    ];
+    const optionsText = {numPages: 1, alignment: "auto"};
+    /*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+    console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findReplaceSpec = [
+            {
+            findText: 'Aspose',
+            replaceText: 'ASPOSE'
+            },
+            {
+            findText: 'Node',
+            replaceText: 'NODE'
+            },
+            {
+            findText: 'ECMAScript',
+            replaceText: '\u200FScript'
+            }
+];
+const optionsText = {numPages: 1, alignment: "auto"};
+/*Replace multiple text fragments in a PDF-file with alignment control and save the "ResultPdfReplaceTextEx.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextEx(pdf_file, findReplaceSpec, optionsText, "ResultPdfReplaceTextEx.pdf");
+console.log("AsposePdfReplaceTextEx => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfreplacetextpages/_index.md
@@ -1,0 +1,82 @@
+---
+title: "AsposePdfReplaceTextPages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ersätt text på sidor i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfreplacetextpages/
+---
+
+_Ersätt text på sidor i en PDF-fil._
+
+```js
+function AsposePdfReplaceTextPages(
+    fileName,
+    findText,
+    replaceText,
+    numPages,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **findText** text fragment to search
+* **replaceText** text fragment to replace
+* **numPages** page numbers:
+  * string, include page numbers with intervals as "7, 20, 22, 30-32, 33, 36-40, 46"
+  * array, array of page numbers, such as [1,3]
+  * number, page number as 2
+* **fileNameResult** result file name
+
+**Return**: 
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    const findText = 'Aspose';
+    const replaceText = 'ASPOSE';
+
+    /*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+    /*const numPages = "1-3";*/
+    /*array, array of number pages*/
+    /*const numPages = [1,3];*/
+    /*number, number page*/
+    const numPages = 1;
+
+    /*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+    console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+const findText = 'Aspose';
+const replaceText = 'ASPOSE';
+
+/*string, include number pages with interval: "7, 20, 22, 30-32, 33, 36-40, 46"*/
+/*const numPages = "1-3";*/
+/*array, array of number pages*/
+/*const numPages = [1,3];*/
+/*number, number page*/
+const numPages = 1;
+
+/*Replace text on first page in a PDF-file and save the "ResultPdfReplaceTextPages.pdf"*/
+const json = AsposePdfModule.AsposePdfReplaceTextPages(pdf_file, findText, replaceText, numPages, "ResultPdfReplaceTextPages.pdf");
+console.log("AsposePdfReplaceTextPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfreversepages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfreversepages/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfReversePages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Vänd på sidordningen i en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfreversepages/
+---
+
+_Vänd på sidordningen i en PDF-fil._
+
+```js
+function AsposePdfReversePages(
+    fileName,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+    const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+    console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Reverse the page order of a PDF-file and save the "ResultPdfReversePages.pdf"*/
+const json = AsposePdfModule.AsposePdfReversePages(pdf_file, "ResultPdfReversePages.pdf");
+console.log("AsposePdfReversePages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfrotateallpages/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePdfRotateAllPages"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Rotera PDF-sidor."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfrotateallpages/
+---
+
+_Rotera PDF-sidor._
+
+```js
+function AsposePdfRotateAllPages(
+    fileName,
+    rotation,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **rotation** pages rotation:
+  * Module.Rotation.None
+  * Module.Rotation.on90
+  * Module.Rotation.on180
+  * Module.Rotation.on270 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+    const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+    console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Rotate PDF-pages and save the "ResultRotation.pdf"*/
+const json = AsposePdfModule.AsposePdfRotateAllPages(pdf_file, AsposePdfModule.Rotation.on270, "ResultRotation.pdf");
+console.log("AsposePdfRotateAllPages => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfsetbackgroundcolor/_index.md
@@ -1,0 +1,53 @@
+---
+title: "AsposePdfSetBackgroundColor"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ställ in bakgrundsfärgen för PDF-filen."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfsetbackgroundcolor/
+---
+
+_Ställ in bakgrundsfärgen för PDF-filen._
+
+```js
+function AsposePdfSetBackgroundColor(
+    fileName,
+    backgroundColor,
+    fileNameResult
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **backgroundColor** PDF background color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+    const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+    console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set the background color for the PDF-file and save the "ResultPdfSetBackgroundColor.pdf"*/
+const json = AsposePdfModule.AsposePdfSetBackgroundColor(pdf_file, "#426bf4", "ResultPdfSetBackgroundColor.pdf");
+console.log("AsposePdfSetBackgroundColor => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfsplit2files/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfsplit2files/_index.md
@@ -1,0 +1,62 @@
+---
+title: "AsposePdfSplit2Files"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Dela upp i två PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfsplit2files/
+---
+
+_Dela upp i två PDF-filer._
+
+```js
+function AsposePdfSplit2Files(
+    fileName,
+    pageToSplit,
+    fileNameResult1,
+    fileNameResult2 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pageToSplit** number page for split 
+* **fileNameResult1** result file name #1 
+* **fileNameResult2** result file name #2 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult1** - result file name #1
+* **fileNameResult2** - result file name #2
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Set number a page to split*/
+    const pageToSplit = 1;
+    /*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+    const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+    console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Set number a page to split*/
+const pageToSplit = 1;
+/*Split to two PDF-files and save the "ResultSplit1.pdf", "ResultSplit2.pdf"*/
+const json = AsposePdfModule.AsposePdfSplit2Files(pdf_file, pageToSplit, "ResultSplit1.pdf", "ResultSplit2.pdf");
+console.log("AsposePdfSplit2Files => %O", json.errorCode == 0 ? [json.fileNameResult1, json.fileNameResult2] : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfunembedfonts/_index.md
@@ -1,0 +1,51 @@
+---
+title: "AsposePdfUnembedFonts"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ta bort inbäddade teckensnitt från en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfunembedfonts/
+---
+
+_Ta bort inbäddning av teckensnitt i en PDF-fil._
+
+```js
+function AsposePdfUnembedFonts(
+    fileName,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **fileNameResult** result file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+    const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+    console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Unembed fonts a PDF-file and save the "ResultUnembedFonts.pdf"*/
+const json = AsposePdfModule.AsposePdfUnembedFonts(pdf_file, "ResultUnembedFonts.pdf");
+console.log("AsposePdfUnembedFonts => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
+++ b/swedish/nodejs-cpp/organize/asposepdfvalidatepdfa/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AsposePdfValidatePDFA"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Validera PDF/A-kompatibilitet för en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/organize/asposepdfvalidatepdfa/
+---
+
+_Validera PDF/A-kompatibilitet för en PDF-fil._
+
+```js
+function AsposePdfValidatePDFA(
+    fileName,
+    pdfFormat,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **pdfFormat** format PDF/A:
+  * Module.PdfFormat.PDF_A_1A
+  * Module.PdfFormat.PDF_A_1B
+  * Module.PdfFormat.PDF_A_2A
+  * Module.PdfFormat.PDF_A_3A
+  * Module.PdfFormat.PDF_A_2U
+  * Module.PdfFormat.PDF_A_3B
+  * Module.PdfFormat.PDF_A_3U
+* **fileNameResult** result file name where verification comments will be stored (xml format)
+
+**Return**:
+ 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+    const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+    console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Validate PDF/A compatibility a PDF-file and save result in the "ResultPdfValidatePDFA.xml"*/
+const json = AsposePdfModule.AsposePdfValidatePDFA(pdf_file, AsposePdfModule.PdfFormat.PDF_A_1A, "ResultPdfValidatePDFA.xml");
+console.log("AsposePdfValidatePDFA => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/security/_index.md
+++ b/swedish/nodejs-cpp/security/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Säkerhetsfunktioner för PDF"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Funktioner för att arbeta med säkerhetsfunktioner i PDF-filer."
+type: docs
+url: /sv/nodejs-cpp/security/
+---
+
+## Security PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePdfEncrypt](./asposepdfencrypt/) | Kryptera en PDF-fil. |
+| [AsposePdfDecrypt](./asposepdfdecrypt/) | Dekryptera en PDF-fil. |
+| [AsposePdfSignPKCS7](./asposepdfsignpkcs7/) | Signera en PDF-fil med digitala signaturer. |
+| [AsposePdfSignPKCS7Detached](./asposepdfsignpkcs7detached/) | Signera en PDF-fil med fristående digitala signaturer. |
+| [AsposePdfChangePassword](./asposepdfchangepassword/) | Ändra lösenord för PDF-filen. |
+
+## Detailed Description
+
+Funktioner för att arbeta med säkerhetsfunktioner i PDF-filer.
+
+CommonJS
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+```
+
+ECMAScript/ES6
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+```

--- a/swedish/nodejs-cpp/security/asposepdfchangepassword/_index.md
+++ b/swedish/nodejs-cpp/security/asposepdfchangepassword/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposePdfChangePassword"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Ändra lösenord för PDF-filen."
+type: docs
+url: /sv/nodejs-cpp/security/asposepdfchangepassword/
+---
+
+_Ändra lösenord för PDF-filen._
+
+```js
+function AsposePdfChangePassword(
+    fileName,
+    ownerPassword,
+    newUserPassword,
+    newOwnerPassword,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **ownerPassword** owner password
+* **newUserPassword** new user password
+* **newOwnerPassword** new owner password
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+    const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+    console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Change passwords of the PDF-file from "owner" to "newowner" and save the "ResultPdfChangePassword.pdf"*/
+const json = AsposePdfModule.AsposePdfChangePassword(pdf_encrypt_file, "owner", "newuser", "newowner", "ResultPdfChangePassword.pdf");
+console.log("AsposePdfChangePassword => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/security/asposepdfdecrypt/_index.md
+++ b/swedish/nodejs-cpp/security/asposepdfdecrypt/_index.md
@@ -1,0 +1,55 @@
+---
+title: "AsposePdfDecrypt"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Dekryptera en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/security/asposepdfdecrypt/
+---
+
+_Dekryptera en PDF-fil._
+
+```js
+function AsposePdfDecrypt(
+    fileName,
+    password,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **password** user password 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+    console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_encrypt_file = 'ResultEncrypt.pdf';
+/*Decrypt a PDF-file with password is "owner" and save the "ResultDecrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfDecrypt(pdf_encrypt_file, "owner", "ResultDecrypt.pdf");
+console.log("AsposePdfDecrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/security/asposepdfencrypt/_index.md
+++ b/swedish/nodejs-cpp/security/asposepdfencrypt/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposePdfEncrypt"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Kryptera en PDF-fil."
+type: docs
+url: /sv/nodejs-cpp/security/asposepdfencrypt/
+---
+
+_Kryptera en PDF-fil._
+
+```js
+function AsposePdfEncrypt(
+    fileName,
+    passwordUser,
+    passwordOwner,
+    permissions,
+    cryptoAlgorithm,
+    fileNameResult 
+)
+```
+
+**Parameters**: 
+
+* **fileName** file name 
+* **passwordUser** user password 
+* **passwordOwner** owner password 
+* **permissions** encrypt permissions:
+  * Module.Permissions.PrintDocument
+  * Module.Permissions.ModifyContent
+  * Module.Permissions.ExtractContent
+  * Module.Permissions.ModifyTextAnnotations
+  * Module.Permissions.FillForm
+  * Module.Permissions.ExtractContentWithDisabilities
+  * Module.Permissions.AssembleDocument
+  * Module.Permissions.PrintingQuality 
+* **cryptoAlgorithm** encrypt algorithm:
+  * Module.CryptoAlgorithm.RC4x40
+  * Module.CryptoAlgorithm.RC4x128
+  * Module.CryptoAlgorithm.AESx128
+  * Module.CryptoAlgorithm.AESx256 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+    const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+    console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Encrypt a PDF-file with passwords "user" and "owner", and save the "ResultEncrypt.pdf"*/
+const json = AsposePdfModule.AsposePdfEncrypt(pdf_file, "user", "owner", AsposePdfModule.Permissions.PrintDocument, AsposePdfModule.CryptoAlgorithm.RC4x40, "ResultEncrypt.pdf");
+console.log("AsposePdfEncrypt => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
+++ b/swedish/nodejs-cpp/security/asposepdfsignpkcs7/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Signera en PDF-fil med digitala signaturer."
+type: docs
+url: /sv/nodejs-cpp/security/asposepdfsignpkcs7/
+---
+
+_Signera en PDF-fil med digitala signaturer._
+
+```js
+function AsposePdfSignPKCS7(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'test.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'Aspose.jpg';
+    /*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+    console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'test.pfx';
+/*Signature appearance*/
+const sign_img_file = 'Aspose.jpg';
+/*Sign a PDF-file with digital signatures and save the "ResultSignPKCS7.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7.pdf");
+console.log("AsposePdfSignPKCS7 => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
+++ b/swedish/nodejs-cpp/security/asposepdfsignpkcs7detached/_index.md
@@ -1,0 +1,85 @@
+---
+title: "AsposePdfSignPKCS7Detached"
+second_title: "Aspose.PDF för Node.js via C++"
+description: "Signera en PDF-fil med fristående digitala signaturer."
+type: docs
+url: /sv/nodejs-cpp/security/asposepdfsignpkcs7detached/
+---
+
+_Signera en PDF-fil med fristående digitala signaturer._
+
+```js
+function AsposePdfSignPKCS7Detached(
+    fileName,
+    pageNum,
+    fileSign,
+    pswSign,
+    setXIndent, 
+    setYIndent, 
+    setHeight,
+    setWidth,
+    reason,
+    contact,
+    location,
+    isVisible,
+    signatureAppearance,
+    fileNameResult 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name 
+* **pageNum**  num page
+* **fileSign** file Sign, PKCS#7 specification in Internet RFC 2315
+* **pswSign**  password Sign
+* **setXIndent** x indent
+* **setYIndent** y indent
+* **setHeight** height
+* **setWidth** width
+* **reason** reason
+* **contact** contact
+* **location** location
+* **isVisible** visible (1 or 0)
+* **signatureAppearance** image (Sign Appearance) file name 
+* **fileNameResult** result file name 
+
+**Return**:
+
+JSON-objekt
+
+* **errorCode** - code error (0 no error)
+* **errorText** - text error ("" no error)
+* **fileNameResult** - result file name
+
+
+**CommonJS**:
+
+```js
+const AsposePdf = require('asposepdfnodejs');
+const pdf_file = 'Aspose.pdf';
+AsposePdf().then(AsposePdfModule => {
+    /*Key PKCS7*/
+    const test_pfx_file = 'sign.pfx';
+    /*Signature appearance*/
+    const sign_img_file = 'sign.png';
+    /*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+    const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+    console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+
+**ECMAScript/ES6**:
+
+```js
+import AsposePdf from 'asposepdfnodejs';
+const AsposePdfModule = await AsposePdf();
+const pdf_file = 'Aspose.pdf';
+/*Key PKCS7*/
+const test_pfx_file = 'sign.pfx';
+/*Signature appearance*/
+const sign_img_file = 'sign.png';
+/*Sign a PDF-file with detached digital signatures and save the "ResultSignPKCS7Detached.pdf"*/
+const json = AsposePdfModule.AsposePdfSignPKCS7Detached(pdf_file, 1, test_pfx_file, "Pa$$w0rd2023", 100, 100, 200, 100, "Reason", "Contact", "Location", 1, sign_img_file, "ResultSignPKCS7Detached.pdf");
+console.log("AsposePdfSignPKCS7Detached => %O", json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 94/94
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `swedish/nodejs-cpp`

🤖 Generated by RDA