### PR TITLE
[draft] Translate RUST-CPP API Reference to French

### DIFF
--- a/french/rust-cpp/_index.md
+++ b/french/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF pour Rust via C++"
+description: "Aspose.PDF pour Rust via C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /fr/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Structures
+
+## Document
+Le document représente un document PDF.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Fonction | Description |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Convertir et enregistrer le document PDF précédemment ouvert en document DocX. |
+| [save_doc](./convert/save_doc/) | Convertir et enregistrer le document PDF précédemment ouvert en document Doc. |
+| [save_xlsx](./convert/save_xlsx/) | Convertir et enregistrer le document PDF précédemment ouvert en document XlsX. |
+| [save_txt](./convert/save_txt/) | Convertir et enregistrer le document PDF précédemment ouvert en document Txt. |
+| [save_pptx](./convert/save_pptx/) | Convertir et enregistrer le document PDF précédemment ouvert en document PptX. |
+| [save_xps](./convert/save_xps/) | Convertir et enregistrer le document PDF précédemment ouvert en document Xps. |
+| [save_tex](./convert/save_tex/) | Convertir et enregistrer le document PDF précédemment ouvert en document TeX. |
+| [save_epub](./convert/save_epub/) | Convertir et enregistrer le document PDF précédemment ouvert en document Epub. |
+| [save_booklet](./convert/save_booklet/) | Convertir et enregistrer le document PDF précédemment ouvert en document PDF livret. |
+| [save_n_up](./convert/save_n_up/) | Convertir et enregistrer le document PDF précédemment ouvert en document PDF N-Up. |
+| [save_markdown](./convert/save_markdown/) | Convertir et enregistrer le document PDF précédemment ouvert en document Markdown. |
+| [save_tiff](./convert/save_tiff/) | Convertir et enregistrer le document PDF précédemment ouvert en document Tiff. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Convertir et enregistrer le document PDF précédemment ouvert en document DocX avec le mode de reconnaissance avancé (tables et paragraphes entièrement modifiables). |
+| [save_svg_zip](./convert/save_svg_zip/) | Convertir et enregistrer le document PDF précédemment ouvert en archive SVG. |
+| [export_fdf](./convert/export_fdf/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document FDF. |
+| [export_xfdf](./convert/export_xfdf/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document XFDF. |
+| [export_xml](./convert/export_xml/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document XML. |
+| [page_to_jpg](./convert/page_to_jpg/) | Convertir et enregistrer la page spécifiée en image Jpg. |
+| [page_to_png](./convert/page_to_png/) | Convertir et enregistrer la page spécifiée en image Png. |
+| [page_to_bmp](./convert/page_to_bmp/) | Convertir et enregistrer la page spécifiée en image Bmp. |
+| [page_to_tiff](./convert/page_to_tiff/) | Convertir et enregistrer la page spécifiée en tant qu'image Tiff. |
+| [page_to_svg](./convert/page_to_svg/) | Convertir et enregistrer la page spécifiée en tant qu'image Svg. |
+| [page_to_pdf](./convert/page_to_pdf/) | Convertir et enregistrer la page spécifiée en tant que document PDF. |
+| [page_to_dicom](./convert/page_to_dicom/) | Convertir et enregistrer la page spécifiée en tant qu'image DICOM. |
+
+
+## Organize PDF functions
+
+| Fonction | Description |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Optimiser le contenu du document PDF. |
+| [optimize_resource](./organize/optimize_resource/) | Optimiser les ressources du document PDF. |
+| [grayscale](./organize/grayscale/) | Convertir le document PDF en noir et blanc. |
+| [rotate](./organize/rotate/) | Faire pivoter le document PDF. |
+| [set_background](./organize/set_background/) | Définir la couleur d'arrière-plan du document PDF en utilisant les valeurs RVB. |
+| [repair](./organize/repair/) | Réparer le document PDF. |
+| [replace_text](./organize/replace_text/) | Remplacer le texte dans le document PDF |
+| [add_page_num](./organize/add_page_num/) | Ajouter le numéro de page à un document PDF |
+| [add_text_header](./organize/add_text_header/) | Ajouter du texte dans l'en-tête d'un document PDF |
+| [add_text_footer](./organize/add_text_footer/) | Ajouter du texte dans le pied de page d'un document PDF |
+| [flatten](./organize/flatten/) | Aplatir le document PDF |
+| [remove_annotations](./organize/remove_annotations/) | Supprimer les annotations du document PDF |
+| [remove_attachments](./organize/remove_attachments/) | Supprimer les pièces jointes du document PDF |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Supprimer les pages blanches du document PDF |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Supprimer les signets du document PDF |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Supprimer le texte masqué du document PDF |
+| [remove_images](./organize/remove_images/) | Supprimer les images du document PDF |
+| [remove_javascripts](./organize/remove_javascripts/) | Supprimer les scripts Java du document PDF |
+| [remove_tables](./organize/remove_tables/) | Supprimer les tableaux d'un document PDF. |
+| [remove_watermarks](./organize/remove_watermarks/) | Supprimer les filigranes du document PDF. |
+| [add_watermark](./organize/add_watermark/) | Ajouter un filigrane au document PDF. |
+| [embed_fonts](./organize/embed_fonts/) | Intégrer les polices dans un PDF-document. |
+| [unembed_fonts](./organize/unembed_fonts/) | Désintégrer les polices d'un PDF-document. |
+| [optimize_file_size](./organize/optimize_file_size/) | Optimiser la taille d'un PDF-document avec la qualité de compression d'image. |
+| [remove_text_headers](./organize/remove_text_headers/) | Supprimer les en-têtes de texte du PDF-document. |
+| [remove_text_footers](./organize/remove_text_footers/) | Supprimer les pieds de page de texte du PDF-document. |
+| [crop](./organize/crop/) | Recadrer les pages d'un PDF-document. |
+| [replace_font](./organize/replace_font/) | Remplacer la police dans un PDF-document. |
+| [convert](./organize/convert/) | Convertir un PDF-document en un PDF-document avec le format PDF spécifié |
+| [validate](./organize/validate/) | Valider un PDF-document pour la conformité au format PDF |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Supprimer la conformité PDF/A d'un PDF-document |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Supprimer la conformité PDF/UA d'un PDF-document |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Déterminer si un PDF-document est conforme PDF/A |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Déterminer si un PDF-document est conforme PDF/UA |
+| [page_rotate](./organize/page_rotate/) | Faire pivoter une page dans le PDF-document. |
+| [page_set_size](./organize/page_set_size/) | Définir la taille d'une page dans le PDF-document. |
+| [page_grayscale](./organize/page_grayscale/) | Convertir la page en noir et blanc. |
+| [page_add_text](./organize/page_add_text/) | Ajouter du texte sur la page. |
+| [page_replace_text](./organize/page_replace_text/) | Remplacer le texte sur la page |
+| [page_add_page_num](./organize/page_add_page_num/) | Ajouter le numéro de page sur la page |
+| [page_add_text_header](./organize/page_add_text_header/) | Ajouter du texte dans l'en-tête de la page |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Ajouter du texte dans le pied de page de la page |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Supprimer les annotations dans la page. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Supprimer le texte caché dans la page. |
+| [page_remove_images](./organize/page_remove_images/) | Supprimer les images dans la page. |
+| [page_remove_tables](./organize/page_remove_tables/) | Supprimer les tableaux dans la page. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Supprimer les filigranes dans la page. |
+| [page_add_watermark](./organize/page_add_watermark/) | Ajouter un filigrane sur la page. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Supprimer les en-têtes de texte dans la page. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Supprimer les pieds de page de texte dans la page. |
+| [page_crop](./organize/page_crop/) | Rogner une page. |
+| [page_replace_font](./organize/page_replace_font/) | Remplacer la police dans la page. |
+| [page_merge_layers](./organize/page_merge_layers/) | Fusionner toutes les couches de la page en une seule couche avec le nom de nouvelle couche spécifié. |
+| [page_layers](./organize/page_layers/) | Obtenir les noms des couches sur la page. |
+
+
+## Core PDF functions
+
+| Fonction | Description |
+| -------- | ----------- |
+| [new](./core/new/) | Créer un nouveau document PDF. |
+| [open](./core/open/) | Ouvrir un document PDF avec le nom de fichier. |
+| [save](./core/save/) | Enregistrer le document PDF précédemment ouvert. |
+| [save_as](./core/save_as/) | Enregistrer le document PDF précédemment ouvert avec un nouveau nom de fichier. |
+| [set_license](./core/set_license/) | Définir la licence avec le nom de fichier. |
+| [extract_text](./core/extract_text/) | Retourner le contenu du document PDF en texte brut. |
+| [word_count](./core/word_count/) | Retourner le nombre de mots dans le document PDF. |
+| [character_count](./core/character_count/) | Retourner le nombre de caractères dans le document PDF. |
+| [append](./core/append/) | Ajouter des pages d'un autre document PDF. |
+| [append_pages](./core/append_pages/) | Ajouter les pages sélectionnées d'un autre document PDF. |
+| [merge_documents](./core/merge_documents/) | Créer un nouveau document PDF en fusionnant les documents PDF fournis. |
+| [split_document](./core/split_document/) | Créer plusieurs nouveaux documents PDF en extrayant des pages du document PDF source. |
+| [split](./core/split/) | Créer plusieurs nouveaux documents PDF en extrayant des pages du document PDF actuel. |
+| [split_at_page](./core/split_at_page/) | Diviser le document PDF en deux nouveaux documents PDF. |
+| [split_at](./core/split_at/) | Diviser le document PDF actuel en deux nouveaux documents PDF. |
+| [bytes](./core/bytes/) | Retourner le contenu du document PDF sous forme de vecteur d'octets. |
+| [get_meta_info](./core/get_meta_info/) | Obtenir la valeur des métadonnées du document PDF. |
+| [set_meta_info](./core/set_meta_info/) | Définir la valeur des métadonnées du PDF-document. |
+| [clear_meta_info](./core/clear_meta_info/) | Effacer toutes les valeurs des métadonnées du PDF-document. |
+| [is_linearized](./core/is_linearized/) | Obtenir une valeur indiquant si le document est linéarisé. |
+| [page_add](./core/page_add/) | Ajouter une nouvelle page dans le PDF-document. |
+| [page_insert](./core/page_insert/) | Insérer une nouvelle page à la position spécifiée dans le PDF-document. |
+| [page_delete](./core/page_delete/) | Supprimer la page spécifiée du PDF-document. |
+| [page_count](./core/page_count/) | Retourner le nombre de pages du PDF-document. |
+| [page_word_count](./core/page_word_count/) | Retourner le nombre de mots sur la page spécifiée du PDF-document. |
+| [page_character_count](./core/page_character_count/) | Retourner le nombre de caractères sur la page spécifiée du PDF-document. |
+| [page_is_blank](./core/page_is_blank/) | Retourner si la page est blanche dans le PDF-document. |
+
+
+## Security
+| Fonction | Description |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Ouvrir un PDF-document protégé par mot de passe. |
+| [encrypt](./security/encrypt/) | Chiffrer le PDF-document. |
+| [decrypt](./security/decrypt/) | Déchiffrer le PDF-document. |
+| [set_permissions](./security/set_permissions/) | Définir les autorisations pour le PDF-document. |
+| [get_permissions](./security/get_permissions/) | Obtenir les autorisations actuelles du PDF-document. |
+| [is_encrypted](./security/is_encrypted/) | Obtenir le statut de chiffrement du PDF-document. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Signer un PDF-document en utilisant des signatures numériques PKCS#7. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Signer un PDF-document en utilisant des signatures numériques PKCS#7 détachées. |
+| [is_signed](./security/is_signed/) | Obtenir le statut de signature du PDF-document. |
+| [remove_signs](./security/remove_signs/) | Supprimer les signatures du PDF-document. |
+
+
+## Miscellaneous
+
+| Fonction | Description |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Retourner les informations de métadonnées sur Aspose.PDF pour Rust via C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Ensemble de bits représentant les capacités d'autorisation PDF.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// Taille A0.
+    A0 = 0,
+    /// Taille A1.
+    A1 = 1,
+    /// Taille A2.
+    A2 = 2,
+    /// taille A3.
+    A3 = 3,
+    /// taille A4.
+    A4 = 4,
+    /// taille A5.
+    A5 = 5,
+    /// taille A6.
+    A6 = 6,
+    /// taille B5.
+    B5 = 7,
+    /// taille PageLetter.
+    PageLetter = 8,
+    /// taille PageLegal.
+    PageLegal = 9,
+    /// taille PageLedger.
+    PageLedger = 10,
+    /// taille P11x17.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Non pivoté.
+    None = 0,
+    /// Pivoté de 90 degrés dans le sens des aiguilles d'une montre.
+    On90 = 1,
+    /// Pivoté de 180 degrés.
+    On180 = 2,
+    /// Pivoté de 270 degrés dans le sens des aiguilles d'une montre.
+    On270 = 3,
+    /// Pivoté de 360 degrés dans le sens des aiguilles d'une montre.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 avec une longueur de clé de 40.
+    RC4x40 = 0,
+    /// RC4 avec une longueur de clé de 128.
+    RC4x128 = 1,
+    /// AES avec une longueur de clé de 128.
+    AESx128 = 2,
+    /// AES avec une longueur de clé de 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// format PDF/A-1a.
+    PDF_A_1A = 0,
+    /// format PDF/A-1b.
+    PDF_A_1B = 1,
+    /// format PDF/A-2a.
+    PDF_A_2A = 2,
+    /// format PDF/A-3a.
+    PDF_A_3A = 3,
+    /// format PDF/A-2b.
+    PDF_A_2B = 4,
+    /// format PDF/A-2u.
+    PDF_A_2U = 5,
+    /// format PDF/A-3b.
+    PDF_A_3B = 6,
+    /// format PDF/A-3u.
+    PDF_A_3U = 7,
+    /// version Adobe 1.0.
+    V_1_0 = 8,
+    /// version Adobe 1.1.
+    V_1_1 = 9,
+    /// version Adobe 1.2.
+    V_1_2 = 10,
+    /// version Adobe 1.3.
+    V_1_3 = 11,
+    /// version Adobe 1.4.
+    V_1_4 = 12,
+    /// version Adobe 1.5.
+    V_1_5 = 13,
+    /// version Adobe 1.6.
+    V_1_6 = 14,
+    /// version Adobe 1.7.
+    V_1_7 = 15,
+    /// norme ISO PDF 2.0.
+    V_2_0 = 16,
+    /// format PDF/UA-1.
+    PDF_UA_1 = 17,
+    /// format PDF/X-1a:2001.
+    PDF_X_1A_2001 = 18,
+    /// format PDF/X-1a.
+    PDF_X_1A = 19,
+    /// format PDF/X-3.
+    PDF_X_3 = 20,
+    /// format ZUGFeRD.
+    ZUGFeRD = 21,
+    /// format PDF/A-4.
+    PDF_A_4 = 22,
+    /// format PDF/A-4e.
+    PDF_A_4E = 23,
+    /// format PDF/A-4f.
+    PDF_A_4F = 24,
+    /// format PDF/X-4.
+    PDF_X_4 = 25,
+    /// format PDF/E-1 (PDF 1.6).
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Supprimer les éléments non conformes.
+    Delete = 0,
+    /// Ne rien faire, conserver les éléments non conformes.
+    None = 1,
+}
+```
+

--- a/french/rust-cpp/convert/_index.md
+++ b/french/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Convertir à partir des fonctions PDF"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fonctions de conversion à partir de fichiers PDF."
+type: docs
+url: /fr/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Convertir et enregistrer le document PDF précédemment ouvert en document DocX. |
+| [save_doc](./save_doc/) | Convertir et enregistrer le document PDF précédemment ouvert en document Doc. |
+| [save_xlsx](./save_xlsx/) | Convertir et enregistrer le document PDF précédemment ouvert en document XlsX. |
+| [save_txt](./save_txt/) | Convertir et enregistrer le document PDF précédemment ouvert en document Txt. |
+| [save_pptx](./save_pptx/) | Convertir et enregistrer le document PDF précédemment ouvert en document PptX. |
+| [save_xps](./save_xps/) | Convertir et enregistrer le document PDF précédemment ouvert en document Xps. |
+| [save_tex](./save_tex/) | Convertir et enregistrer le document PDF précédemment ouvert en document TeX. |
+| [save_epub](./save_epub/) | Convertir et enregistrer le document PDF précédemment ouvert en document Epub. |
+| [save_booklet](./save_booklet/) | Convertir et enregistrer le document PDF précédemment ouvert en document PDF livret. |
+| [save_n_up](./save_n_up/) | Convertir et enregistrer le document PDF précédemment ouvert en document PDF N-Up. |
+| [save_markdown](./save_markdown/) | Convertir et enregistrer le document PDF précédemment ouvert en document Markdown. |
+| [save_tiff](./save_tiff/) | Convertir et enregistrer le document PDF précédemment ouvert en document Tiff. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Convertir et enregistrer le document PDF précédemment ouvert en document DocX avec le mode de reconnaissance avancé (tables et paragraphes entièrement modifiables). |
+| [save_svg_zip](./save_svg_zip/) | Convertir et enregistrer le document PDF précédemment ouvert en archive SVG. |
+| [export_fdf](./export_fdf/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document FDF. |
+| [export_xfdf](./export_xfdf/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document XFDF. |
+| [export_xml](./export_xml/) | Exporter depuis le document PDF précédemment ouvert avec AcroForm vers le document XML. |
+| [page_to_jpg](./page_to_jpg/) | Convertir et enregistrer la page spécifiée en image Jpg. |
+| [page_to_png](./page_to_png/) | Convertir et enregistrer la page spécifiée en image Png. |
+| [page_to_bmp](./page_to_bmp/) | Convertir et enregistrer la page spécifiée en image Bmp. |
+| [page_to_tiff](./page_to_tiff/) | Convertir et enregistrer la page spécifiée en tant qu'image Tiff. |
+| [page_to_svg](./page_to_svg/) | Convertir et enregistrer la page spécifiée en tant qu'image Svg. |
+| [page_to_pdf](./page_to_pdf/) | Convertir et enregistrer la page spécifiée en tant que document PDF. |
+| [page_to_dicom](./page_to_dicom/) | Convertir et enregistrer la page spécifiée en tant qu'image DICOM. |
+
+
+## Detailed Description
+
+Fonctions de conversion à partir de fichiers PDF.
+

--- a/french/rust-cpp/convert/export_fdf/_index.md
+++ b/french/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Exporte le PDF-document précédemment ouvert avec AcroForm vers un FDF-document avec le nom de fichier."
+type: docs
+url: /fr/rust-cpp/convert/export_fdf/
+---
+
+_Exporte le PDF-document précédemment ouvert avec AcroForm vers un FDF-document avec le nom de fichier._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exporter le PDF-document précédemment ouvert avec AcroForm vers un FDF-document
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/export_xfdf/_index.md
+++ b/french/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Exportations du PDF-document précédemment ouvert avec AcroForm vers un document XFDF avec le nom de fichier."
+type: docs
+url: /fr/rust-cpp/convert/export_xfdf/
+---
+
+_Exportations du PDF-document précédemment ouvert avec AcroForm vers un document XFDF avec le nom de fichier._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportation du PDF-document précédemment ouvert avec AcroForm vers un document XFDF
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/export_xml/_index.md
+++ b/french/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Exportations du PDF-document précédemment ouvert avec AcroForm vers un document XML avec le nom de fichier."
+type: docs
+url: /fr/rust-cpp/convert/export_xml/
+---
+
+_Exportations du PDF-document précédemment ouvert avec AcroForm vers un document XML avec le nom de fichier._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportation du PDF-document précédemment ouvert avec AcroForm vers un document XML
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_bmp/_index.md
+++ b/french/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image BMP."
+type: docs
+url: /fr/rust-cpp/convert/page_to_bmp/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image BMP._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant qu'image BMP
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_dicom/_index.md
+++ b/french/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image DICOM."
+type: docs
+url: /fr/rust-cpp/convert/page_to_dicom/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image DICOM._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant qu'image DICOM
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_jpg/_index.md
+++ b/french/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image JPG."
+type: docs
+url: /fr/rust-cpp/convert/page_to_jpg/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image JPG._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en Jpg-image
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_pdf/_index.md
+++ b/french/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant que document PDF."
+type: docs
+url: /fr/rust-cpp/convert/page_to_pdf/
+---
+
+_Convertit et enregistre la page spécifiée en tant que document PDF._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant que document PDF
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_png/_index.md
+++ b/french/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image PNG."
+type: docs
+url: /fr/rust-cpp/convert/page_to_png/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image PNG._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant qu'image Png
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_svg/_index.md
+++ b/french/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image SVG."
+type: docs
+url: /fr/rust-cpp/convert/page_to_svg/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image SVG._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant qu'image SVG
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/page_to_tiff/_index.md
+++ b/french/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre la page spécifiée en tant qu'image TIFF."
+type: docs
+url: /fr/rust-cpp/convert/page_to_tiff/
+---
+
+_Convertit et enregistre la page spécifiée en tant qu'image TIFF._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer la page spécifiée en tant qu'image Tiff
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_booklet/_index.md
+++ b/french/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que livret PDF-document."
+type: docs
+url: /fr/rust-cpp/convert/save_booklet/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que livret PDF-document._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que livret PDF-document
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/french/rust-cpp/convert/save_doc/_index.md
+++ b/french/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document DOC."
+type: docs
+url: /fr/rust-cpp/convert/save_doc/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document DOC._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document Doc
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_docx/_index.md
+++ b/french/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document DOCX."
+type: docs
+url: /fr/rust-cpp/convert/save_docx/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document DOCX._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document DocX
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/french/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le document PDF précédemment ouvert en tant que document DOCX avec le mode de reconnaissance améliorée (tables et paragraphes entièrement modifiables)."
+type: docs
+url: /fr/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Convertit et enregistre le document PDF précédemment ouvert en tant que document DOCX avec le mode de reconnaissance améliorée (tables et paragraphes entièrement modifiables)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le document PDF précédemment ouvert en tant que document DocX avec le mode de reconnaissance améliorée (tables et paragraphes entièrement modifiables)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_epub/_index.md
+++ b/french/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document EPUB."
+type: docs
+url: /fr/rust-cpp/convert/save_epub/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document EPUB._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document Epub
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_markdown/_index.md
+++ b/french/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que Markdown-document."
+type: docs
+url: /fr/rust-cpp/convert/save_markdown/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que Markdown-document._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que Markdown-document
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/french/rust-cpp/convert/save_n_up/_index.md
+++ b/french/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le document PDF précédemment ouvert en tant que document PDF N-Up."
+type: docs
+url: /fr/rust-cpp/convert/save_n_up/
+---
+
+_Convertit et enregistre le document PDF précédemment ouvert en tant que document PDF N-Up._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le document PDF précédemment ouvert en tant que document PDF N-Up
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/french/rust-cpp/convert/save_pptx/_index.md
+++ b/french/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document PPTX."
+type: docs
+url: /fr/rust-cpp/convert/save_pptx/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document PPTX._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document PptX
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_svg_zip/_index.md
+++ b/french/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant qu'archive SVG."
+type: docs
+url: /fr/rust-cpp/convert/save_svg_zip/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant qu'archive SVG._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant qu'archive SVG
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_tex/_index.md
+++ b/french/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le document PDF précédemment ouvert en tant que document TeX."
+type: docs
+url: /fr/rust-cpp/convert/save_tex/
+---
+
+_Convertit et enregistre le document PDF précédemment ouvert en tant que document TeX._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le document PDF précédemment ouvert en tant que document TeX
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_tiff/_index.md
+++ b/french/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document Tiff."
+type: docs
+url: /fr/rust-cpp/convert/save_tiff/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document Tiff._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document Tiff
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/french/rust-cpp/convert/save_txt/_index.md
+++ b/french/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document TXT."
+type: docs
+url: /fr/rust-cpp/convert/save_txt/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document TXT._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document Txt
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_xlsx/_index.md
+++ b/french/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le PDF-document précédemment ouvert en tant que document XLSX."
+type: docs
+url: /fr/rust-cpp/convert/save_xlsx/
+---
+
+_Convertit et enregistre le PDF-document précédemment ouvert en tant que document XLSX._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le PDF-document précédemment ouvert en tant que document XlsX
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/convert/save_xps/_index.md
+++ b/french/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit et enregistre le document PDF précédemment ouvert en tant que document XPS."
+type: docs
+url: /fr/rust-cpp/convert/save_xps/
+---
+
+_Convertit et enregistre le document PDF précédemment ouvert en tant que document XPS._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir et enregistrer le document PDF précédemment ouvert en tant que document XPS
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/_index.md
+++ b/french/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Fonctions PDF de base"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fonctions de base pour travailler avec des fichiers PDF."
+type: docs
+url: /fr/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [new](./new/) | Créer un nouveau document PDF. |
+| [open](./open/) | Ouvrir un document PDF avec le nom de fichier. |
+| [save](./save/) | Enregistrer le document PDF précédemment ouvert. |
+| [save_as](./save_as/) | Enregistrer le document PDF précédemment ouvert avec un nouveau nom de fichier. |
+| [set_license](./set_license/) | Définir la licence avec le nom de fichier. |
+| [extract_text](./extract_text/) | Retourner le contenu du document PDF en texte brut. |
+| [word_count](./word_count/) | Retourner le nombre de mots dans le document PDF. |
+| [character_count](./character_count/) | Retourner le nombre de caractères dans le document PDF. |
+| [append](./append/) | Ajouter des pages d'un autre document PDF. |
+| [append_pages](./append_pages/) | Ajouter les pages sélectionnées d'un autre document PDF. |
+| [merge_documents](./merge_documents/) | Créer un nouveau document PDF en fusionnant les documents PDF fournis. |
+| [split_document](./split_document/) | Créer plusieurs nouveaux documents PDF en extrayant des pages du document PDF source. |
+| [split](./split/) | Créer plusieurs nouveaux documents PDF en extrayant des pages du document PDF actuel. |
+| [split_at_page](./split_at_page/) | Diviser le document PDF en deux nouveaux documents PDF. |
+| [split_at](./split_at/) | Diviser le document PDF actuel en deux nouveaux documents PDF. |
+| [bytes](./bytes/) | Retourner le contenu du document PDF sous forme de vecteur d'octets. |
+| [get_meta_info](./get_meta_info/) | Obtenir la valeur des métadonnées du document PDF. |
+| [set_meta_info](./set_meta_info/) | Définir la valeur des métadonnées du PDF-document. |
+| [clear_meta_info](./clear_meta_info/) | Effacer toutes les valeurs des métadonnées du PDF-document. |
+| [is_linearized](./is_linearized/) | Obtenir une valeur indiquant si le document est linéarisé. |
+| [page_add](./page_add/) | Ajouter une nouvelle page dans le PDF-document. |
+| [page_insert](./page_insert/) | Insérer une nouvelle page à la position spécifiée dans le PDF-document. |
+| [page_delete](./page_delete/) | Supprimer la page spécifiée du PDF-document. |
+| [page_count](./page_count/) | Retourner le nombre de pages du PDF-document. |
+| [page_word_count](./page_word_count/) | Retourner le nombre de mots sur la page spécifiée du PDF-document. |
+| [page_character_count](./page_character_count/) | Retourner le nombre de caractères sur la page spécifiée du PDF-document. |
+| [page_is_blank](./page_is_blank/) | Retourner si la page est blanche dans le PDF-document. |
+
+
+## Detailed Description
+
+Fonctions de base pour travailler avec des fichiers PDF.
+

--- a/french/rust-cpp/core/append/_index.md
+++ b/french/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute des pages d'un autre PDF-document."
+type: docs
+url: /fr/rust-cpp/core/append/
+---
+
+_Ajoute des pages d'un autre PDF-document._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir le PDF-document principal
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ouvrir un autre PDF-document à ajouter
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Ajouter des pages d'un autre PDF-document
+    pdf.append(&another_pdf)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/append_pages/_index.md
+++ b/french/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute les pages sélectionnées d'un autre PDF-document."
+type: docs
+url: /fr/rust-cpp/core/append_pages/
+---
+
+_Ajoute les pages sélectionnées d'un autre PDF-document._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir le PDF-document principal
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Ouvrir un autre PDF-document à ajouter
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Ajoute les pages spécifiques (1 et 3) d'un autre PDF-document
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/bytes/_index.md
+++ b/french/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "octets"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le contenu du document PDF sous forme de vecteur d'octets."
+type: docs
+url: /fr/rust-cpp/core/bytes/
+---
+
+_Renvoie le contenu du document PDF sous forme de vecteur d'octets._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Renvoie le contenu du document PDF sous forme de vecteur d'octets
+    let data = pdf.bytes()?;
+
+    // Afficher la longueur du vecteur d'octets
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/character_count/_index.md
+++ b/french/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le nombre de caractères dans le document PDF."
+type: docs
+url: /fr/rust-cpp/core/character_count/
+---
+
+_Renvoie le nombre de caractères dans le document PDF._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Renvoie le nombre de caractères dans le document PDF
+    let count = pdf.character_count()?;
+
+    // Afficher le nombre de caractères
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/clear_meta_info/_index.md
+++ b/french/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime toutes les valeurs des métadonnées du document PDF."
+type: docs
+url: /fr/rust-cpp/core/clear_meta_info/
+---
+
+_Supprime toutes les valeurs des métadonnées du document PDF._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer toutes les valeurs des métadonnées du document PDF
+    pdf.clear_meta_info()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/extract_text/_index.md
+++ b/french/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le contenu du PDF-document en texte brut."
+type: docs
+url: /fr/rust-cpp/core/extract_text/
+---
+
+_Renvoie le contenu du PDF-document en texte brut._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Renvoie le contenu du PDF-document en texte brut
+    let txt = pdf.extract_text()?;
+
+    // Imprimer le texte extrait
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/get_meta_info/_index.md
+++ b/french/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtient la valeur des métadonnées du PDF-document."
+type: docs
+url: /fr/rust-cpp/core/get_meta_info/
+---
+
+_Obtient la valeur des métadonnées du PDF-document._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtenir la valeur des métadonnées du PDF-document
+    let author = pdf.get_meta_info("Author")?;
+
+    // Imprimer le résultat
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/is_linearized/_index.md
+++ b/french/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtient une valeur indiquant si le document est linéarisé."
+type: docs
+url: /fr/rust-cpp/core/is_linearized/
+---
+
+_Obtient une valeur indiquant si le document est linéarisé._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtenir une valeur indiquant si le document est linéarisé
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/merge_documents/_index.md
+++ b/french/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Crée un nouveau document PDF en fusionnant les documents PDF fournis."
+type: docs
+url: /fr/rust-cpp/core/merge_documents/
+---
+
+_Crée un nouveau document PDF en fusionnant les documents PDF fournis._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf1 = Document::new()?;
+
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Créer un nouveau document PDF en fusionnant les documents PDF fournis
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/new/_index.md
+++ b/french/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "nouveau"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Crée un nouveau document PDF."
+type: docs
+url: /fr/rust-cpp/core/new/
+---
+
+_Crée un nouveau document PDF._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/open/_index.md
+++ b/french/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "ouvrir"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ouvre un PDF-document avec le nom de fichier."
+type: docs
+url: /fr/rust-cpp/core/open/
+---
+
+_Ouvre un PDF-document avec le nom de fichier._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_add/_index.md
+++ b/french/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute une nouvelle page au document PDF."
+type: docs
+url: /fr/rust-cpp/core/page_add/
+---
+
+_Ajoute une nouvelle page au document PDF._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter une nouvelle page dans le document PDF
+    pdf.page_add()?;
+
+    // Enregistrer le PDF-document précédemment ouvert
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_character_count/_index.md
+++ b/french/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le nombre de caractères sur la page spécifiée du document PDF."
+type: docs
+url: /fr/rust-cpp/core/page_character_count/
+---
+
+_Renvoie le nombre de caractères sur la page spécifiée du document PDF._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Spécifiez le numéro de page (indice à partir de 1)
+    let page_number = 1;
+
+    // Renvoie le nombre de caractères sur la page spécifiée
+    let count = pdf.page_character_count(page_number)?;
+
+    // Afficher le nombre de caractères
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_count/_index.md
+++ b/french/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le nombre de pages du document PDF."
+type: docs
+url: /fr/rust-cpp/core/page_count/
+---
+
+_Renvoie le nombre de pages du document PDF._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Renvoie le nombre de pages du document PDF
+    let count = pdf.page_count()?;
+
+    // Imprime le nombre de pages
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_delete/_index.md
+++ b/french/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime la page spécifiée du PDF-document."
+type: docs
+url: /fr/rust-cpp/core/page_delete/
+---
+
+_Supprime la page spécifiée du PDF-document._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer la page spécifiée dans le PDF-document
+    pdf.page_delete(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_insert/_index.md
+++ b/french/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Insère une nouvelle page à la position spécifiée dans le PDF-document."
+type: docs
+url: /fr/rust-cpp/core/page_insert/
+---
+
+_Insère une nouvelle page à la position spécifiée dans le PDF-document._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Insérer une nouvelle page à la position spécifiée dans le PDF-document
+    pdf.page_insert(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_is_blank/_index.md
+++ b/french/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Retourner si la page est blanche dans le PDF-document."
+type: docs
+url: /fr/rust-cpp/core/page_is_blank/
+---
+
+_Retourne la page vide dans le PDF-document._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Spécifiez le numéro de page (indice à partir de 1)
+    let page_number = 1;
+
+    // Retourne la page vide dans le PDF-document
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Imprimer si la page spécifiée est vide
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/page_word_count/_index.md
+++ b/french/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le nombre de mots sur la page spécifiée dans le PDF-document."
+type: docs
+url: /fr/rust-cpp/core/page_word_count/
+---
+
+_Renvoie le nombre de mots sur la page spécifiée dans le PDF-document._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Spécifiez le numéro de page (indice à partir de 1)
+    let page_number = 1;
+
+    // Renvoie le nombre de mots sur la page spécifiée
+    let count = pdf.page_word_count(page_number)?;
+
+    // Afficher le nombre de mots
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/save/_index.md
+++ b/french/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Enregistre le PDF-document précédemment ouvert."
+type: docs
+url: /fr/rust-cpp/core/save/
+---
+
+_Enregistre le PDF-document précédemment ouvert._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Enregistrer le PDF-document précédemment ouvert
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/save_as/_index.md
+++ b/french/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Enregistre le PDF-document précédemment ouvert avec un nouveau nom de fichier."
+type: docs
+url: /fr/rust-cpp/core/save_as/
+---
+
+_Enregistre le PDF-document précédemment ouvert avec un nouveau nom de fichier._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Enregistrer le PDF-document avec un nouveau nom de fichier
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/set_license/_index.md
+++ b/french/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Définit la licence à l'aide du nom de fichier."
+type: docs
+url: /fr/rust-cpp/core/set_license/
+---
+
+_Définit la licence à l'aide du nom de fichier._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Définir la licence avec le nom de fichier
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Vous pouvez maintenant travailler avec le document PDF sous licence
+    // ...
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/set_meta_info/_index.md
+++ b/french/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Définit la valeur des métadonnées du document PDF."
+type: docs
+url: /fr/rust-cpp/core/set_meta_info/
+---
+
+_Définit la valeur des métadonnées du document PDF._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Définir la valeur des métadonnées du document PDF
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/split/_index.md
+++ b/french/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Crée plusieurs nouveaux documents PDF en extrayant les pages du document PDF actuel."
+type: docs
+url: /fr/rust-cpp/core/split/
+---
+
+_Crée plusieurs nouveaux documents PDF en extrayant les pages du document PDF actuel._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Créer plusieurs nouveaux documents PDF en extrayant les pages du document PDF actuel
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Enregistrer chaque partie découpée en tant que PDF-document séparé
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/split_at/_index.md
+++ b/french/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Divise le PDF-document actuel en deux nouveaux PDF-documents."
+type: docs
+url: /fr/rust-cpp/core/split_at/
+---
+
+_Divise le PDF-document actuel en deux nouveaux PDF-documents._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Diviser le PDF-document actuel en deux nouveaux PDF-documents
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Enregistrer chaque partie découpée en tant que PDF-document séparé
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/split_at_page/_index.md
+++ b/french/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Divise le PDF-document en deux nouveaux PDF-documents."
+type: docs
+url: /fr/rust-cpp/core/split_at_page/
+---
+
+_Divise le PDF-document en deux nouveaux PDF-documents._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Diviser le PDF-document en deux nouveaux PDF-documents
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Enregistrer chaque partie découpée en tant que PDF-document séparé
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/split_document/_index.md
+++ b/french/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Crée plusieurs nouveaux PDF-documents en extrayant des pages du PDF-document source."
+type: docs
+url: /fr/rust-cpp/core/split_document/
+---
+
+_Crée plusieurs nouveaux PDF-documents en extrayant des pages du PDF-document source._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document nommé "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Crée plusieurs nouveaux PDF-documents en extrayant des pages du PDF-document source
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Enregistrer chaque partie découpée en tant que PDF-document séparé
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/core/word_count/_index.md
+++ b/french/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie le nombre de mots dans le PDF-document."
+type: docs
+url: /fr/rust-cpp/core/word_count/
+---
+
+_Renvoie le nombre de mots dans le PDF-document._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Renvoie le nombre de mots dans le PDF-document
+    let count = pdf.word_count()?;
+
+    // Afficher le nombre de mots
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/miscellaneous/_index.md
+++ b/french/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Fonctions diverses"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fonctions diverses pour travailler."
+type: docs
+url: /fr/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Fonction | Description |
+| -------- | ----------- |
+| [about](./about/) | Retourner les informations de métadonnées sur Aspose.PDF pour Rust via C++. |
+
+
+## Detailed Description
+
+Fonctions diverses pour travailler.
+

--- a/french/rust-cpp/miscellaneous/about/_index.md
+++ b/french/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "à propos"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Renvoie les informations de métadonnées sur le Aspose.PDF pour Rust via C++."
+type: docs
+url: /fr/rust-cpp/miscellaneous/about/
+---
+
+_Renvoie les informations de métadonnées sur le Aspose.PDF pour Rust via C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Renvoie les informations de métadonnées sur le Aspose.PDF pour Go via C++.
+    let info = pdf.about()?;
+
+    // Afficher les champs de métadonnées
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/_index.md
+++ b/french/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Fonctions d'organisation de PDF"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fonctions pour organiser des fichiers PDF."
+type: docs
+url: /fr/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Optimiser le contenu du document PDF. |
+| [optimize_resource](./optimize_resource/) | Optimiser les ressources du document PDF. |
+| [grayscale](./grayscale/) | Convertir le document PDF en noir et blanc. |
+| [rotate](./rotate/) | Faire pivoter le document PDF. |
+| [set_background](./set_background/) | Définir la couleur d'arrière-plan du document PDF en utilisant les valeurs RVB. |
+| [repair](./repair/) | Réparer le document PDF. |
+| [replace_text](./replace_text/) | Remplacer le texte dans le document PDF |
+| [add_page_num](./add_page_num/) | Ajouter le numéro de page à un document PDF |
+| [add_text_header](./add_text_header/) | Ajouter du texte dans l'en-tête d'un document PDF |
+| [add_text_footer](./add_text_footer/) | Ajouter du texte dans le pied de page d'un document PDF |
+| [flatten](./flatten/) | Aplatir le document PDF |
+| [remove_annotations](./remove_annotations/) | Supprimer les annotations du document PDF |
+| [remove_attachments](./remove_attachments/) | Supprimer les pièces jointes du document PDF |
+| [remove_blank_pages](./remove_blank_pages/) | Supprimer les pages blanches du document PDF |
+| [remove_bookmarks](./remove_bookmarks/) | Supprimer les signets du document PDF |
+| [remove_hidden_text](./remove_hidden_text/) | Supprimer le texte masqué du document PDF |
+| [remove_images](./remove_images/) | Supprimer les images du document PDF |
+| [remove_javascripts](./remove_javascripts/) | Supprimer les scripts Java du document PDF |
+| [remove_tables](./remove_tables/) | Supprimer les tableaux d'un document PDF. |
+| [remove_watermarks](./remove_watermarks/) | Supprimer les filigranes du document PDF. |
+| [add_watermark](./add_watermark/) | Ajouter un filigrane au document PDF. |
+| [embed_fonts](./embed_fonts/) | Intégrer les polices dans un PDF-document. |
+| [unembed_fonts](./unembed_fonts/) | Désintégrer les polices d'un PDF-document. |
+| [optimize_file_size](./optimize_file_size/) | Optimiser la taille d'un PDF-document avec la qualité de compression d'image. |
+| [remove_text_headers](./remove_text_headers/) | Supprimer les en-têtes de texte du PDF-document. |
+| [remove_text_footers](./remove_text_footers/) | Supprimer les pieds de page de texte du PDF-document. |
+| [crop](./crop/) | Recadrer les pages d'un PDF-document. |
+| [replace_font](./replace_font/) | Remplacer la police dans un PDF-document. |
+| [convert](./convert/) | Convertir un PDF-document en un PDF-document avec le format PDF spécifié |
+| [validate](./validate/) | Valider un PDF-document pour la conformité au format PDF |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Supprimer la conformité PDF/A d'un PDF-document |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Supprimer la conformité PDF/UA d'un PDF-document |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Déterminer si un PDF-document est conforme PDF/A |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Déterminer si un PDF-document est conforme PDF/UA |
+| [page_rotate](./page_rotate/) | Faire pivoter une page dans le PDF-document. |
+| [page_set_size](./page_set_size/) | Définir la taille d'une page dans le PDF-document. |
+| [page_grayscale](./page_grayscale/) | Convertir la page en noir et blanc. |
+| [page_add_text](./page_add_text/) | Ajouter du texte sur la page. |
+| [page_replace_text](./page_replace_text/) | Remplacer le texte sur la page |
+| [page_add_page_num](./page_add_page_num/) | Ajouter le numéro de page sur la page |
+| [page_add_text_header](./page_add_text_header/) | Ajouter du texte dans l'en-tête de la page |
+| [page_add_text_footer](./page_add_text_footer/) | Ajouter du texte dans le pied de page de la page |
+| [page_remove_annotations](./page_remove_annotations/) | Supprimer les annotations dans la page. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Supprimer le texte caché dans la page. |
+| [page_remove_images](./page_remove_images/) | Supprimer les images dans la page. |
+| [page_remove_tables](./page_remove_tables/) | Supprimer les tableaux dans la page. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Supprimer les filigranes dans la page. |
+| [page_add_watermark](./page_add_watermark/) | Ajouter un filigrane sur la page. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Supprimer les en-têtes de texte dans la page. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Supprimer les pieds de page de texte dans la page. |
+| [page_crop](./page_crop/) | Rogner une page. |
+| [page_replace_font](./page_replace_font/) | Remplacer la police dans la page. |
+| [page_merge_layers](./page_merge_layers/) | Fusionner toutes les couches de la page en une seule couche avec le nom de nouvelle couche spécifié. |
+| [page_layers](./page_layers/) | Obtenir les noms des couches sur la page. |
+
+
+## Detailed Description
+
+Fonctions pour organiser des fichiers PDF.

--- a/french/rust-cpp/organize/add_page_num/_index.md
+++ b/french/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute le numéro de page à un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/add_page_num/
+---
+
+_Ajoute le numéro de page à un PDF-document._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter le numéro de page à un document PDF
+    pdf.add_page_num()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/add_text_footer/_index.md
+++ b/french/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute du texte dans le pied de page d'un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/add_text_footer/
+---
+
+_Ajoute du texte dans le pied de page d'un PDF-document._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter du texte dans le pied de page d'un document PDF
+    pdf.add_text_footer("FOOTER")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/add_text_header/_index.md
+++ b/french/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute du texte dans l'en-tête d'un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/add_text_header/
+---
+
+_Ajoute du texte dans l'en-tête d'un PDF-document._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter du texte dans l'en-tête d'un document PDF
+    pdf.add_text_header("HEADER")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/add_watermark/_index.md
+++ b/french/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute un filigrane au PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/add_watermark/
+---
+
+_Ajoute un filigrane au PDF-document._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter un filigrane au PDF-document
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/convert/_index.md
+++ b/french/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convertir"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit un PDF-document en un PDF-document avec le format PDF spécifié."
+type: docs
+url: /fr/rust-cpp/organize/convert/
+---
+
+_Convertit un PDF-document en un PDF-document avec le format PDF spécifié._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir un PDF-document en un PDF-document avec le format PDF spécifié
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Afficher le résultat de la conversion et le journal complet
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/crop/_index.md
+++ b/french/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "recadrer"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Recadre les pages d'un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/crop/
+---
+
+_Recadre les pages d'un PDF-document._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recadrer les pages d'un PDF-document
+    pdf.crop(10.5)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/embed_fonts/_index.md
+++ b/french/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Intègre les polices dans un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/embed_fonts/
+---
+
+_Intègre les polices dans un PDF-document._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Intégrer les polices dans un PDF-document
+    pdf.embed_fonts()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/flatten/_index.md
+++ b/french/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Aplati le document PDF."
+type: docs
+url: /fr/rust-cpp/organize/flatten/
+---
+
+_Aplati le document PDF._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Renvoie le contenu du PDF-document en texte brut
+    let txt = pdf.extract_text()?;
+
+    // Imprimer le texte extrait
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/grayscale/_index.md
+++ b/french/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit le document PDF en noir et blanc."
+type: docs
+url: /fr/rust-cpp/organize/grayscale/
+---
+
+_Convertit le document PDF en noir et blanc._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir le document PDF en noir et blanc
+    pdf.grayscale()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/french/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "est_pdfa_conforme"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtient si un PDF-document est conforme PDF/A."
+type: docs
+url: /fr/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Obtient si un PDF-document est conforme PDF/A._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtenir le statut de conformité PDF/A du PDF-document
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/french/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtient si un document PDF est conforme PDF/UA."
+type: docs
+url: /fr/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Obtient si un document PDF est conforme PDF/UA._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtenez le statut de conformité PDF/UA du document PDF
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/optimize/_index.md
+++ b/french/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Optimise le contenu du document PDF."
+type: docs
+url: /fr/rust-cpp/organize/optimize/
+---
+
+_Optimise le contenu du document PDF._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimiser le contenu du document PDF
+    pdf.optimize()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/optimize_file_size/_index.md
+++ b/french/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Optimise la taille du PDF-document avec la qualité de compression d'image."
+type: docs
+url: /fr/rust-cpp/organize/optimize_file_size/
+---
+
+_Optimise la taille du PDF-document avec la qualité de compression d'image._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimiser la taille du PDF-document avec la qualité de compression d'image
+    pdf.optimize_file_size(50)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/optimize_resource/_index.md
+++ b/french/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimiser_ressource"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Optimise les ressources du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/optimize_resource/
+---
+
+_Optimise les ressources du PDF-document._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimiser les ressources du PDF-document
+    pdf.optimize_resource()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_add_page_num/_index.md
+++ b/french/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute le numéro de page sur la page."
+type: docs
+url: /fr/rust-cpp/organize/page_add_page_num/
+---
+
+_Ajoute le numéro de page sur la page._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter le numéro de page sur la page
+    pdf.page_add_page_num(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_add_text/_index.md
+++ b/french/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute du texte à une page."
+type: docs
+url: /fr/rust-cpp/organize/page_add_text/
+---
+
+_Ajoute du texte à une page._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter du texte sur la page
+    pdf.page_add_text(1, "added text")?;
+
+    // Enregistrer le PDF-document précédemment ouvert
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/french/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute du texte dans le pied de page."
+type: docs
+url: /fr/rust-cpp/organize/page_add_text_footer/
+---
+
+_Ajoute du texte dans le pied de page._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter du texte dans le pied de page de la page
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_add_text_header/_index.md
+++ b/french/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute du texte dans l'en-tête de page."
+type: docs
+url: /fr/rust-cpp/organize/page_add_text_header/
+---
+
+_Ajoute du texte dans l'en-tête de page._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter du texte dans l'en-tête de la page
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_add_watermark/_index.md
+++ b/french/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ajoute un filigrane sur la page."
+type: docs
+url: /fr/rust-cpp/organize/page_add_watermark/
+---
+
+_Ajoute un filigrane sur la page._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ajouter un filigrane sur la page
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_crop/_index.md
+++ b/french/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_recadrer"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Recadre une page."
+type: docs
+url: /fr/rust-cpp/organize/page_crop/
+---
+
+_Recadre une page._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recadrer une page
+    pdf.page_crop(1, 1.0)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_grayscale/_index.md
+++ b/french/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Convertit une page en noir et blanc."
+type: docs
+url: /fr/rust-cpp/organize/page_grayscale/
+---
+
+_Convertit une page en noir et blanc._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir la page en noir et blanc
+    pdf.page_grayscale(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_layers/_index.md
+++ b/french/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtient les noms des calques sur la page."
+type: docs
+url: /fr/rust-cpp/organize/page_layers/
+---
+
+_Obtient les noms des calques sur la page._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Obtenez les noms des calques sur la page 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_merge_layers/_index.md
+++ b/french/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fusionne toutes les couches de la page en une seule couche avec le nom de nouvelle couche spécifié."
+type: docs
+url: /fr/rust-cpp/organize/page_merge_layers/
+---
+
+_Fusionne toutes les couches de la page en une seule couche avec le nom de nouvelle couche spécifié._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Fusionner toutes les couches de la page en une seule couche avec le nom de nouvelle couche spécifié
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/french/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_supprimer_annotations"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les annotations dans la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_annotations/
+---
+
+_Supprime les annotations dans la page._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les annotations dans la page
+    pdf.page_remove_annotations(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/french/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime le texte caché dans la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Supprime le texte caché dans la page._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer le texte caché dans la page
+    pdf.page_remove_hidden_text(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_images/_index.md
+++ b/french/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les images de la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_images/
+---
+
+_Supprime les images de la page._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les images de la page
+    pdf.page_remove_images(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_tables/_index.md
+++ b/french/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les tables de la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_tables/
+---
+
+_Supprime les tables de la page._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les tables de la page
+    pdf.page_remove_tables(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/french/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les pieds de texte de la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Supprime les pieds de texte de la page._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les pieds de texte de la page
+    pdf.page_remove_text_footers(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/french/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les en-têtes texte de la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Supprime les en-têtes texte de la page._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les en-têtes texte de la page
+    pdf.page_remove_text_headers(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/french/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les filigranes de la page."
+type: docs
+url: /fr/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Supprime les filigranes de la page._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les filigranes de la page
+    pdf.page_remove_watermarks(1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_replace_font/_index.md
+++ b/french/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_remplacer_police"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Remplace la police dans la page."
+type: docs
+url: /fr/rust-cpp/organize/page_replace_font/
+---
+
+_Remplace la police dans la page._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remplacer la police dans la page
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_replace_text/_index.md
+++ b/french/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Remplace le texte sur la page."
+type: docs
+url: /fr/rust-cpp/organize/page_replace_text/
+---
+
+_Remplace le texte sur la page._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remplacer le texte sur la page
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_rotate/_index.md
+++ b/french/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fait pivoter une page du document PDF."
+type: docs
+url: /fr/rust-cpp/organize/page_rotate/
+---
+
+_Fait pivoter une page du document PDF._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document depuis un fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Faire pivoter la page
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/page_set_size/_index.md
+++ b/french/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Définit la taille d'une page dans le document PDF."
+type: docs
+url: /fr/rust-cpp/organize/page_set_size/
+---
+
+_Définit la taille d'une page dans le document PDF._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Définir la taille d'une page dans le document PDF
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_annotations/_index.md
+++ b/french/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les annotations du document PDF."
+type: docs
+url: /fr/rust-cpp/organize/remove_annotations/
+---
+
+_Supprime les annotations du document PDF._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les annotations du document PDF
+    pdf.remove_annotations()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_attachments/_index.md
+++ b/french/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les pièces jointes du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_attachments/
+---
+
+_Supprime les pièces jointes du PDF-document._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les pièces jointes du document PDF
+    pdf.remove_attachments()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/french/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les pages blanches du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_blank_pages/
+---
+
+_Supprime les pages blanches du PDF-document._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les pages blanches du document PDF
+    pdf.remove_blank_pages()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/french/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les signets du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_bookmarks/
+---
+
+_Supprime les signets du PDF-document._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les signets du document PDF
+    pdf.remove_bookmarks()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/french/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime le texte masqué du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_hidden_text/
+---
+
+_Supprime le texte masqué du PDF-document._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer le texte masqué du document PDF
+    pdf.remove_hidden_text()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_images/_index.md
+++ b/french/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les images du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_images/
+---
+
+_Supprime les images du PDF-document._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les images du document PDF
+    pdf.remove_images()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_javascripts/_index.md
+++ b/french/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les scripts Java du document PDF."
+type: docs
+url: /fr/rust-cpp/organize/remove_javascripts/
+---
+
+_Supprime les scripts Java du document PDF._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les scripts Java du document PDF
+    pdf.remove_javascripts()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/french/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprimer la conformité PDF/A d'un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Supprimer la conformité PDF/A d'un PDF-document._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer la conformité PDF/A d'un PDF-document
+    pdf.remove_pdfa_compliance()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/french/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime la conformité PDF/UA d'un document PDF."
+type: docs
+url: /fr/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Supprime la conformité PDF/UA d'un document PDF._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer la conformité PDF/UA d'un PDF-document
+    pdf.remove_pdfua_compliance()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_tables/_index.md
+++ b/french/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les tables du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_tables/
+---
+
+_Supprime les tables du PDF-document._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les tables du PDF-document
+    pdf.remove_tables()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_text_footers/_index.md
+++ b/french/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les pieds de page texte du document PDF."
+type: docs
+url: /fr/rust-cpp/organize/remove_text_footers/
+---
+
+_Supprime les pieds de page texte du document PDF._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les pieds de page texte du document PDF
+    pdf.remove_text_footers()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_text_headers/_index.md
+++ b/french/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les en-têtes de texte du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_text_headers/
+---
+
+_Supprime les en-têtes de texte du PDF-document._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les en-têtes de texte du PDF-document
+    pdf.remove_text_headers()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/remove_watermarks/_index.md
+++ b/french/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprime les filigranes du PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/remove_watermarks/
+---
+
+_Supprime les filigranes du PDF-document._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Supprimer les filigranes du PDF-document
+    pdf.remove_watermarks()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/repair/_index.md
+++ b/french/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Répare le document PDF."
+type: docs
+url: /fr/rust-cpp/organize/repair/
+---
+
+_Répare le PDF-document._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Réparer PDF-document
+    pdf.repair()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/replace_font/_index.md
+++ b/french/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Remplace la police dans un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/replace_font/
+---
+
+_Remplace la police dans un PDF-document._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remplacer la police dans un PDF-document.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/replace_text/_index.md
+++ b/french/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Remplace le texte."
+type: docs
+url: /fr/rust-cpp/organize/replace_text/
+---
+
+_Remplace le texte._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remplacer le texte dans le document PDF
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/rotate/_index.md
+++ b/french/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fait pivoter le PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/rotate/
+---
+
+_Fait pivoter le PDF-document._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Faire pivoter le PDF-document
+    pdf.rotate(Rotation::On270)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/set_background/_index.md
+++ b/french/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Définit la couleur d'arrière-plan du PDF-document en utilisant les valeurs RGB."
+type: docs
+url: /fr/rust-cpp/organize/set_background/
+---
+
+_Définit la couleur d'arrière-plan du PDF-document en utilisant les valeurs RGB._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Définir la couleur d'arrière-plan du PDF-document en utilisant les valeurs RGB
+    pdf.set_background(200, 100, 101)?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/unembed_fonts/_index.md
+++ b/french/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Désintègre les polices d'un PDF-document."
+type: docs
+url: /fr/rust-cpp/organize/unembed_fonts/
+---
+
+_Désintègre les polices d'un PDF-document._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Désintégrer les polices d'un PDF-document
+    pdf.unembed_fonts()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/organize/validate/_index.md
+++ b/french/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Valide un PDF-document pour la conformité au format PDF."
+type: docs
+url: /fr/rust-cpp/organize/validate/
+---
+
+_Valide un PDF-document pour la conformité au format PDF._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Valider un PDF-document pour la conformité au format PDF
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Imprimer le résultat de validation et le journal complet
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/_index.md
+++ b/french/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Fonctions de sécurité"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Fonctions de sécurité."
+type: docs
+url: /fr/rust-cpp/security/
+---
+
+## Security
+
+| Fonction | Description |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Ouvrir un PDF-document protégé par mot de passe. |
+| [encrypt](./encrypt/) | Chiffrer le PDF-document. |
+| [decrypt](./decrypt/) | Déchiffrer le PDF-document. |
+| [set_permissions](./set_permissions/) | Définir les autorisations pour le PDF-document. |
+| [get_permissions](./get_permissions/) | Obtenir les autorisations actuelles du PDF-document. |
+| [is_encrypted](./is_encrypted/) | Obtenir le statut de chiffrement du PDF-document. |
+| [sign_pkcs7](./sign_pkcs7/) | Signer un PDF-document en utilisant des signatures numériques PKCS#7. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Signer un PDF-document en utilisant des signatures numériques PKCS#7 détachées. |
+| [is_signed](./is_signed/) | Obtenir le statut de signature du PDF-document. |
+| [remove_signs](./remove_signs/) | Supprimer les signatures du PDF-document. |
+
+
+## Detailed Description
+
+Fonctions de sécurité.
+

--- a/french/rust-cpp/security/decrypt/_index.md
+++ b/french/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "décrypter"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Déchiffrer le PDF-document."
+type: docs
+url: /fr/rust-cpp/security/decrypt/
+---
+
+_Décrypter le document PDF._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF protégé par mot de passe
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Décrypter le document PDF
+    pdf.decrypt()?;
+
+    // Enregistrer le PDF-document précédemment ouvert avec un nouveau nom de fichier
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/encrypt/_index.md
+++ b/french/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "chiffrer"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Chiffrer le PDF-document."
+type: docs
+url: /fr/rust-cpp/security/encrypt/
+---
+
+_Chiffrer PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Chiffrer PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Enregistrer le PDF-document chiffré
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/get_permissions/_index.md
+++ b/french/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtenir les autorisations actuelles du PDF-document."
+type: docs
+url: /fr/rust-cpp/security/get_permissions/
+---
+
+_Obtenir les autorisations actuelles du document PDF._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF protégé par mot de passe
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Obtenir les autorisations actuelles du document PDF
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Afficher les autorisations
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/is_encrypted/_index.md
+++ b/french/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtenir le statut de chiffrement du PDF-document."
+type: docs
+url: /fr/rust-cpp/security/is_encrypted/
+---
+
+_Obtenir le statut chiffré du document PDF._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF protégé par mot de passe
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Obtenir le statut chiffré du document PDF
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/is_signed/_index.md
+++ b/french/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Obtenir le statut de signature du PDF-document."
+type: docs
+url: /fr/rust-cpp/security/is_signed/
+---
+
+_Obtenir le statut signé du PDF-document._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF nommé "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Obtenir le statut signé du PDF-document
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/open_with_password/_index.md
+++ b/french/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Ouvrir un PDF-document protégé par mot de passe."
+type: docs
+url: /fr/rust-cpp/security/open_with_password/
+---
+
+_Ouvrir un document PDF protégé par mot de passe._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF protégé par mot de passe
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // en cours...
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/remove_signs/_index.md
+++ b/french/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Supprimer les signatures du PDF-document."
+type: docs
+url: /fr/rust-cpp/security/remove_signs/
+---
+
+_Supprimer les signatures du document PDF._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ouvrir un document PDF nommé "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Supprimer les signatures du document PDF
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/set_permissions/_index.md
+++ b/french/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Définir les autorisations pour le PDF-document."
+type: docs
+url: /fr/rust-cpp/security/set_permissions/
+---
+
+_Définir les autorisations pour le PDF-document._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Créer un nouveau PDF-document
+    let pdf = Document::new()?;
+
+    // Définir les autorisations pour le PDF-document.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Enregistrer le PDF-document avec les autorisations mises à jour
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/sign_pkcs7/_index.md
+++ b/french/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Signer un PDF-document en utilisant des signatures numériques PKCS#7."
+type: docs
+url: /fr/rust-cpp/security/sign_pkcs7/
+---
+
+_Signer un PDF-document en utilisant des signatures numériques PKCS#7._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Lire les fichiers de certificat et d'image en vecteurs d'octets
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signer un PDF-document en utilisant des signatures numériques PKCS#7
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/french/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/french/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF pour Rust via C++"
+description: "Signer un PDF-document en utilisant des signatures numériques PKCS#7 détachées."
+type: docs
+url: /fr/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Signer un PDF-document en utilisant des signatures numériques PKCS#7 détachées._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Lire les fichiers de certificat et d'image en vecteurs d'octets
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Ouvrir un PDF-document avec le nom de fichier
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signer un PDF-document en utilisant des signatures numériques PKCS#7 détachées
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
🔄 **In progress** — incremental translation of RUST-CPP API Reference to **French** (`fr`).

Updated at each cache checkpoint. Source: `english/rust-cpp`

🤖 Generated by RDA