### PR TITLE
[draft] Translate RUST-CPP API Reference to Arabic

### DIFF
--- a/arabic/rust-cpp/_index.md
+++ b/arabic/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF لـ Rust عبر C++"
+description: "Aspose.PDF لـ Rust عبر C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /ar/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# الهياكل
+
+## Document
+المستند يمثل مستند PDF.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف DocX. |
+| [save_doc](./convert/save_doc/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Doc. |
+| [save_xlsx](./convert/save_xlsx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف XlsX. |
+| [save_txt](./convert/save_txt/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Txt. |
+| [save_pptx](./convert/save_pptx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PptX. |
+| [save_xps](./convert/save_xps/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Xps. |
+| [save_tex](./convert/save_tex/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف TeX. |
+| [save_epub](./convert/save_epub/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Epub. |
+| [save_booklet](./convert/save_booklet/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PDF ككتيب. |
+| [save_n_up](./convert/save_n_up/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PDF N-Up. |
+| [save_markdown](./convert/save_markdown/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Markdown. |
+| [save_tiff](./convert/save_tiff/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Tiff. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف DocX مع وضع التعرف المحسن (جداول وفقرة قابلة للتحرير بالكامل). |
+| [save_svg_zip](./convert/save_svg_zip/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كأرشيف SVG. |
+| [export_fdf](./convert/export_fdf/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف FDF. |
+| [export_xfdf](./convert/export_xfdf/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف XFDF. |
+| [export_xml](./convert/export_xml/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف XML. |
+| [page_to_jpg](./convert/page_to_jpg/) | تحويل وحفظ الصفحة المحددة كصورة Jpg. |
+| [page_to_png](./convert/page_to_png/) | تحويل وحفظ الصفحة المحددة كصورة Png. |
+| [page_to_bmp](./convert/page_to_bmp/) | تحويل وحفظ الصفحة المحددة كصورة Bmp. |
+| [page_to_tiff](./convert/page_to_tiff/) | تحويل وحفظ الصفحة المحددة كـ Tiff-image. |
+| [page_to_svg](./convert/page_to_svg/) | تحويل وحفظ الصفحة المحددة كـ Svg-image. |
+| [page_to_pdf](./convert/page_to_pdf/) | تحويل وحفظ الصفحة المحددة كـ PDF-document. |
+| [page_to_dicom](./convert/page_to_dicom/) | تحويل وحفظ الصفحة المحددة كـ DICOM-image. |
+
+
+## Organize PDF functions
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | تحسين محتوى PDF-document. |
+| [optimize_resource](./organize/optimize_resource/) | تحسين موارد PDF-document. |
+| [grayscale](./organize/grayscale/) | تحويل PDF-document إلى أبيض وأسود. |
+| [rotate](./organize/rotate/) | تدوير PDF-document. |
+| [set_background](./organize/set_background/) | تعيين لون خلفية PDF-document باستخدام قيم RGB. |
+| [repair](./organize/repair/) | إصلاح PDF-document. |
+| [replace_text](./organize/replace_text/) | استبدال النص في PDF-document |
+| [add_page_num](./organize/add_page_num/) | إضافة رقم الصفحة إلى PDF-document |
+| [add_text_header](./organize/add_text_header/) | إضافة نص في رأس PDF-document |
+| [add_text_footer](./organize/add_text_footer/) | إضافة نص في تذييل PDF-document |
+| [flatten](./organize/flatten/) | تسوية PDF-document |
+| [remove_annotations](./organize/remove_annotations/) | إزالة التعليقات التوضيحية من PDF-document |
+| [remove_attachments](./organize/remove_attachments/) | إزالة المرفقات من PDF-document |
+| [remove_blank_pages](./organize/remove_blank_pages/) | إزالة الصفحات الفارغة من PDF-document |
+| [remove_bookmarks](./organize/remove_bookmarks/) | إزالة العلامات المرجعية من PDF-document |
+| [remove_hidden_text](./organize/remove_hidden_text/) | إزالة النص المخفي من PDF-document |
+| [remove_images](./organize/remove_images/) | إزالة الصور من PDF-document |
+| [remove_javascripts](./organize/remove_javascripts/) | إزالة سكريبتات جافا من PDF-document |
+| [remove_tables](./organize/remove_tables/) | إزالة الجداول من PDF-document. |
+| [remove_watermarks](./organize/remove_watermarks/) | إزالة العلامات المائية من PDF-document. |
+| [add_watermark](./organize/add_watermark/) | إضافة علامة مائية إلى PDF-document. |
+| [embed_fonts](./organize/embed_fonts/) | تضمين الخطوط في PDF-document. |
+| [unembed_fonts](./organize/unembed_fonts/) | إزالة تضمين الخطوط في PDF-document. |
+| [optimize_file_size](./organize/optimize_file_size/) | تحسين حجم PDF-document باستخدام جودة ضغط الصور. |
+| [remove_text_headers](./organize/remove_text_headers/) | إزالة رؤوس النص من PDF-document. |
+| [remove_text_footers](./organize/remove_text_footers/) | إزالة تذييلات النص من PDF-document. |
+| [crop](./organize/crop/) | قص صفحات PDF-document. |
+| [replace_font](./organize/replace_font/) | استبدال الخط في PDF-document. |
+| [convert](./organize/convert/) | تحويل PDF-document إلى PDF-document بالتنسيق PDF المحدد |
+| [validate](./organize/validate/) | التحقق من توافق PDF-document مع تنسيق PDF |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | إزالة الامتثال لـ PDF/A من PDF-document |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | إزالة الامتثال لـ PDF/UA من PDF-document |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | تحقق ما إذا كان PDF-document متوافقًا مع PDF/A |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | تحقق ما إذا كان PDF-document متوافقًا مع PDF/UA |
+| [page_rotate](./organize/page_rotate/) | تدوير صفحة في PDF-document. |
+| [page_set_size](./organize/page_set_size/) | تحديد حجم صفحة في PDF-document. |
+| [page_grayscale](./organize/page_grayscale/) | تحويل الصفحة إلى أبيض وأسود. |
+| [page_add_text](./organize/page_add_text/) | إضافة نص على الصفحة. |
+| [page_replace_text](./organize/page_replace_text/) | استبدال النص على الصفحة |
+| [page_add_page_num](./organize/page_add_page_num/) | إضافة رقم الصفحة إلى الصفحة |
+| [page_add_text_header](./organize/page_add_text_header/) | إضافة نص في رأس الصفحة |
+| [page_add_text_footer](./organize/page_add_text_footer/) | إضافة نص في تذييل الصفحة |
+| [page_remove_annotations](./organize/page_remove_annotations/) | إزالة التعليقات التوضيحية في الصفحة. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | إزالة النص المخفي في الصفحة. |
+| [page_remove_images](./organize/page_remove_images/) | إزالة الصور في الصفحة. |
+| [page_remove_tables](./organize/page_remove_tables/) | إزالة الجداول في الصفحة. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | إزالة العلامات المائية في الصفحة. |
+| [page_add_watermark](./organize/page_add_watermark/) | إضافة علامة مائية على الصفحة. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | إزالة رؤوس النص في الصفحة. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | إزالة تذييلات النص في الصفحة. |
+| [page_crop](./organize/page_crop/) | قص صفحة. |
+| [page_replace_font](./organize/page_replace_font/) | استبدال الخط في الصفحة. |
+| [page_merge_layers](./organize/page_merge_layers/) | دمج جميع الطبقات على الصفحة في طبقة واحدة بالاسم الجديد المحدد للطبقة. |
+| [page_layers](./organize/page_layers/) | الحصول على أسماء الطبقات في الصفحة. |
+
+
+## Core PDF functions
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [new](./core/new/) | إنشاء مستند PDF جديد. |
+| [open](./core/open/) | فتح مستند PDF باستخدام اسم الملف. |
+| [save](./core/save/) | حفظ مستند PDF المفتوح مسبقًا. |
+| [save_as](./core/save_as/) | حفظ مستند PDF المفتوح مسبقًا باسم ملف جديد. |
+| [set_license](./core/set_license/) | تعيين الترخيص باستخدام اسم الملف. |
+| [extract_text](./core/extract_text/) | إرجاع محتويات مستند PDF كنص عادي. |
+| [word_count](./core/word_count/) | إرجاع عدد الكلمات في مستند PDF. |
+| [character_count](./core/character_count/) | إرجاع عدد الأحرف في مستند PDF. |
+| [append](./core/append/) | إضافة صفحات من مستند PDF آخر. |
+| [append_pages](./core/append_pages/) | إضافة الصفحات المحددة من مستند PDF آخر. |
+| [merge_documents](./core/merge_documents/) | إنشاء مستند PDF جديد بدمج مستندات PDF المقدمة. |
+| [split_document](./core/split_document/) | إنشاء عدة مستندات PDF جديدة باستخراج صفحات من مستند PDF المصدر. |
+| [split](./core/split/) | إنشاء عدة مستندات PDF جديدة باستخراج صفحات من مستند PDF الحالي. |
+| [split_at_page](./core/split_at_page/) | تقسيم مستند PDF إلى مستندين PDF جديدين. |
+| [split_at](./core/split_at/) | تقسيم مستند PDF الحالي إلى مستندين PDF جديدين. |
+| [bytes](./core/bytes/) | إرجاع محتويات مستند PDF كمتجه بايت. |
+| [get_meta_info](./core/get_meta_info/) | الحصول على قيمة معلومات التعريف لمستند PDF. |
+| [set_meta_info](./core/set_meta_info/) | تعيين قيمة المعلومات الوصفية لمستند PDF. |
+| [clear_meta_info](./core/clear_meta_info/) | مسح جميع قيم المعلومات الوصفية لمستند PDF. |
+| [is_linearized](./core/is_linearized/) | الحصول على قيمة تشير إلى ما إذا كان المستند مُخططًا خطيًا. |
+| [page_add](./core/page_add/) | إضافة صفحة جديدة إلى مستند PDF. |
+| [page_insert](./core/page_insert/) | إدراج صفحة جديدة في الموضع المحدد في مستند PDF. |
+| [page_delete](./core/page_delete/) | حذف الصفحة المحددة في مستند PDF. |
+| [page_count](./core/page_count/) | إرجاع عدد الصفحات في مستند PDF. |
+| [page_word_count](./core/page_word_count/) | إرجاع عدد الكلمات في الصفحة المحددة في مستند PDF. |
+| [page_character_count](./core/page_character_count/) | إرجاع عدد الأحرف في الصفحة المحددة في مستند PDF. |
+| [page_is_blank](./core/page_is_blank/) | إرجاع ما إذا كانت الصفحة فارغة في مستند PDF. |
+
+
+## Security
+| دالة | الوصف |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | فتح مستند PDF محمي بكلمة مرور. |
+| [encrypt](./security/encrypt/) | تشفير مستند PDF. |
+| [decrypt](./security/decrypt/) | فك تشفير مستند PDF. |
+| [set_permissions](./security/set_permissions/) | تعيين الأذونات لمستند PDF. |
+| [get_permissions](./security/get_permissions/) | الحصول على الأذونات الحالية لمستند PDF. |
+| [is_encrypted](./security/is_encrypted/) | الحصول على حالة التشفير لمستند PDF. |
+| [sign_pkcs7](./security/sign_pkcs7/) | توقيع مستند PDF باستخدام توقيعات رقمية PKCS#7. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | توقيع مستند PDF باستخدام توقيعات رقمية منفصلة PKCS#7. |
+| [is_signed](./security/is_signed/) | الحصول على حالة التوقيع لمستند PDF. |
+| [remove_signs](./security/remove_signs/) | إزالة التوقيعات من مستند PDF. |
+
+
+## Miscellaneous
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | إرجاع معلومات البيانات الوصفية حول Aspose.PDF لـ Rust عبر C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// مجموعة علمية تمثل قدرات أذونات PDF.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// حجم A0.
+    A0 = 0,
+    /// حجم A1.
+    A1 = 1,
+    /// حجم A2.
+    A2 = 2,
+    /// حجم A3.
+    A3 = 3,
+    /// حجم A4.
+    A4 = 4,
+    /// حجم A5.
+    A5 = 5,
+    /// حجم A6.
+    A6 = 6,
+    /// حجم B5.
+    B5 = 7,
+    /// حجم PageLetter.
+    PageLetter = 8,
+    /// حجم PageLegal.
+    PageLegal = 9,
+    /// حجم PageLedger.
+    PageLedger = 10,
+    /// حجم P11x17.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// غير مدور.
+    None = 0,
+    /// مدور بزاوية 90 درجة باتجاه عقارب الساعة.
+    On90 = 1,
+    /// مدور بزاوية 180 درجة.
+    On180 = 2,
+    /// مدور بزاوية 270 درجة باتجاه عقارب الساعة.
+    On270 = 3,
+    /// مدور بزاوية 360 درجة باتجاه عقارب الساعة.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 بطول مفتاح 40.
+    RC4x40 = 0,
+    /// RC4 بطول مفتاح 128.
+    RC4x128 = 1,
+    /// AES بطول مفتاح 128.
+    AESx128 = 2,
+    /// AES بطول مفتاح 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// تنسيق PDF/A-1a.
+    PDF_A_1A = 0,
+    /// تنسيق PDF/A-1b.
+    PDF_A_1B = 1,
+    /// تنسيق PDF/A-2a.
+    PDF_A_2A = 2,
+    /// تنسيق PDF/A-3a.
+    PDF_A_3A = 3,
+    /// تنسيق PDF/A-2b.
+    PDF_A_2B = 4,
+    /// تنسيق PDF/A-2u.
+    PDF_A_2U = 5,
+    /// تنسيق PDF/A-3b.
+    PDF_A_3B = 6,
+    /// تنسيق PDF/A-3u.
+    PDF_A_3U = 7,
+    /// إصدار Adobe 1.0.
+    V_1_0 = 8,
+    /// إصدار Adobe 1.1.
+    V_1_1 = 9,
+    /// إصدار Adobe 1.2.
+    V_1_2 = 10,
+    /// إصدار Adobe 1.3.
+    V_1_3 = 11,
+    /// إصدار Adobe 1.4.
+    V_1_4 = 12,
+    /// إصدار Adobe 1.5.
+    V_1_5 = 13,
+    /// إصدار Adobe 1.6.
+    V_1_6 = 14,
+    /// إصدار Adobe 1.7.
+    V_1_7 = 15,
+    /// معيار ISO PDF 2.0.
+    V_2_0 = 16,
+    /// تنسيق PDF/UA-1.
+    PDF_UA_1 = 17,
+    /// تنسيق PDF/X-1a:2001.
+    PDF_X_1A_2001 = 18,
+    /// تنسيق PDF/X-1a.
+    PDF_X_1A = 19,
+    /// تنسيق PDF/X-3.
+    PDF_X_3 = 20,
+    /// تنسيق ZUGFeRD.
+    ZUGFeRD = 21,
+    /// تنسيق PDF/A-4.
+    PDF_A_4 = 22,
+    /// تنسيق PDF/A-4e.
+    PDF_A_4E = 23,
+    /// تنسيق PDF/A-4f.
+    PDF_A_4F = 24,
+    /// تنسيق PDF/X-4.
+    PDF_X_4 = 25,
+    /// تنسيق PDF/E-1 (PDF 1.6).
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// حذف العناصر غير المتوافقة.
+    Delete = 0,
+    /// لا تفعل شيئًا، احتفظ بالعناصر غير المتوافقة.
+    None = 1,
+}
+```
+

--- a/arabic/rust-cpp/convert/_index.md
+++ b/arabic/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "تحويل من وظائف PDF"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "وظائف لتحويل ملفات PDF."
+type: docs
+url: /ar/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف DocX. |
+| [save_doc](./save_doc/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Doc. |
+| [save_xlsx](./save_xlsx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف XlsX. |
+| [save_txt](./save_txt/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Txt. |
+| [save_pptx](./save_pptx/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PptX. |
+| [save_xps](./save_xps/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Xps. |
+| [save_tex](./save_tex/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف TeX. |
+| [save_epub](./save_epub/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Epub. |
+| [save_booklet](./save_booklet/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PDF ككتيب. |
+| [save_n_up](./save_n_up/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف PDF N-Up. |
+| [save_markdown](./save_markdown/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Markdown. |
+| [save_tiff](./save_tiff/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف Tiff. |
+| [save_docx_enhanced](./save_docx_enhanced/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كملف DocX مع وضع التعرف المحسن (جداول وفقرة قابلة للتحرير بالكامل). |
+| [save_svg_zip](./save_svg_zip/) | تحويل وحفظ مستند PDF المفتوح مسبقًا كأرشيف SVG. |
+| [export_fdf](./export_fdf/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف FDF. |
+| [export_xfdf](./export_xfdf/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف XFDF. |
+| [export_xml](./export_xml/) | تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى ملف XML. |
+| [page_to_jpg](./page_to_jpg/) | تحويل وحفظ الصفحة المحددة كصورة Jpg. |
+| [page_to_png](./page_to_png/) | تحويل وحفظ الصفحة المحددة كصورة Png. |
+| [page_to_bmp](./page_to_bmp/) | تحويل وحفظ الصفحة المحددة كصورة Bmp. |
+| [page_to_tiff](./page_to_tiff/) | تحويل وحفظ الصفحة المحددة كـ Tiff-image. |
+| [page_to_svg](./page_to_svg/) | تحويل وحفظ الصفحة المحددة كـ Svg-image. |
+| [page_to_pdf](./page_to_pdf/) | تحويل وحفظ الصفحة المحددة كـ PDF-document. |
+| [page_to_dicom](./page_to_dicom/) | تحويل وحفظ الصفحة المحددة كـ DICOM-image. |
+
+
+## Detailed Description
+
+وظائف لتحويل ملفات PDF.
+

--- a/arabic/rust-cpp/convert/export_fdf/_index.md
+++ b/arabic/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يصدّر من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند FDF مع اسم الملف."
+type: docs
+url: /ar/rust-cpp/convert/export_fdf/
+---
+
+_يصدّر من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند FDF مع اسم الملف._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند FDF
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/export_xfdf/_index.md
+++ b/arabic/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XFDF مع اسم الملف."
+type: docs
+url: /ar/rust-cpp/convert/export_xfdf/
+---
+
+_تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XFDF مع اسم الملف._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XFDF
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/export_xml/_index.md
+++ b/arabic/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XML مع اسم الملف."
+type: docs
+url: /ar/rust-cpp/convert/export_xml/
+---
+
+_تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XML مع اسم الملف._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تصدير من مستند PDF المفتوح مسبقًا مع AcroForm إلى مستند XML
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_bmp/_index.md
+++ b/arabic/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة BMP-image."
+type: docs
+url: /ar/rust-cpp/convert/page_to_bmp/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة BMP-image._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ الصفحة المحددة كصورة Bmp-image
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_dicom/_index.md
+++ b/arabic/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة DICOM."
+type: docs
+url: /ar/rust-cpp/convert/page_to_dicom/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة DICOM._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ الصفحة المحددة كصورة DICOM
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_jpg/_index.md
+++ b/arabic/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة JPG-image."
+type: docs
+url: /ar/rust-cpp/convert/page_to_jpg/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة JPG-image._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ الصفحة المحددة كـ Jpg-image
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_pdf/_index.md
+++ b/arabic/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كمستند PDF."
+type: docs
+url: /ar/rust-cpp/convert/page_to_pdf/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كمستند PDF._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ الصفحة المحددة كمستند PDF
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_png/_index.md
+++ b/arabic/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة PNG."
+type: docs
+url: /ar/rust-cpp/convert/page_to_png/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة PNG._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ الصفحة المحددة كصورة Png
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_svg/_index.md
+++ b/arabic/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة SVG-image."
+type: docs
+url: /ar/rust-cpp/convert/page_to_svg/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة SVG-image._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ الصفحة المحددة كصورة Svg-image
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/page_to_tiff/_index.md
+++ b/arabic/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ الصفحة المحددة كصورة TIFF."
+type: docs
+url: /ar/rust-cpp/convert/page_to_tiff/
+---
+
+_يقوم بتحويل وحفظ الصفحة المحددة كصورة TIFF._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ الصفحة المحددة كصورة Tiff
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_booklet/_index.md
+++ b/arabic/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف كتيب PDF-document."
+type: docs
+url: /ar/rust-cpp/convert/save_booklet/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف كتيب PDF-document._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف كتيب PDF-document
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/arabic/rust-cpp/convert/save_doc/_index.md
+++ b/arabic/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف DOC-document."
+type: docs
+url: /ar/rust-cpp/convert/save_doc/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف DOC-document._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف Doc-document
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_docx/_index.md
+++ b/arabic/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف DOCX-document."
+type: docs
+url: /ar/rust-cpp/convert/save_docx/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف DOCX-document._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف DocX-document
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/arabic/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة DOCX-document مع وضع التعرف المحسن (جداول وفقرات قابلة للتحرير بالكامل)."
+type: docs
+url: /ar/rust-cpp/convert/save_docx_enhanced/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة DOCX-document مع وضع التعرف المحسن (جداول وفقرات قابلة للتحرير بالكامل)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة DocX-document مع وضع التعرف المحسن (جداول وفقرات قابلة للتحرير بالكامل)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_epub/_index.md
+++ b/arabic/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كمستند EPUB."
+type: docs
+url: /ar/rust-cpp/convert/save_epub/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف EPUB-document._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف Epub-document
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_markdown/_index.md
+++ b/arabic/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كوثيقة Markdown."
+type: docs
+url: /ar/rust-cpp/convert/save_markdown/
+---
+
+_يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كوثيقة Markdown._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ مستند PDF المفتوح مسبقًا كوثيقة Markdown
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/arabic/rust-cpp/convert/save_n_up/_index.md
+++ b/arabic/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة N-Up PDF-document."
+type: docs
+url: /ar/rust-cpp/convert/save_n_up/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة N-Up PDF-document._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة N-Up PDF-document
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/arabic/rust-cpp/convert/save_pptx/_index.md
+++ b/arabic/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف PPTX-document."
+type: docs
+url: /ar/rust-cpp/convert/save_pptx/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف PPTX-document._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف PptX-document
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_svg_zip/_index.md
+++ b/arabic/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كأرشيف SVG."
+type: docs
+url: /ar/rust-cpp/convert/save_svg_zip/
+---
+
+_يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كأرشيف SVG._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ مستند PDF المفتوح مسبقًا كأرشيف SVG
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_tex/_index.md
+++ b/arabic/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة TeX-document."
+type: docs
+url: /ar/rust-cpp/convert/save_tex/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة TeX-document._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة TeX-document
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_tiff/_index.md
+++ b/arabic/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف Tiff-document."
+type: docs
+url: /ar/rust-cpp/convert/save_tiff/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف Tiff-document._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ المستند PDF-document المفتوح مسبقًا كملف Tiff-document
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/arabic/rust-cpp/convert/save_txt/_index.md
+++ b/arabic/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كمستند TXT."
+type: docs
+url: /ar/rust-cpp/convert/save_txt/
+---
+
+_يقوم بتحويل وحفظ مستند PDF المفتوح مسبقًا كمستند TXT._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ مستند PDF المفتوح مسبقًا كمستند Txt
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_xlsx/_index.md
+++ b/arabic/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف XLSX-document."
+type: docs
+url: /ar/rust-cpp/convert/save_xlsx/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف XLSX-document._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل وحفظ مستند PDF-document المفتوح مسبقًا كملف XlsX-document
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/convert/save_xps/_index.md
+++ b/arabic/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة XPS-document."
+type: docs
+url: /ar/rust-cpp/convert/save_xps/
+---
+
+_يقوم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة XPS-document._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قم بتحويل وحفظ مستند PDF-document المفتوح مسبقًا كوثيقة Xps-document
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/_index.md
+++ b/arabic/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "وظائف PDF الأساسية"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "وظائف أساسية للعمل مع ملفات PDF."
+type: docs
+url: /ar/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [new](./new/) | إنشاء مستند PDF جديد. |
+| [open](./open/) | فتح مستند PDF باستخدام اسم الملف. |
+| [save](./save/) | حفظ مستند PDF المفتوح مسبقًا. |
+| [save_as](./save_as/) | حفظ مستند PDF المفتوح مسبقًا باسم ملف جديد. |
+| [set_license](./set_license/) | تعيين الترخيص باستخدام اسم الملف. |
+| [extract_text](./extract_text/) | إرجاع محتويات مستند PDF كنص عادي. |
+| [word_count](./word_count/) | إرجاع عدد الكلمات في مستند PDF. |
+| [character_count](./character_count/) | إرجاع عدد الأحرف في مستند PDF. |
+| [append](./append/) | إضافة صفحات من مستند PDF آخر. |
+| [append_pages](./append_pages/) | إضافة الصفحات المحددة من مستند PDF آخر. |
+| [merge_documents](./merge_documents/) | إنشاء مستند PDF جديد بدمج مستندات PDF المقدمة. |
+| [split_document](./split_document/) | إنشاء عدة مستندات PDF جديدة باستخراج صفحات من مستند PDF المصدر. |
+| [split](./split/) | إنشاء عدة مستندات PDF جديدة باستخراج صفحات من مستند PDF الحالي. |
+| [split_at_page](./split_at_page/) | تقسيم مستند PDF إلى مستندين PDF جديدين. |
+| [split_at](./split_at/) | تقسيم مستند PDF الحالي إلى مستندين PDF جديدين. |
+| [bytes](./bytes/) | إرجاع محتويات مستند PDF كمتجه بايت. |
+| [get_meta_info](./get_meta_info/) | الحصول على قيمة معلومات التعريف لمستند PDF. |
+| [set_meta_info](./set_meta_info/) | تعيين قيمة المعلومات الوصفية لمستند PDF. |
+| [clear_meta_info](./clear_meta_info/) | مسح جميع قيم المعلومات الوصفية لمستند PDF. |
+| [is_linearized](./is_linearized/) | الحصول على قيمة تشير إلى ما إذا كان المستند مُخططًا خطيًا. |
+| [page_add](./page_add/) | إضافة صفحة جديدة إلى مستند PDF. |
+| [page_insert](./page_insert/) | إدراج صفحة جديدة في الموضع المحدد في مستند PDF. |
+| [page_delete](./page_delete/) | حذف الصفحة المحددة في مستند PDF. |
+| [page_count](./page_count/) | إرجاع عدد الصفحات في مستند PDF. |
+| [page_word_count](./page_word_count/) | إرجاع عدد الكلمات في الصفحة المحددة في مستند PDF. |
+| [page_character_count](./page_character_count/) | إرجاع عدد الأحرف في الصفحة المحددة في مستند PDF. |
+| [page_is_blank](./page_is_blank/) | إرجاع ما إذا كانت الصفحة فارغة في مستند PDF. |
+
+
+## Detailed Description
+
+وظائف أساسية للعمل مع ملفات PDF.
+

--- a/arabic/rust-cpp/core/append/_index.md
+++ b/arabic/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف صفحات من مستند PDF-document آخر."
+type: docs
+url: /ar/rust-cpp/core/append/
+---
+
+_يضيف صفحات من مستند PDF-document آخر._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document الأساسي
+    let pdf = Document::open("sample.pdf")?;
+
+    // افتح مستند PDF آخر للإلحاق
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // إلحاق صفحات من مستند PDF آخر
+    pdf.append(&another_pdf)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/append_pages/_index.md
+++ b/arabic/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف الصفحات المحددة من مستند PDF آخر."
+type: docs
+url: /ar/rust-cpp/core/append_pages/
+---
+
+_يضيف الصفحات المحددة من مستند PDF آخر._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document الأساسي
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // افتح مستند PDF آخر للإلحاق
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // أضف الصفحات المحددة (1 و 3) من مستند PDF آخر
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/bytes/_index.md
+++ b/arabic/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "بايت"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد محتويات PDF-document كمتجه بايت."
+type: docs
+url: /ar/rust-cpp/core/bytes/
+---
+
+_يعيد محتويات PDF-document كمتجه بايت._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // إرجاع محتويات PDF-document كمتجه بايت
+    let data = pdf.bytes()?;
+
+    // اطبع طول متجه البايت
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/character_count/_index.md
+++ b/arabic/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد عدد الأحرف في PDF-document."
+type: docs
+url: /ar/rust-cpp/core/character_count/
+---
+
+_يعيد عدد الأحرف في PDF-document._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إرجاع عدد الأحرف في PDF-document
+    let count = pdf.character_count()?;
+
+    // اطبع عدد الأحرف
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/clear_meta_info/_index.md
+++ b/arabic/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يمسح جميع قيم معلومات التعريف لمستند PDF."
+type: docs
+url: /ar/rust-cpp/core/clear_meta_info/
+---
+
+_يمسح جميع قيم معلومات التعريف لمستند PDF._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // مسح جميع قيم معلومات التعريف لمستند PDF
+    pdf.clear_meta_info()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/extract_text/_index.md
+++ b/arabic/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يرجع محتويات مستند PDF كنص عادي."
+type: docs
+url: /ar/rust-cpp/core/extract_text/
+---
+
+_يرجع محتويات مستند PDF كنص عادي._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إرجاع محتويات مستند PDF كنص عادي
+    let txt = pdf.extract_text()?;
+
+    // اطبع النص المستخرج
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/get_meta_info/_index.md
+++ b/arabic/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحصل على قيمة معلومات التعريف لمستند PDF."
+type: docs
+url: /ar/rust-cpp/core/get_meta_info/
+---
+
+_يحصل على قيمة معلومات التعريف لمستند PDF._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // احصل على قيمة معلومات التعريف لمستند PDF
+    let author = pdf.get_meta_info("Author")?;
+
+    // اطبع النتيجة
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/is_linearized/_index.md
+++ b/arabic/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحصل على قيمة تشير إلى ما إذا كان المستند مُخططًا خطيًا."
+type: docs
+url: /ar/rust-cpp/core/is_linearized/
+---
+
+_يحصل على قيمة تشير إلى ما إذا كان المستند مُخططًا خطيًا._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // احصل على قيمة تشير إلى ما إذا كان المستند مُخططًا خطيًا
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/merge_documents/_index.md
+++ b/arabic/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "ينشئ مستند PDF جديد عن طريق دمج مستندات PDF المقدمة."
+type: docs
+url: /ar/rust-cpp/core/merge_documents/
+---
+
+_ينشئ مستند PDF جديد عن طريق دمج مستندات PDF المقدمة._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf1 = Document::new()?;
+
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // إنشاء مستند PDF جديد عن طريق دمج مستندات PDF المقدمة
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/new/_index.md
+++ b/arabic/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "جديد"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "ينشئ PDF-document جديدًا."
+type: docs
+url: /ar/rust-cpp/core/new/
+---
+
+_ينشئ PDF-document جديدًا._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/open/_index.md
+++ b/arabic/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "فتح"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يفتح مستند PDF بالاسم المحدد."
+type: docs
+url: /ar/rust-cpp/core/open/
+---
+
+_يفتح مستند PDF بالاسم المحدد._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_add/_index.md
+++ b/arabic/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف صفحة جديدة إلى PDF-document."
+type: docs
+url: /ar/rust-cpp/core/page_add/
+---
+
+_يضيف صفحة جديدة إلى PDF-document._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة صفحة جديدة في PDF-document
+    pdf.page_add()?;
+
+    // احفظ مستند PDF-document المفتوح مسبقًا
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_character_count/_index.md
+++ b/arabic/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد عدد الأحرف في الصفحة المحددة في PDF-document."
+type: docs
+url: /ar/rust-cpp/core/page_character_count/
+---
+
+_يعيد عدد الأحرف في الصفحة المحددة في PDF-document._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // حدد رقم الصفحة (فهرس يبدأ من 1)
+    let page_number = 1;
+
+    // إرجاع عدد الأحرف في الصفحة المحددة
+    let count = pdf.page_character_count(page_number)?;
+
+    // اطبع عدد الأحرف
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_count/_index.md
+++ b/arabic/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد عدد الصفحات في مستند PDF."
+type: docs
+url: /ar/rust-cpp/core/page_count/
+---
+
+_يعيد عدد الصفحات في مستند PDF._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إرجاع عدد الصفحات في مستند PDF
+    let count = pdf.page_count()?;
+
+    // اطبع عدد الصفحات
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_delete/_index.md
+++ b/arabic/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحذف الصفحة المحددة من مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/core/page_delete/
+---
+
+_يحذف الصفحة المحددة من مستند PDF-document._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // حذف الصفحة المحددة في مستند PDF-document
+    pdf.page_delete(1)?;
+
+    // احفظ مستند PDF-document المفتوح مسبقًا
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_insert/_index.md
+++ b/arabic/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يدرج صفحة جديدة في الموضع المحدد داخل مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/core/page_insert/
+---
+
+_يدرج صفحة جديدة في الموضع المحدد داخل مستند PDF-document._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إدراج صفحة جديدة في الموضع المحدد داخل مستند PDF-document
+    pdf.page_insert(1)?;
+
+    // احفظ مستند PDF-document المفتوح مسبقًا
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_is_blank/_index.md
+++ b/arabic/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "إرجاع ما إذا كانت الصفحة فارغة في مستند PDF."
+type: docs
+url: /ar/rust-cpp/core/page_is_blank/
+---
+
+_إرجاع الصفحة فارغة في مستند PDF._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // حدد رقم الصفحة (فهرس يبدأ من 1)
+    let page_number = 1;
+
+    // إرجاع الصفحة فارغة في مستند PDF
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // اطبع إذا كانت الصفحة المحددة فارغة
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/page_word_count/_index.md
+++ b/arabic/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد عدد الكلمات في الصفحة المحددة في مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/core/page_word_count/
+---
+
+_يعيد عدد الكلمات في الصفحة المحددة في مستند PDF-document._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // حدد رقم الصفحة (فهرس يبدأ من 1)
+    let page_number = 1;
+
+    // إرجاع عدد الكلمات في الصفحة المحددة
+    let count = pdf.page_word_count(page_number)?;
+
+    // اطبع عدد الكلمات
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/save/_index.md
+++ b/arabic/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحفظ مستند PDF-document المفتوح مسبقًا."
+type: docs
+url: /ar/rust-cpp/core/save/
+---
+
+_يحفظ مستند PDF-document المفتوح مسبقًا._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // احفظ مستند PDF-document المفتوح مسبقًا
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/save_as/_index.md
+++ b/arabic/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحفظ مستند PDF-document المفتوح مسبقًا باسم ملف جديد."
+type: docs
+url: /ar/rust-cpp/core/save_as/
+---
+
+_يحفظ مستند PDF-document المفتوح مسبقًا باسم ملف جديد._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // احفظ مستند PDF-document باسم ملف جديد
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/set_license/_index.md
+++ b/arabic/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضبط الترخيص باستخدام اسم الملف."
+type: docs
+url: /ar/rust-cpp/core/set_license/
+---
+
+_يضبط الترخيص باستخدام اسم الملف._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // ضبط الترخيص باستخدام اسم الملف
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // الآن يمكنك العمل مع مستند PDF المرخص
+    // ...
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/set_meta_info/_index.md
+++ b/arabic/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضبط قيمة معلومات التعريف لمستند PDF."
+type: docs
+url: /ar/rust-cpp/core/set_meta_info/
+---
+
+_يضبط قيمة معلومات التعريف لمستند PDF._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // ضبط قيمة معلومات التعريف لمستند PDF
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/split/_index.md
+++ b/arabic/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "ينشئ مستندات PDF متعددة جديدة عن طريق استخراج الصفحات من مستند PDF الحالي."
+type: docs
+url: /ar/rust-cpp/core/split/
+---
+
+_ينشئ مستندات PDF متعددة جديدة عن طريق استخراج الصفحات من مستند PDF الحالي._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // إنشاء مستندات PDF متعددة جديدة عن طريق استخراج الصفحات من مستند PDF الحالي
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // احفظ كل جزء مقسّم كملف PDF-document منفصل
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/split_at/_index.md
+++ b/arabic/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقسم مستند PDF-document الحالي إلى مستندين PDF-documents جديدين."
+type: docs
+url: /ar/rust-cpp/core/split_at/
+---
+
+_يقسم مستند PDF-document الحالي إلى مستندين PDF-documents جديدين._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // قسم مستند PDF-document الحالي إلى مستندين PDF-documents جديدين
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // احفظ كل جزء مقسّم كملف PDF-document منفصل
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/split_at_page/_index.md
+++ b/arabic/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقسم مستند PDF-document إلى مستندين PDF-documents جديدين."
+type: docs
+url: /ar/rust-cpp/core/split_at_page/
+---
+
+_يقسم مستند PDF-document إلى مستندين PDF-documents جديدين._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // قسم مستند PDF-document إلى مستندين PDF-documents جديدين
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // احفظ كل جزء مقسّم كملف PDF-document منفصل
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/split_document/_index.md
+++ b/arabic/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "ينشئ عدة مستندات PDF-documents جديدة عن طريق استخراج الصفحات من مستند PDF-document المصدر."
+type: docs
+url: /ar/rust-cpp/core/split_document/
+---
+
+_ينشئ عدة مستندات PDF-documents جديدة عن طريق استخراج الصفحات من مستند PDF-document المصدر._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document باسم "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // ينشئ عدة مستندات PDF-documents جديدة عن طريق استخراج الصفحات من مستند PDF-document المصدر
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // احفظ كل جزء مقسّم كملف PDF-document منفصل
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/core/word_count/_index.md
+++ b/arabic/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد عدد الكلمات في مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/core/word_count/
+---
+
+_يعيد عدد الكلمات في مستند PDF-document._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إرجاع عدد الكلمات في مستند PDF-document
+    let count = pdf.word_count()?;
+
+    // اطبع عدد الكلمات
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/miscellaneous/_index.md
+++ b/arabic/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "وظائف متنوعة"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "وظائف متنوعة للعمل."
+type: docs
+url: /ar/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [about](./about/) | إرجاع معلومات البيانات الوصفية حول Aspose.PDF لـ Rust عبر C++. |
+
+
+## Detailed Description
+
+وظائف متنوعة للعمل.
+

--- a/arabic/rust-cpp/miscellaneous/about/_index.md
+++ b/arabic/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "حول"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يعيد معلومات البيانات الوصفية حول Aspose.PDF للـ Rust عبر C++."
+type: docs
+url: /ar/rust-cpp/miscellaneous/about/
+---
+
+_يعيد معلومات البيانات الوصفية حول Aspose.PDF للـ Rust عبر C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // يعيد معلومات البيانات الوصفية حول Aspose.PDF للـ Go عبر C++.
+    let info = pdf.about()?;
+
+    // طباعة حقول البيانات الوصفية
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/_index.md
+++ b/arabic/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "وظائف تنظيم PDF"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "وظائف لتنظيم ملفات PDF."
+type: docs
+url: /ar/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [optimize](./optimize/) | تحسين محتوى PDF-document. |
+| [optimize_resource](./optimize_resource/) | تحسين موارد PDF-document. |
+| [grayscale](./grayscale/) | تحويل PDF-document إلى أبيض وأسود. |
+| [rotate](./rotate/) | تدوير PDF-document. |
+| [set_background](./set_background/) | تعيين لون خلفية PDF-document باستخدام قيم RGB. |
+| [repair](./repair/) | إصلاح PDF-document. |
+| [replace_text](./replace_text/) | استبدال النص في PDF-document |
+| [add_page_num](./add_page_num/) | إضافة رقم الصفحة إلى PDF-document |
+| [add_text_header](./add_text_header/) | إضافة نص في رأس PDF-document |
+| [add_text_footer](./add_text_footer/) | إضافة نص في تذييل PDF-document |
+| [flatten](./flatten/) | تسوية PDF-document |
+| [remove_annotations](./remove_annotations/) | إزالة التعليقات التوضيحية من PDF-document |
+| [remove_attachments](./remove_attachments/) | إزالة المرفقات من PDF-document |
+| [remove_blank_pages](./remove_blank_pages/) | إزالة الصفحات الفارغة من PDF-document |
+| [remove_bookmarks](./remove_bookmarks/) | إزالة العلامات المرجعية من PDF-document |
+| [remove_hidden_text](./remove_hidden_text/) | إزالة النص المخفي من PDF-document |
+| [remove_images](./remove_images/) | إزالة الصور من PDF-document |
+| [remove_javascripts](./remove_javascripts/) | إزالة سكريبتات جافا من PDF-document |
+| [remove_tables](./remove_tables/) | إزالة الجداول من PDF-document. |
+| [remove_watermarks](./remove_watermarks/) | إزالة العلامات المائية من PDF-document. |
+| [add_watermark](./add_watermark/) | إضافة علامة مائية إلى PDF-document. |
+| [embed_fonts](./embed_fonts/) | تضمين الخطوط في PDF-document. |
+| [unembed_fonts](./unembed_fonts/) | إزالة تضمين الخطوط في PDF-document. |
+| [optimize_file_size](./optimize_file_size/) | تحسين حجم PDF-document باستخدام جودة ضغط الصور. |
+| [remove_text_headers](./remove_text_headers/) | إزالة رؤوس النص من PDF-document. |
+| [remove_text_footers](./remove_text_footers/) | إزالة تذييلات النص من PDF-document. |
+| [crop](./crop/) | قص صفحات PDF-document. |
+| [replace_font](./replace_font/) | استبدال الخط في PDF-document. |
+| [convert](./convert/) | تحويل PDF-document إلى PDF-document بالتنسيق PDF المحدد |
+| [validate](./validate/) | التحقق من توافق PDF-document مع تنسيق PDF |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | إزالة الامتثال لـ PDF/A من PDF-document |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | إزالة الامتثال لـ PDF/UA من PDF-document |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | تحقق ما إذا كان PDF-document متوافقًا مع PDF/A |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | تحقق ما إذا كان PDF-document متوافقًا مع PDF/UA |
+| [page_rotate](./page_rotate/) | تدوير صفحة في PDF-document. |
+| [page_set_size](./page_set_size/) | تحديد حجم صفحة في PDF-document. |
+| [page_grayscale](./page_grayscale/) | تحويل الصفحة إلى أبيض وأسود. |
+| [page_add_text](./page_add_text/) | إضافة نص على الصفحة. |
+| [page_replace_text](./page_replace_text/) | استبدال النص على الصفحة |
+| [page_add_page_num](./page_add_page_num/) | إضافة رقم الصفحة إلى الصفحة |
+| [page_add_text_header](./page_add_text_header/) | إضافة نص في رأس الصفحة |
+| [page_add_text_footer](./page_add_text_footer/) | إضافة نص في تذييل الصفحة |
+| [page_remove_annotations](./page_remove_annotations/) | إزالة التعليقات التوضيحية في الصفحة. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | إزالة النص المخفي في الصفحة. |
+| [page_remove_images](./page_remove_images/) | إزالة الصور في الصفحة. |
+| [page_remove_tables](./page_remove_tables/) | إزالة الجداول في الصفحة. |
+| [page_remove_watermarks](./page_remove_watermarks/) | إزالة العلامات المائية في الصفحة. |
+| [page_add_watermark](./page_add_watermark/) | إضافة علامة مائية على الصفحة. |
+| [page_remove_text_headers](./page_remove_text_headers/) | إزالة رؤوس النص في الصفحة. |
+| [page_remove_text_footers](./page_remove_text_footers/) | إزالة تذييلات النص في الصفحة. |
+| [page_crop](./page_crop/) | قص صفحة. |
+| [page_replace_font](./page_replace_font/) | استبدال الخط في الصفحة. |
+| [page_merge_layers](./page_merge_layers/) | دمج جميع الطبقات على الصفحة في طبقة واحدة بالاسم الجديد المحدد للطبقة. |
+| [page_layers](./page_layers/) | الحصول على أسماء الطبقات في الصفحة. |
+
+
+## Detailed Description
+
+وظائف لتنظيم ملفات PDF.

--- a/arabic/rust-cpp/organize/add_page_num/_index.md
+++ b/arabic/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف رقم الصفحة إلى مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/add_page_num/
+---
+
+_يضيف رقم الصفحة إلى مستند PDF._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة رقم الصفحة إلى PDF-document
+    pdf.add_page_num()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/add_text_footer/_index.md
+++ b/arabic/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف نصًا في تذييل مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/add_text_footer/
+---
+
+_يضيف نصًا في تذييل مستند PDF._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة نص في تذييل PDF-document
+    pdf.add_text_footer("FOOTER")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/add_text_header/_index.md
+++ b/arabic/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف نصًا في رأس مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/add_text_header/
+---
+
+_يضيف نصًا في رأس مستند PDF._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة نص في رأس PDF-document
+    pdf.add_text_header("HEADER")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/add_watermark/_index.md
+++ b/arabic/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف علامة مائية إلى مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/add_watermark/
+---
+
+_يضيف علامة مائية إلى مستند PDF._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة علامة مائية إلى مستند PDF
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/convert/_index.md
+++ b/arabic/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "تحويل"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحوّل مستند PDF إلى مستند PDF بالتنسيق المحدد للـ PDF."
+type: docs
+url: /ar/rust-cpp/organize/convert/
+---
+
+_يحوّل مستند PDF إلى مستند PDF بالتنسيق المحدد للـ PDF._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل PDF-document إلى PDF-document بالتنسيق PDF المحدد
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // طباعة نتيجة التحويل والسجل الكامل
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/crop/_index.md
+++ b/arabic/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "crop"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقص صفحات من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/crop/
+---
+
+_يقص صفحات من PDF-document._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قص صفحات من PDF-document
+    pdf.crop(10.5)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/embed_fonts/_index.md
+++ b/arabic/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضمّن الخطوط في مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/embed_fonts/
+---
+
+_يضمّن الخطوط في مستند PDF-document._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // ضمّن الخطوط في مستند PDF-document
+    pdf.embed_fonts()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/flatten/_index.md
+++ b/arabic/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتسطيح مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/flatten/
+---
+
+_يقوم بتسطيح مستند PDF._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إرجاع محتويات مستند PDF كنص عادي
+    let txt = pdf.extract_text()?;
+
+    // اطبع النص المستخرج
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/grayscale/_index.md
+++ b/arabic/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحول مستند PDF إلى أبيض وأسود."
+type: docs
+url: /ar/rust-cpp/organize/grayscale/
+---
+
+_يحول مستند PDF إلى أبيض وأسود._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل مستند PDF إلى أبيض وأسود
+    pdf.grayscale()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/arabic/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحصل على ما إذا كان PDF-document متوافقًا مع PDF/A."
+type: docs
+url: /ar/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_يحصل على ما إذا كان PDF-document متوافقًا مع PDF/A._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // احصل على حالة توافق PDF/A لمستند PDF-document
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/arabic/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحصل على ما إذا كان PDF-document متوافقًا مع PDF/UA."
+type: docs
+url: /ar/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_يحصل على ما إذا كان PDF-document متوافقًا مع PDF/UA._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // احصل على حالة توافق PDF/UA لـ PDF-document
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/optimize/_index.md
+++ b/arabic/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحسين محتوى PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/optimize/
+---
+
+_يقوم بتحسين محتوى PDF-document._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحسين محتوى PDF-document
+    pdf.optimize()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/optimize_file_size/_index.md
+++ b/arabic/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحسن حجم مستند PDF باستخدام جودة ضغط الصورة."
+type: docs
+url: /ar/rust-cpp/organize/optimize_file_size/
+---
+
+_يحسن حجم مستند PDF باستخدام جودة ضغط الصورة._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحسين حجم مستند PDF باستخدام جودة ضغط الصورة
+    pdf.optimize_file_size(50)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/optimize_resource/_index.md
+++ b/arabic/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بتحسين موارد PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/optimize_resource/
+---
+
+_يقوم بتحسين موارد PDF-document._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحسين موارد PDF-document
+    pdf.optimize_resource()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_add_page_num/_index.md
+++ b/arabic/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف رقم الصفحة على الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_add_page_num/
+---
+
+_يضيف رقم الصفحة على الصفحة._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة رقم الصفحة إلى الصفحة
+    pdf.page_add_page_num(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_add_text/_index.md
+++ b/arabic/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف نصًا إلى صفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_add_text/
+---
+
+_يضيف نصًا إلى صفحة._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة نص إلى الصفحة
+    pdf.page_add_text(1, "added text")?;
+
+    // احفظ مستند PDF-document المفتوح مسبقًا
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/arabic/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف النص في تذييل الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_add_text_footer/
+---
+
+_يضيف النص في تذييل الصفحة._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة نص في تذييل الصفحة
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_add_text_header/_index.md
+++ b/arabic/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف نصًا في رأس الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_add_text_header/
+---
+
+_يضيف نصًا في رأس الصفحة._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة نص في رأس الصفحة
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_add_watermark/_index.md
+++ b/arabic/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضيف علامة مائية على الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_add_watermark/
+---
+
+_يضيف علامة مائية على الصفحة._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إضافة علامة مائية على الصفحة
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_crop/_index.md
+++ b/arabic/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقص صفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_crop/
+---
+
+_يقص صفحة._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // قص صفحة
+    pdf.page_crop(1, 1.0)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_grayscale/_index.md
+++ b/arabic/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحوّل صفحة إلى أبيض وأسود."
+type: docs
+url: /ar/rust-cpp/organize/page_grayscale/
+---
+
+_يقوم بتحويل صفحة إلى أبيض وأسود._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تحويل الصفحة إلى أبيض وأسود
+    pdf.page_grayscale(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_layers/_index.md
+++ b/arabic/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يحصل على أسماء الطبقات في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_layers/
+---
+
+_يحصل على أسماء الطبقات في الصفحة._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // احصل على أسماء الطبقات في الصفحة 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_merge_layers/_index.md
+++ b/arabic/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يدمج جميع الطبقات على الصفحة في طبقة واحدة مع اسم الطبقة الجديدة المحدد."
+type: docs
+url: /ar/rust-cpp/organize/page_merge_layers/
+---
+
+_يدمج جميع الطبقات على الصفحة في طبقة واحدة مع اسم الطبقة الجديدة المحدد._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // دمج جميع الطبقات على الصفحة في طبقة واحدة مع اسم الطبقة الجديدة المحدد
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل التعليقات التوضيحية في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_annotations/
+---
+
+_يزيل التعليقات التوضيحية في الصفحة._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة التعليقات التوضيحية في الصفحة
+    pdf.page_remove_annotations(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل النص المخفي في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_يزيل النص المخفي في الصفحة._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة النص المخفي في الصفحة
+    pdf.page_remove_hidden_text(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_images/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل الصور في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_images/
+---
+
+_يزيل الصور في الصفحة._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الصور في الصفحة
+    pdf.page_remove_images(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_tables/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل الجداول في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_tables/
+---
+
+_يزيل الجداول في الصفحة._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الجداول في الصفحة
+    pdf.page_remove_tables(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل تذييلات النص في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_text_footers/
+---
+
+_يزيل تذييلات النص في الصفحة._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة تذييلات النص في الصفحة
+    pdf.page_remove_text_footers(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل رؤوس النص في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_text_headers/
+---
+
+_يزيل رؤوس النص في الصفحة._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة رؤوس النص في الصفحة
+    pdf.page_remove_text_headers(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/arabic/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل العلامات المائية في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_remove_watermarks/
+---
+
+_يزيل العلامات المائية في الصفحة._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة العلامات المائية في الصفحة
+    pdf.page_remove_watermarks(1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_replace_font/_index.md
+++ b/arabic/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يستبدل الخط في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_replace_font/
+---
+
+_يستبدل الخط في الصفحة._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // استبدال الخط في الصفحة
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_replace_text/_index.md
+++ b/arabic/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يستبدل النص في الصفحة."
+type: docs
+url: /ar/rust-cpp/organize/page_replace_text/
+---
+
+_يستبدل النص في الصفحة._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // استبدال النص على الصفحة
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_rotate/_index.md
+++ b/arabic/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يدور صفحة في مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/page_rotate/
+---
+
+_يدور صفحة في مستند PDF._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF-document من ملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تدوير الصفحة
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/page_set_size/_index.md
+++ b/arabic/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضبط حجم الصفحة في PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/page_set_size/
+---
+
+_يضبط حجم الصفحة في PDF-document._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // ضبط حجم الصفحة في PDF-document
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_annotations/_index.md
+++ b/arabic/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل التعليقات التوضيحية من مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/remove_annotations/
+---
+
+_يزيل التعليقات التوضيحية من مستند PDF._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة التعليقات التوضيحية من PDF-document
+    pdf.remove_annotations()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_attachments/_index.md
+++ b/arabic/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل المرفقات من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_attachments/
+---
+
+_يزيل المرفقات من PDF-document._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة المرفقات من PDF-document
+    pdf.remove_attachments()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/arabic/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل الصفحات الفارغة من مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_blank_pages/
+---
+
+_يزيل الصفحات الفارغة من مستند PDF-document._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الصفحات الفارغة من PDF-document
+    pdf.remove_blank_pages()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/arabic/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل العلامات المرجعية من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_bookmarks/
+---
+
+_يزيل العلامات المرجعية من PDF-document._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة العلامات المرجعية من PDF-document
+    pdf.remove_bookmarks()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/arabic/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل النص المخفي من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_hidden_text/
+---
+
+_يزيل النص المخفي من PDF-document._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة النص المخفي من PDF-document
+    pdf.remove_hidden_text()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_images/_index.md
+++ b/arabic/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل الصور من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_images/
+---
+
+_يزيل الصور من PDF-document._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الصور من PDF-document
+    pdf.remove_images()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_javascripts/_index.md
+++ b/arabic/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل سكريبتات جافا من مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/remove_javascripts/
+---
+
+_يزيل سكريبتات جافا من مستند PDF._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة سكريبتات جافا من PDF-document
+    pdf.remove_javascripts()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/arabic/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "إزالة توافق PDF/A من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_إزالة توافق PDF/A من PDF-document._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الامتثال لـ PDF/A من PDF-document
+    pdf.remove_pdfa_compliance()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/arabic/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "إزالة توافق PDF/UA من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_إزالة توافق PDF/UA من PDF-document._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة الامتثال لـ PDF/UA من PDF-document
+    pdf.remove_pdfua_compliance()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_tables/_index.md
+++ b/arabic/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل الجداول من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_tables/
+---
+
+_يزيل الجداول من PDF-document._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // أزل الجداول من PDF-document
+    pdf.remove_tables()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_text_footers/_index.md
+++ b/arabic/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل تذييلات النص من مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/remove_text_footers/
+---
+
+_يزيل تذييلات النص من مستند PDF._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة تذييلات النص من مستند PDF
+    pdf.remove_text_footers()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_text_headers/_index.md
+++ b/arabic/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل رؤوس النص من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_text_headers/
+---
+
+_يزيل رؤوس النص من PDF-document._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة رؤوس النص من PDF-document
+    pdf.remove_text_headers()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/remove_watermarks/_index.md
+++ b/arabic/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يزيل العلامات المائية من PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/remove_watermarks/
+---
+
+_يزيل العلامات المائية من PDF-document._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إزالة العلامات المائية من PDF-document
+    pdf.remove_watermarks()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/repair/_index.md
+++ b/arabic/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يقوم بإصلاح PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/repair/
+---
+
+_يُصلح مستند PDF-document._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // إصلاح مستند PDF-document
+    pdf.repair()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/replace_font/_index.md
+++ b/arabic/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يستبدل الخط في مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/replace_font/
+---
+
+_يستبدل الخط في مستند PDF-document._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // استبدال الخط في PDF-document.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/replace_text/_index.md
+++ b/arabic/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يستبدل النص."
+type: docs
+url: /ar/rust-cpp/organize/replace_text/
+---
+
+_يستبدل النص._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // استبدال النص في PDF-document
+    pdf.replace_text("PDF", "TXT")?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/rotate/_index.md
+++ b/arabic/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يدور مستند PDF-document."
+type: docs
+url: /ar/rust-cpp/organize/rotate/
+---
+
+_يدور مستند PDF-document._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // تدوير مستند PDF-document
+    pdf.rotate(Rotation::On270)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/set_background/_index.md
+++ b/arabic/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يضبط لون خلفية مستند PDF باستخدام قيم RGB."
+type: docs
+url: /ar/rust-cpp/organize/set_background/
+---
+
+_يضبط لون خلفية مستند PDF باستخدام قيم RGB._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // ضبط لون خلفية مستند PDF باستخدام قيم RGB
+    pdf.set_background(200, 100, 101)?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/unembed_fonts/_index.md
+++ b/arabic/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يفك تضمين الخطوط في مستند PDF."
+type: docs
+url: /ar/rust-cpp/organize/unembed_fonts/
+---
+
+_يفك تضمين الخطوط في مستند PDF._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // فك تضمين الخطوط في مستند PDF
+    pdf.unembed_fonts()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/organize/validate/_index.md
+++ b/arabic/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "يتحقق من مستند PDF للتوافق مع تنسيق PDF."
+type: docs
+url: /ar/rust-cpp/organize/validate/
+---
+
+_يتحقق من مستند PDF للتوافق مع تنسيق PDF._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // التحقق من توافق PDF-document مع تنسيق PDF
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // طباعة نتيجة التحقق والسجل الكامل
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/_index.md
+++ b/arabic/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "وظائف الأمان"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "وظائف الأمان."
+type: docs
+url: /ar/rust-cpp/security/
+---
+
+## Security
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | فتح مستند PDF محمي بكلمة مرور. |
+| [encrypt](./encrypt/) | تشفير مستند PDF. |
+| [decrypt](./decrypt/) | فك تشفير مستند PDF. |
+| [set_permissions](./set_permissions/) | تعيين الأذونات لمستند PDF. |
+| [get_permissions](./get_permissions/) | الحصول على الأذونات الحالية لمستند PDF. |
+| [is_encrypted](./is_encrypted/) | الحصول على حالة التشفير لمستند PDF. |
+| [sign_pkcs7](./sign_pkcs7/) | توقيع مستند PDF باستخدام توقيعات رقمية PKCS#7. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | توقيع مستند PDF باستخدام توقيعات رقمية منفصلة PKCS#7. |
+| [is_signed](./is_signed/) | الحصول على حالة التوقيع لمستند PDF. |
+| [remove_signs](./remove_signs/) | إزالة التوقيعات من مستند PDF. |
+
+
+## Detailed Description
+
+وظائف الأمان.
+

--- a/arabic/rust-cpp/security/decrypt/_index.md
+++ b/arabic/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "فك التشفير"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "فك تشفير مستند PDF."
+type: docs
+url: /ar/rust-cpp/security/decrypt/
+---
+
+_فك تشفير مستند PDF._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF محمي بكلمة مرور
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // فك تشفير مستند PDF
+    pdf.decrypt()?;
+
+    // احفظ مستند PDF المفتوح مسبقًا باسم ملف جديد
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/encrypt/_index.md
+++ b/arabic/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "تشفير"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "تشفير مستند PDF."
+type: docs
+url: /ar/rust-cpp/security/encrypt/
+---
+
+_تشفير PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // تشفير PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // احفظ PDF-document المشفر
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/get_permissions/_index.md
+++ b/arabic/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "الحصول على الأذونات الحالية لمستند PDF."
+type: docs
+url: /ar/rust-cpp/security/get_permissions/
+---
+
+_احصل على الأذونات الحالية لمستند PDF._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF محمي بكلمة مرور
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // احصل على الأذونات الحالية لمستند PDF
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // طباعة الأذونات
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/is_encrypted/_index.md
+++ b/arabic/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "الحصول على حالة التشفير لمستند PDF."
+type: docs
+url: /ar/rust-cpp/security/is_encrypted/
+---
+
+_احصل على حالة التشفير لمستند PDF._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF محمي بكلمة مرور
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // احصل على حالة التشفير لمستند PDF
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/is_signed/_index.md
+++ b/arabic/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "الحصول على حالة التوقيع لمستند PDF."
+type: docs
+url: /ar/rust-cpp/security/is_signed/
+---
+
+_احصل على حالة التوقيع لـ PDF-document._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF باسم "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // احصل على حالة التوقيع لـ PDF-document
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/open_with_password/_index.md
+++ b/arabic/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "فتح مستند PDF محمي بكلمة مرور."
+type: docs
+url: /ar/rust-cpp/security/open_with_password/
+---
+
+_فتح مستند PDF محمي بكلمة مرور._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF محمي بكلمة مرور
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // جارٍ العمل...
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/remove_signs/_index.md
+++ b/arabic/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "إزالة التوقيعات من مستند PDF."
+type: docs
+url: /ar/rust-cpp/security/remove_signs/
+---
+
+_إزالة العلامات من مستند PDF._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // فتح مستند PDF باسم "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // إزالة العلامات من مستند PDF
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/set_permissions/_index.md
+++ b/arabic/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "تعيين الأذونات لمستند PDF."
+type: docs
+url: /ar/rust-cpp/security/set_permissions/
+---
+
+_حدد الأذونات لـ PDF-document._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // إنشاء مستند PDF-document جديد
+    let pdf = Document::new()?;
+
+    // تعيين الأذونات لمستند PDF.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // احفظ PDF-document مع الأذونات المحدثة
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/sign_pkcs7/_index.md
+++ b/arabic/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "توقيع مستند PDF باستخدام توقيعات رقمية PKCS#7."
+type: docs
+url: /ar/rust-cpp/security/sign_pkcs7/
+---
+
+_وقع على PDF-document باستخدام توقيعات رقمية PKCS#7._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // اقرأ ملفات الشهادة والصورة إلى متجهات بايت
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // وقع على PDF-document باستخدام توقيعات رقمية PKCS#7
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/arabic/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/arabic/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF لـ Rust عبر C++"
+description: "توقيع مستند PDF باستخدام توقيعات رقمية منفصلة PKCS#7."
+type: docs
+url: /ar/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_وقع على PDF-document باستخدام توقيعات رقمية PKCS#7 منفصلة._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // اقرأ ملفات الشهادة والصورة إلى متجهات بايت
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // فتح مستند PDF مع اسم الملف
+    let pdf = Document::open("sample.pdf")?;
+
+    // وقع على PDF-document باستخدام توقيعات رقمية PKCS#7 منفصلة
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
🔄 **In progress** — incremental translation of RUST-CPP API Reference to **Arabic** (`ar`).

Updated at each cache checkpoint. Source: `english/rust-cpp`

🤖 Generated by RDA