### PR TITLE
[draft] Translate RUST-CPP API Reference to German

### DIFF
--- a/german/rust-cpp/_index.md
+++ b/german/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF für Rust über C++"
+description: "Aspose.PDF für Rust über C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /de/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Strukturen
+
+## Document
+Dokument stellt ein PDF-document dar.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als DocX-document. |
+| [save_doc](./convert/save_doc/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Doc-document. |
+| [save_xlsx](./convert/save_xlsx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als XlsX-document. |
+| [save_txt](./convert/save_txt/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Txt-document. |
+| [save_pptx](./convert/save_pptx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als PptX-document. |
+| [save_xps](./convert/save_xps/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Xps-document. |
+| [save_tex](./convert/save_tex/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als TeX-document. |
+| [save_epub](./convert/save_epub/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Epub-document. |
+| [save_booklet](./convert/save_booklet/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als booklet PDF-document. |
+| [save_n_up](./convert/save_n_up/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als N-Up PDF-document. |
+| [save_markdown](./convert/save_markdown/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Markdown-document. |
+| [save_tiff](./convert/save_tiff/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Tiff-document. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als DocX-document mit erweitertem Erkennungsmodus (vollständig editierbare Tabellen und Absätze). |
+| [save_svg_zip](./convert/save_svg_zip/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als SVG-Archiv. |
+| [export_fdf](./convert/export_fdf/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu FDF-document. |
+| [export_xfdf](./convert/export_xfdf/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu XFDF-document. |
+| [export_xml](./convert/export_xml/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu XML-document. |
+| [page_to_jpg](./convert/page_to_jpg/) | Konvertieren und speichern Sie die angegebene Seite als Jpg-Bild. |
+| [page_to_png](./convert/page_to_png/) | Konvertieren und speichern Sie die angegebene Seite als Png-Bild. |
+| [page_to_bmp](./convert/page_to_bmp/) | Konvertieren und speichern Sie die angegebene Seite als Bmp-Bild. |
+| [page_to_tiff](./convert/page_to_tiff/) | Konvertieren und speichern Sie die angegebene Seite als Tiff-Bild. |
+| [page_to_svg](./convert/page_to_svg/) | Konvertieren und speichern Sie die angegebene Seite als Svg-Bild. |
+| [page_to_pdf](./convert/page_to_pdf/) | Konvertieren und speichern Sie die angegebene Seite als PDF-Dokument. |
+| [page_to_dicom](./convert/page_to_dicom/) | Konvertieren und speichern Sie die angegebene Seite als DICOM-Bild. |
+
+
+## Organize PDF functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Optimieren Sie den Inhalt des PDF-Dokuments. |
+| [optimize_resource](./organize/optimize_resource/) | Optimieren Sie die Ressourcen des PDF-Dokuments. |
+| [grayscale](./organize/grayscale/) | Konvertieren Sie das PDF-Dokument in Schwarzweiß. |
+| [rotate](./organize/rotate/) | Drehen Sie das PDF-Dokument. |
+| [set_background](./organize/set_background/) | Legen Sie die Hintergrundfarbe des PDF-Dokuments mit RGB-Werten fest. |
+| [repair](./organize/repair/) | Reparieren Sie das PDF-Dokument. |
+| [replace_text](./organize/replace_text/) | Ersetzen Sie Text im PDF-Dokument |
+| [add_page_num](./organize/add_page_num/) | Fügen Sie einem PDF-Dokument eine Seitenzahl hinzu |
+| [add_text_header](./organize/add_text_header/) | Fügen Sie Text in die Kopfzeile eines PDF-Dokuments ein |
+| [add_text_footer](./organize/add_text_footer/) | Fügen Sie Text in die Fußzeile eines PDF-Dokuments ein |
+| [flatten](./organize/flatten/) | PDF-Dokument flachlegen |
+| [remove_annotations](./organize/remove_annotations/) | Entfernen Sie Anmerkungen aus dem PDF-Dokument |
+| [remove_attachments](./organize/remove_attachments/) | Entfernen Sie Anhänge aus dem PDF-Dokument |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Entfernen Sie leere Seiten aus dem PDF-Dokument |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Entfernen Sie Lesezeichen aus dem PDF-Dokument |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Entfernen Sie versteckten Text aus dem PDF-Dokument |
+| [remove_images](./organize/remove_images/) | Entfernen Sie Bilder aus dem PDF-Dokument |
+| [remove_javascripts](./organize/remove_javascripts/) | Entfernen Sie JavaScript aus dem PDF-Dokument |
+| [remove_tables](./organize/remove_tables/) | Entfernen Sie Tabellen aus einem PDF-Dokument. |
+| [remove_watermarks](./organize/remove_watermarks/) | Entfernen Sie Wasserzeichen aus dem PDF-Dokument. |
+| [add_watermark](./organize/add_watermark/) | Fügen Sie ein Wasserzeichen zum PDF-Dokument hinzu. |
+| [embed_fonts](./organize/embed_fonts/) | Schriftarten in ein PDF-Dokument einbetten. |
+| [unembed_fonts](./organize/unembed_fonts/) | Schriftarten aus einem PDF-Dokument entfernen. |
+| [optimize_file_size](./organize/optimize_file_size/) | Größe des PDF-Dokuments mit Bildkomprimierungsqualität optimieren. |
+| [remove_text_headers](./organize/remove_text_headers/) | Textkopfzeilen aus dem PDF-Dokument entfernen. |
+| [remove_text_footers](./organize/remove_text_footers/) | Textfußzeilen aus dem PDF-Dokument entfernen. |
+| [crop](./organize/crop/) | Seiten eines PDF-Dokuments zuschneiden. |
+| [replace_font](./organize/replace_font/) | Schriftart in einem PDF-Dokument ersetzen. |
+| [convert](./organize/convert/) | Ein PDF-Dokument in ein PDF-Dokument mit dem angegebenen PDF-Format konvertieren |
+| [validate](./organize/validate/) | Ein PDF-Dokument auf Konformität mit dem PDF-Format prüfen |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | PDF/A-Konformität aus einem PDF-Dokument entfernen |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | PDF/UA-Konformität aus einem PDF-Dokument entfernen |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Ermitteln, ob ein PDF-Dokument PDF/A-konform ist |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Ermitteln, ob ein PDF-Dokument PDF/UA-konform ist |
+| [page_rotate](./organize/page_rotate/) | Eine Seite im PDF-Dokument drehen. |
+| [page_set_size](./organize/page_set_size/) | Die Größe einer Seite im PDF-Dokument festlegen. |
+| [page_grayscale](./organize/page_grayscale/) | Seite in Schwarzweiß konvertieren. |
+| [page_add_text](./organize/page_add_text/) | Text auf der Seite hinzufügen. |
+| [page_replace_text](./organize/page_replace_text/) | Text auf der Seite ersetzen |
+| [page_add_page_num](./organize/page_add_page_num/) | Seitennummer auf der Seite hinzufügen |
+| [page_add_text_header](./organize/page_add_text_header/) | Text in der Seitenkopfzeile hinzufügen |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Text in der Seitenfußzeile hinzufügen |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Anmerkungen auf der Seite entfernen. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Versteckten Text auf der Seite entfernen. |
+| [page_remove_images](./organize/page_remove_images/) | Bilder auf der Seite entfernen. |
+| [page_remove_tables](./organize/page_remove_tables/) | Tabellen auf der Seite entfernen. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Wasserzeichen auf der Seite entfernen. |
+| [page_add_watermark](./organize/page_add_watermark/) | Wasserzeichen auf der Seite hinzufügen. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Textkopfzeilen auf der Seite entfernen. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Textfußzeilen auf der Seite entfernen. |
+| [page_crop](./organize/page_crop/) | Eine Seite zuschneiden. |
+| [page_replace_font](./organize/page_replace_font/) | Schriftart auf der Seite ersetzen. |
+| [page_merge_layers](./organize/page_merge_layers/) | Alle Ebenen auf der Seite zu einer einzigen Ebene mit dem angegebenen neuen Ebenennamen zusammenführen. |
+| [page_layers](./organize/page_layers/) | Namen der Ebenen auf der Seite abrufen. |
+
+
+## Core PDF functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [new](./core/new/) | Ein neues PDF-Dokument erstellen. |
+| [open](./core/open/) | Ein PDF-Dokument mit Dateinamen öffnen. |
+| [save](./core/save/) | Das zuvor geöffnete PDF-Dokument speichern. |
+| [save_as](./core/save_as/) | Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern. |
+| [set_license](./core/set_license/) | Lizenz mit Dateinamen festlegen. |
+| [extract_text](./core/extract_text/) | Den Inhalt des PDF-Dokuments als Klartext zurückgeben. |
+| [word_count](./core/word_count/) | Wortanzahl im PDF-Dokument zurückgeben. |
+| [character_count](./core/character_count/) | Zeichenanzahl im PDF-Dokument zurückgeben. |
+| [append](./core/append/) | Seiten aus einem anderen PDF-Dokument anhängen. |
+| [append_pages](./core/append_pages/) | Ausgewählte Seiten aus einem anderen PDF-Dokument anhängen. |
+| [merge_documents](./core/merge_documents/) | Ein neues PDF-Dokument erstellen, indem die bereitgestellten PDF-Dokumente zusammengeführt werden. |
+| [split_document](./core/split_document/) | Mehrere neue PDF-Dokumente erstellen, indem Seiten aus dem Quell-PDF-Dokument extrahiert werden. |
+| [split](./core/split/) | Mehrere neue PDF-Dokumente erstellen, indem Seiten aus dem aktuellen PDF-Dokument extrahiert werden. |
+| [split_at_page](./core/split_at_page/) | Das PDF-Dokument in zwei neue PDF-Dokumente aufteilen. |
+| [split_at](./core/split_at/) | Das aktuelle PDF-Dokument in zwei neue PDF-Dokumente aufteilen. |
+| [bytes](./core/bytes/) | Den Inhalt des PDF-Dokuments als Byte-Vektor zurückgeben. |
+| [get_meta_info](./core/get_meta_info/) | Metainformationswert des PDF-Dokuments abrufen. |
+| [set_meta_info](./core/set_meta_info/) | Setze den Meta-Informationswert des PDF-Dokuments. |
+| [clear_meta_info](./core/clear_meta_info/) | Lösche alle Meta-Informationswerte des PDF-Dokuments. |
+| [is_linearized](./core/is_linearized/) | Erhalte einen Wert, der angibt, ob das Dokument linearisiert ist. |
+| [page_add](./core/page_add/) | Füge eine neue Seite im PDF-Dokument hinzu. |
+| [page_insert](./core/page_insert/) | Füge eine neue Seite an der angegebenen Position im PDF-Dokument ein. |
+| [page_delete](./core/page_delete/) | Lösche die angegebene Seite im PDF-Dokument. |
+| [page_count](./core/page_count/) | Gib die Anzahl der Seiten im PDF-Dokument zurück. |
+| [page_word_count](./core/page_word_count/) | Gib die Wortanzahl auf der angegebenen Seite im PDF-Dokument zurück. |
+| [page_character_count](./core/page_character_count/) | Gib die Zeichenanzahl auf der angegebenen Seite im PDF-Dokument zurück. |
+| [page_is_blank](./core/page_is_blank/) | Gib zurück, ob die Seite im PDF-Dokument leer ist. |
+
+
+## Security
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Öffne ein passwortgeschütztes PDF-Dokument. |
+| [encrypt](./security/encrypt/) | Verschlüssele das PDF-Dokument. |
+| [decrypt](./security/decrypt/) | Entschlüssele das PDF-Dokument. |
+| [set_permissions](./security/set_permissions/) | Setze Berechtigungen für das PDF-Dokument. |
+| [get_permissions](./security/get_permissions/) | Erhalte die aktuellen Berechtigungen des PDF-Dokuments. |
+| [is_encrypted](./security/is_encrypted/) | Erhalte den verschlüsselten Status des PDF-Dokuments. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Signiere ein PDF-Dokument mit PKCS#7-Digitalsignaturen. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Signiere ein PDF-Dokument mit PKCS#7-Detached-Digitalsignaturen. |
+| [is_signed](./security/is_signed/) | Erhalte den signierten Status des PDF-Dokuments. |
+| [remove_signs](./security/remove_signs/) | Entferne Signaturen vom PDF-Dokument. |
+
+
+## Miscellaneous
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Gib Metadateninformationen über Aspose.PDF für Rust via C++ zurück. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Bitflag-Set, das PDF-Berechtigungsfähigkeiten darstellt.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// A0-Größe.
+    A0 = 0,
+    /// A1-Größe.
+    A1 = 1,
+    /// A2-Größe.
+    A2 = 2,
+    /// A3 Größe.
+    A3 = 3,
+    /// A4 Größe.
+    A4 = 4,
+    /// A5 Größe.
+    A5 = 5,
+    /// A6 Größe.
+    A6 = 6,
+    /// B5 Größe.
+    B5 = 7,
+    /// PageLetter Größe.
+    PageLetter = 8,
+    /// PageLegal Größe.
+    PageLegal = 9,
+    /// PageLedger Größe.
+    PageLedger = 10,
+    /// P11x17 Größe.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Nicht rotiert.
+    None = 0,
+    /// Um 90 Grad im Uhrzeigersinn rotiert.
+    On90 = 1,
+    /// Um 180 Grad rotiert.
+    On180 = 2,
+    /// Um 270 Grad im Uhrzeigersinn rotiert.
+    On270 = 3,
+    /// Um 360 Grad im Uhrzeigersinn rotiert.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 mit Schlüssellänge 40.
+    RC4x40 = 0,
+    /// RC4 mit Schlüssellänge 128.
+    RC4x128 = 1,
+    /// AES mit Schlüssellänge 128.
+    AESx128 = 2,
+    /// AES mit Schlüssellänge 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// PDF/A-1a Format.
+    PDF_A_1A = 0,
+    /// PDF/A-1b Format.
+    PDF_A_1B = 1,
+    /// PDF/A-2a Format.
+    PDF_A_2A = 2,
+    /// PDF/A-3a Format.
+    PDF_A_3A = 3,
+    /// PDF/A-2b Format.
+    PDF_A_2B = 4,
+    /// PDF/A-2u Format.
+    PDF_A_2U = 5,
+    /// PDF/A-3b Format.
+    PDF_A_3B = 6,
+    /// PDF/A-3u-Format.
+    PDF_A_3U = 7,
+    /// Adobe-Version 1.0.
+    V_1_0 = 8,
+    /// Adobe-Version 1.1.
+    V_1_1 = 9,
+    /// Adobe-Version 1.2.
+    V_1_2 = 10,
+    /// Adobe-Version 1.3.
+    V_1_3 = 11,
+    /// Adobe-Version 1.4.
+    V_1_4 = 12,
+    /// Adobe-Version 1.5.
+    V_1_5 = 13,
+    /// Adobe-Version 1.6.
+    V_1_6 = 14,
+    /// Adobe-Version 1.7.
+    V_1_7 = 15,
+    /// ISO-Standard PDF 2.0.
+    V_2_0 = 16,
+    /// PDF/UA-1-Format.
+    PDF_UA_1 = 17,
+    /// PDF/X-1a:2001-Format.
+    PDF_X_1A_2001 = 18,
+    /// PDF/X-1a-Format.
+    PDF_X_1A = 19,
+    /// PDF/X-3-Format.
+    PDF_X_3 = 20,
+    /// ZUGFeRD-Format.
+    ZUGFeRD = 21,
+    /// PDF/A-4-Format.
+    PDF_A_4 = 22,
+    /// PDF/A-4e-Format.
+    PDF_A_4E = 23,
+    /// PDF/A-4f-Format.
+    PDF_A_4F = 24,
+    /// PDF/X-4-Format.
+    PDF_X_4 = 25,
+    /// PDF/E-1 (PDF 1.6)-Format.
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Nicht konforme Elemente löschen.
+    Delete = 0,
+    /// Nichts tun, nicht konforme Elemente behalten.
+    None = 1,
+}
+```
+

--- a/german/rust-cpp/convert/_index.md
+++ b/german/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Funktionen zum Konvertieren von PDF"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Funktionen zum Konvertieren von PDF-Dateien."
+type: docs
+url: /de/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als DocX-document. |
+| [save_doc](./save_doc/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Doc-document. |
+| [save_xlsx](./save_xlsx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als XlsX-document. |
+| [save_txt](./save_txt/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Txt-document. |
+| [save_pptx](./save_pptx/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als PptX-document. |
+| [save_xps](./save_xps/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Xps-document. |
+| [save_tex](./save_tex/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als TeX-document. |
+| [save_epub](./save_epub/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Epub-document. |
+| [save_booklet](./save_booklet/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als booklet PDF-document. |
+| [save_n_up](./save_n_up/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als N-Up PDF-document. |
+| [save_markdown](./save_markdown/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Markdown-document. |
+| [save_tiff](./save_tiff/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als Tiff-document. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als DocX-document mit erweitertem Erkennungsmodus (vollständig editierbare Tabellen und Absätze). |
+| [save_svg_zip](./save_svg_zip/) | Konvertieren und speichern Sie das zuvor geöffnete PDF-document als SVG-Archiv. |
+| [export_fdf](./export_fdf/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu FDF-document. |
+| [export_xfdf](./export_xfdf/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu XFDF-document. |
+| [export_xml](./export_xml/) | Exportieren Sie aus dem zuvor geöffneten PDF-document mit AcroForm zu XML-document. |
+| [page_to_jpg](./page_to_jpg/) | Konvertieren und speichern Sie die angegebene Seite als Jpg-Bild. |
+| [page_to_png](./page_to_png/) | Konvertieren und speichern Sie die angegebene Seite als Png-Bild. |
+| [page_to_bmp](./page_to_bmp/) | Konvertieren und speichern Sie die angegebene Seite als Bmp-Bild. |
+| [page_to_tiff](./page_to_tiff/) | Konvertieren und speichern Sie die angegebene Seite als Tiff-Bild. |
+| [page_to_svg](./page_to_svg/) | Konvertieren und speichern Sie die angegebene Seite als Svg-Bild. |
+| [page_to_pdf](./page_to_pdf/) | Konvertieren und speichern Sie die angegebene Seite als PDF-Dokument. |
+| [page_to_dicom](./page_to_dicom/) | Konvertieren und speichern Sie die angegebene Seite als DICOM-Bild. |
+
+
+## Detailed Description
+
+Funktionen zum Konvertieren von PDF-Dateien.
+

--- a/german/rust-cpp/convert/export_fdf/_index.md
+++ b/german/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Exportiert das zuvor geöffnete PDF-Dokument mit AcroForm zu einem FDF-Dokument mit Dateiname."
+type: docs
+url: /de/rust-cpp/convert/export_fdf/
+---
+
+_Exportiert das zuvor geöffnete PDF-Dokument mit AcroForm zu einem FDF-Dokument mit Dateiname._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportiere das zuvor geöffnete PDF-Dokument mit AcroForm zu einem FDF-Dokument
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/export_xfdf/_index.md
+++ b/german/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Exportiert aus zuvor geöffnetem PDF-Dokument mit AcroForm zu XFDF-Dokument mit Dateiname."
+type: docs
+url: /de/rust-cpp/convert/export_xfdf/
+---
+
+_Exportiert aus zuvor geöffnetem PDF-Dokument mit AcroForm zu XFDF-Dokument mit Dateiname._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Export aus dem zuvor geöffneten PDF-Dokument mit AcroForm zu XFDF-Dokument
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/export_xml/_index.md
+++ b/german/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Exportiert aus zuvor geöffnetem PDF-Dokument mit AcroForm zu XML-Dokument mit Dateiname."
+type: docs
+url: /de/rust-cpp/convert/export_xml/
+---
+
+_Exportiert aus zuvor geöffnetem PDF-Dokument mit AcroForm zu XML-Dokument mit Dateiname._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Export aus dem zuvor geöffneten PDF-Dokument mit AcroForm zu XML-Dokument
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_bmp/_index.md
+++ b/german/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als BMP-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_bmp/
+---
+
+_Konvertiert und speichert die angegebene Seite als BMP-Bild._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als BMP-Bild
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_dicom/_index.md
+++ b/german/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als ein DICOM-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_dicom/
+---
+
+_Konvertiert und speichert die angegebene Seite als ein DICOM-Bild._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als DICOM-Bild
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_jpg/_index.md
+++ b/german/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als ein JPG-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_jpg/
+---
+
+_Konvertiert und speichert die angegebene Seite als ein JPG-Bild._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als Jpg-image
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_pdf/_index.md
+++ b/german/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als ein PDF-Dokument."
+type: docs
+url: /de/rust-cpp/convert/page_to_pdf/
+---
+
+_Konvertiert und speichert die angegebene Seite als ein PDF-Dokument._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als PDF-Dokument
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_png/_index.md
+++ b/german/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als PNG-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_png/
+---
+
+_Konvertiert und speichert die angegebene Seite als PNG-Bild._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als Png-Bild
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_svg/_index.md
+++ b/german/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als SVG-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_svg/
+---
+
+_Konvertiert und speichert die angegebene Seite als SVG-Bild._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als SVG-Bild
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/page_to_tiff/_index.md
+++ b/german/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert die angegebene Seite als TIFF-Bild."
+type: docs
+url: /de/rust-cpp/convert/page_to_tiff/
+---
+
+_Konvertiert und speichert die angegebene Seite als TIFF-Bild._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere die angegebene Seite als Tiff-Bild
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_booklet/_index.md
+++ b/german/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein Booklet-PDF-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_booklet/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein Booklet-PDF-Dokument._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Booklet-PDF-Dokument
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/german/rust-cpp/convert/save_doc/_index.md
+++ b/german/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein DOC-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_doc/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein DOC-Dokument._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Doc-Dokument
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_docx/_index.md
+++ b/german/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein DOCX-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_docx/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein DOCX-Dokument._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als DocX-Dokument
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/german/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als DOCX-Dokument mit erweitertem Erkennungsmodus (vollständig editierbare Tabellen und Absätze)."
+type: docs
+url: /de/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als DOCX-Dokument mit erweitertem Erkennungsmodus (vollständig editierbare Tabellen und Absätze)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als DOCX-Dokument mit erweitertem Erkennungsmodus (vollständig editierbare Tabellen und Absätze)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_epub/_index.md
+++ b/german/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein EPUB-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_epub/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein EPUB-Dokument._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Epub-Dokument
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_markdown/_index.md
+++ b/german/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als Markdown-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_markdown/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als Markdown-Dokument._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Markdown-Dokument
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/german/rust-cpp/convert/save_n_up/_index.md
+++ b/german/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als N-Up-PDF-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_n_up/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als N-Up-PDF-Dokument._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als N-Up-PDF-Dokument
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/german/rust-cpp/convert/save_pptx/_index.md
+++ b/german/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein PPTX-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_pptx/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein PPTX-Dokument._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als PptX-Dokument
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_svg_zip/_index.md
+++ b/german/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein SVG-Archiv."
+type: docs
+url: /de/rust-cpp/convert/save_svg_zip/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein SVG-Archiv._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als SVG-Archiv
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_tex/_index.md
+++ b/german/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als TeX-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_tex/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als TeX-Dokument._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als TeX-Dokument
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_tiff/_index.md
+++ b/german/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein Tiff-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_tiff/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein Tiff-Dokument._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Tiff-Dokument
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/german/rust-cpp/convert/save_txt/_index.md
+++ b/german/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein TXT-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_txt/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als ein TXT-Dokument._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als Txt-Dokument
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_xlsx/_index.md
+++ b/german/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-document als ein XLSX-document."
+type: docs
+url: /de/rust-cpp/convert/save_xlsx/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-document als ein XLSX-document._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-document als XlsX-document
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/convert/save_xps/_index.md
+++ b/german/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert und speichert das zuvor geöffnete PDF-Dokument als XPS-Dokument."
+type: docs
+url: /de/rust-cpp/convert/save_xps/
+---
+
+_Konvertiert und speichert das zuvor geöffnete PDF-Dokument als XPS-Dokument._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere und speichere das zuvor geöffnete PDF-Dokument als XPS-Dokument
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/_index.md
+++ b/german/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Kern-PDF-Funktionen"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Kernfunktionen für die Arbeit mit PDF-Dateien."
+type: docs
+url: /de/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [new](./new/) | Ein neues PDF-Dokument erstellen. |
+| [open](./open/) | Ein PDF-Dokument mit Dateinamen öffnen. |
+| [save](./save/) | Das zuvor geöffnete PDF-Dokument speichern. |
+| [save_as](./save_as/) | Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern. |
+| [set_license](./set_license/) | Lizenz mit Dateinamen festlegen. |
+| [extract_text](./extract_text/) | Den Inhalt des PDF-Dokuments als Klartext zurückgeben. |
+| [word_count](./word_count/) | Wortanzahl im PDF-Dokument zurückgeben. |
+| [character_count](./character_count/) | Zeichenanzahl im PDF-Dokument zurückgeben. |
+| [append](./append/) | Seiten aus einem anderen PDF-Dokument anhängen. |
+| [append_pages](./append_pages/) | Ausgewählte Seiten aus einem anderen PDF-Dokument anhängen. |
+| [merge_documents](./merge_documents/) | Ein neues PDF-Dokument erstellen, indem die bereitgestellten PDF-Dokumente zusammengeführt werden. |
+| [split_document](./split_document/) | Mehrere neue PDF-Dokumente erstellen, indem Seiten aus dem Quell-PDF-Dokument extrahiert werden. |
+| [split](./split/) | Mehrere neue PDF-Dokumente erstellen, indem Seiten aus dem aktuellen PDF-Dokument extrahiert werden. |
+| [split_at_page](./split_at_page/) | Das PDF-Dokument in zwei neue PDF-Dokumente aufteilen. |
+| [split_at](./split_at/) | Das aktuelle PDF-Dokument in zwei neue PDF-Dokumente aufteilen. |
+| [bytes](./bytes/) | Den Inhalt des PDF-Dokuments als Byte-Vektor zurückgeben. |
+| [get_meta_info](./get_meta_info/) | Metainformationswert des PDF-Dokuments abrufen. |
+| [set_meta_info](./set_meta_info/) | Setze den Meta-Informationswert des PDF-Dokuments. |
+| [clear_meta_info](./clear_meta_info/) | Lösche alle Meta-Informationswerte des PDF-Dokuments. |
+| [is_linearized](./is_linearized/) | Erhalte einen Wert, der angibt, ob das Dokument linearisiert ist. |
+| [page_add](./page_add/) | Füge eine neue Seite im PDF-Dokument hinzu. |
+| [page_insert](./page_insert/) | Füge eine neue Seite an der angegebenen Position im PDF-Dokument ein. |
+| [page_delete](./page_delete/) | Lösche die angegebene Seite im PDF-Dokument. |
+| [page_count](./page_count/) | Gib die Anzahl der Seiten im PDF-Dokument zurück. |
+| [page_word_count](./page_word_count/) | Gib die Wortanzahl auf der angegebenen Seite im PDF-Dokument zurück. |
+| [page_character_count](./page_character_count/) | Gib die Zeichenanzahl auf der angegebenen Seite im PDF-Dokument zurück. |
+| [page_is_blank](./page_is_blank/) | Gib zurück, ob die Seite im PDF-Dokument leer ist. |
+
+
+## Detailed Description
+
+Kernfunktionen für die Arbeit mit PDF-Dateien.
+

--- a/german/rust-cpp/core/append/_index.md
+++ b/german/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt Seiten aus einem anderen PDF-document hinzu."
+type: docs
+url: /de/rust-cpp/core/append/
+---
+
+_Fügt Seiten aus einem anderen PDF-document hinzu._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne das primäre PDF-document
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ein weiteres PDF-Dokument zum Anhängen öffnen
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Seiten aus einem anderen PDF-Dokument anhängen
+    pdf.append(&another_pdf)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/append_pages/_index.md
+++ b/german/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt ausgewählte Seiten aus einem anderen PDF-document hinzu."
+type: docs
+url: /de/rust-cpp/core/append_pages/
+---
+
+_Fügt ausgewählte Seiten aus einem anderen PDF-document hinzu._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne das primäre PDF-document
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Ein weiteres PDF-Dokument zum Anhängen öffnen
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Füge bestimmte Seiten (1 und 3) aus einem anderen PDF-document hinzu
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/bytes/_index.md
+++ b/german/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Bytes"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt den Inhalt des PDF-Dokuments als Byte-Vektor zurück."
+type: docs
+url: /de/rust-cpp/core/bytes/
+---
+
+_Gibt den Inhalt des PDF-Dokuments als Byte-Vektor zurück._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Gib den Inhalt des PDF-Dokuments als Byte-Vektor zurück
+    let data = pdf.bytes()?;
+
+    // Länge des Byte-Vektors ausgeben
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/character_count/_index.md
+++ b/german/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt die Zeichenanzahl im PDF-Dokument zurück."
+type: docs
+url: /de/rust-cpp/core/character_count/
+---
+
+_Gibt die Zeichenanzahl im PDF-Dokument zurück._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Gib die Zeichenanzahl im PDF-Dokument zurück
+    let count = pdf.character_count()?;
+
+    // Zeichenanzahl ausgeben
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/clear_meta_info/_index.md
+++ b/german/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Löscht alle Meta-Informationswerte des PDF-documents."
+type: docs
+url: /de/rust-cpp/core/clear_meta_info/
+---
+
+_Löscht alle Meta-Informationswerte des PDF-documents._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lösche alle Meta-Informationswerte des PDF-documents
+    pdf.clear_meta_info()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/extract_text/_index.md
+++ b/german/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt den Inhalt des PDF-Dokuments als Klartext zurück."
+type: docs
+url: /de/rust-cpp/core/extract_text/
+---
+
+_Gibt den Inhalt des PDF-Dokuments als Klartext zurück._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Gib den Inhalt des PDF-Dokuments als Klartext zurück
+    let txt = pdf.extract_text()?;
+
+    // Extrahierten Text ausgeben
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/get_meta_info/_index.md
+++ b/german/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ermittelt den Metainformationswert des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/core/get_meta_info/
+---
+
+_Ermittelt den Metainformationswert des PDF-Dokuments._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Erhalte den Metainformationswert des PDF-Dokuments
+    let author = pdf.get_meta_info("Author")?;
+
+    // Gib das Ergebnis aus
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/is_linearized/_index.md
+++ b/german/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ermittelt einen Wert, der angibt, ob das Dokument linearisiert ist."
+type: docs
+url: /de/rust-cpp/core/is_linearized/
+---
+
+_Ermittelt einen Wert, der angibt, ob das Dokument linearisiert ist._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Erhalte einen Wert, der angibt, ob das Dokument linearisiert ist
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/merge_documents/_index.md
+++ b/german/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erstellt ein neues PDF-document durch Zusammenführen der bereitgestellten PDF-documents."
+type: docs
+url: /de/rust-cpp/core/merge_documents/
+---
+
+_Erstellt ein neues PDF-document durch Zusammenführen der bereitgestellten PDF-documents._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf1 = Document::new()?;
+
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Erstelle ein neues PDF-document durch Zusammenführen der bereitgestellten PDF-documents
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/new/_index.md
+++ b/german/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "neu"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erstellt ein neues PDF-Dokument."
+type: docs
+url: /de/rust-cpp/core/new/
+---
+
+_Erstellt ein neues PDF-Dokument._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/open/_index.md
+++ b/german/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Öffnet ein PDF-Dokument mit Dateinamen."
+type: docs
+url: /de/rust-cpp/core/open/
+---
+
+_Öffnet ein PDF-Dokument mit Dateinamen._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_add/_index.md
+++ b/german/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt dem PDF-Dokument eine neue Seite hinzu."
+type: docs
+url: /de/rust-cpp/core/page_add/
+---
+
+_Fügt dem PDF-Dokument eine neue Seite hinzu._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Neue Seite im PDF-Dokument hinzufügen
+    pdf.page_add()?;
+
+    // Speichere das zuvor geöffnete PDF-document
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_character_count/_index.md
+++ b/german/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt die Zeichenanzahl auf der angegebenen Seite im PDF-Dokument zurück."
+type: docs
+url: /de/rust-cpp/core/page_character_count/
+---
+
+_Gibt die Zeichenanzahl auf der angegebenen Seite im PDF-Dokument zurück._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Geben Sie die Seitennummer an (1-basierter Index)
+    let page_number = 1;
+
+    // Gib die Zeichenanzahl auf der angegebenen Seite zurück
+    let count = pdf.page_character_count(page_number)?;
+
+    // Zeichenanzahl ausgeben
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_count/_index.md
+++ b/german/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt die Anzahl der Seiten im PDF-document zurück."
+type: docs
+url: /de/rust-cpp/core/page_count/
+---
+
+_Gibt die Anzahl der Seiten im PDF-document zurück._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Gib die Seitenanzahl im PDF-document zurück
+    let count = pdf.page_count()?;
+
+    // Gib die Seitenanzahl aus
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_delete/_index.md
+++ b/german/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Löscht die angegebene Seite aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/core/page_delete/
+---
+
+_Löscht die angegebene Seite aus dem PDF-Dokument._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lösche die angegebene Seite im PDF-Dokument
+    pdf.page_delete(1)?;
+
+    // Speichere das zuvor geöffnete PDF-document
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_insert/_index.md
+++ b/german/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt eine neue Seite an der angegebenen Position im PDF-document ein."
+type: docs
+url: /de/rust-cpp/core/page_insert/
+---
+
+_Fügt eine neue Seite an der angegebenen Position im PDF-document ein._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Füge neue Seite an der angegebenen Position im PDF-document ein
+    pdf.page_insert(1)?;
+
+    // Speichere das zuvor geöffnete PDF-document
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_is_blank/_index.md
+++ b/german/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gib zurück, ob die Seite im PDF-Dokument leer ist."
+type: docs
+url: /de/rust-cpp/core/page_is_blank/
+---
+
+_Rückgabeseite ist im PDF-Dokument leer._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Geben Sie die Seitennummer an (1-basierter Index)
+    let page_number = 1;
+
+    // Rückgabeseite ist im PDF-Dokument leer
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Ausgeben, wenn die angegebene Seite leer ist
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/page_word_count/_index.md
+++ b/german/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt die Wortanzahl auf der angegebenen Seite im PDF-Dokument zurück."
+type: docs
+url: /de/rust-cpp/core/page_word_count/
+---
+
+_Gibt die Wortanzahl auf der angegebenen Seite im PDF-Dokument zurück._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Geben Sie die Seitennummer an (1-basierter Index)
+    let page_number = 1;
+
+    // Gib die Wortanzahl auf der angegebenen Seite zurück
+    let count = pdf.page_word_count(page_number)?;
+
+    // Gib die Wortanzahl aus
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/save/_index.md
+++ b/german/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Speichert das zuvor geöffnete PDF-Dokument."
+type: docs
+url: /de/rust-cpp/core/save/
+---
+
+_Speichert das zuvor geöffnete PDF-Dokument._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Speichere das zuvor geöffnete PDF-document
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/save_as/_index.md
+++ b/german/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Speichert das zuvor geöffnete PDF-Dokument mit einem neuen Dateinamen."
+type: docs
+url: /de/rust-cpp/core/save_as/
+---
+
+_Speichert das zuvor geöffnete PDF-Dokument mit einem neuen Dateinamen._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Speichere das PDF-Dokument mit neuem Dateinamen
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/set_license/_index.md
+++ b/german/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Setzt die Lizenz mit Dateinamen."
+type: docs
+url: /de/rust-cpp/core/set_license/
+---
+
+_Setzt die Lizenz mit Dateinamen._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lizenz mit Dateinamen setzen
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Jetzt können Sie mit dem lizenzierten PDF-Dokument arbeiten
+    // ...
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/set_meta_info/_index.md
+++ b/german/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Setzt den Meta-Informationswert des PDF-documents."
+type: docs
+url: /de/rust-cpp/core/set_meta_info/
+---
+
+_Setzt den Meta-Informationswert des PDF-documents._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Setze Meta-Informationswert des PDF-documents
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/split/_index.md
+++ b/german/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erstellt mehrere neue PDF-documents, indem Seiten aus dem aktuellen PDF-document extrahiert werden."
+type: docs
+url: /de/rust-cpp/core/split/
+---
+
+_Erstellt mehrere neue PDF-documents, indem Seiten aus dem aktuellen PDF-document extrahiert werden._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Erstelle mehrere neue PDF-documents, indem Seiten aus dem aktuellen PDF-document extrahiert werden
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Speichere jeden geteilten Teil als separates PDF-document
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/split_at/_index.md
+++ b/german/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Teilt das aktuelle PDF-Dokument in zwei neue PDF-Dokumente."
+type: docs
+url: /de/rust-cpp/core/split_at/
+---
+
+_Teilt das aktuelle PDF-Dokument in zwei neue PDF-Dokumente._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Teile das aktuelle PDF-Dokument in zwei neue PDF-Dokumente
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Speichere jeden geteilten Teil als separates PDF-document
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/split_at_page/_index.md
+++ b/german/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Teilt das PDF-document in zwei neue PDF-documents."
+type: docs
+url: /de/rust-cpp/core/split_at_page/
+---
+
+_Teilt das PDF-document in zwei neue PDF-documents._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Teile das PDF-document in zwei neue PDF-documents
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Speichere jeden geteilten Teil als separates PDF-document
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/split_document/_index.md
+++ b/german/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erstellt mehrere neue PDF-documents, indem Seiten aus dem Quell-PDF-document extrahiert werden."
+type: docs
+url: /de/rust-cpp/core/split_document/
+---
+
+_Erstellt mehrere neue PDF-documents, indem Seiten aus dem Quell-PDF-document extrahiert werden._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document mit dem Namen "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Erstellt mehrere neue PDF-documents, indem Seiten aus dem Quell-PDF-document extrahiert werden
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Speichere jeden geteilten Teil als separates PDF-document
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/core/word_count/_index.md
+++ b/german/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt die Wortanzahl im PDF-Dokument zurück."
+type: docs
+url: /de/rust-cpp/core/word_count/
+---
+
+_Gibt die Wortanzahl im PDF-Dokument zurück._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Gib die Wortanzahl im PDF-Dokument zurück
+    let count = pdf.word_count()?;
+
+    // Gib die Wortanzahl aus
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/miscellaneous/_index.md
+++ b/german/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Verschiedene Funktionen"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Verschiedene Funktionen für die Arbeit."
+type: docs
+url: /de/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [about](./about/) | Gib Metadateninformationen über Aspose.PDF für Rust via C++ zurück. |
+
+
+## Detailed Description
+
+Verschiedene Funktionen für die Arbeit.
+

--- a/german/rust-cpp/miscellaneous/about/_index.md
+++ b/german/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "über"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Gibt Metadateninformationen über das Aspose.PDF für Rust über C++ zurück."
+type: docs
+url: /de/rust-cpp/miscellaneous/about/
+---
+
+_Gibt Metadateninformationen über das Aspose.PDF für Rust über C++ zurück._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Gibt Metadateninformationen über das Aspose.PDF für Go über C++ zurück.
+    let info = pdf.about()?;
+
+    // Metadatenfelder drucken
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/_index.md
+++ b/german/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PDF-Organisationsfunktionen"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Funktionen zum Organisieren von PDF-Dateien."
+type: docs
+url: /de/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Optimieren Sie den Inhalt des PDF-Dokuments. |
+| [optimize_resource](./optimize_resource/) | Optimieren Sie die Ressourcen des PDF-Dokuments. |
+| [grayscale](./grayscale/) | Konvertieren Sie das PDF-Dokument in Schwarzweiß. |
+| [rotate](./rotate/) | Drehen Sie das PDF-Dokument. |
+| [set_background](./set_background/) | Legen Sie die Hintergrundfarbe des PDF-Dokuments mit RGB-Werten fest. |
+| [repair](./repair/) | Reparieren Sie das PDF-Dokument. |
+| [replace_text](./replace_text/) | Ersetzen Sie Text im PDF-Dokument |
+| [add_page_num](./add_page_num/) | Fügen Sie einem PDF-Dokument eine Seitenzahl hinzu |
+| [add_text_header](./add_text_header/) | Fügen Sie Text in die Kopfzeile eines PDF-Dokuments ein |
+| [add_text_footer](./add_text_footer/) | Fügen Sie Text in die Fußzeile eines PDF-Dokuments ein |
+| [flatten](./flatten/) | PDF-Dokument flachlegen |
+| [remove_annotations](./remove_annotations/) | Entfernen Sie Anmerkungen aus dem PDF-Dokument |
+| [remove_attachments](./remove_attachments/) | Entfernen Sie Anhänge aus dem PDF-Dokument |
+| [remove_blank_pages](./remove_blank_pages/) | Entfernen Sie leere Seiten aus dem PDF-Dokument |
+| [remove_bookmarks](./remove_bookmarks/) | Entfernen Sie Lesezeichen aus dem PDF-Dokument |
+| [remove_hidden_text](./remove_hidden_text/) | Entfernen Sie versteckten Text aus dem PDF-Dokument |
+| [remove_images](./remove_images/) | Entfernen Sie Bilder aus dem PDF-Dokument |
+| [remove_javascripts](./remove_javascripts/) | Entfernen Sie JavaScript aus dem PDF-Dokument |
+| [remove_tables](./remove_tables/) | Entfernen Sie Tabellen aus einem PDF-Dokument. |
+| [remove_watermarks](./remove_watermarks/) | Entfernen Sie Wasserzeichen aus dem PDF-Dokument. |
+| [add_watermark](./add_watermark/) | Fügen Sie ein Wasserzeichen zum PDF-Dokument hinzu. |
+| [embed_fonts](./embed_fonts/) | Schriftarten in ein PDF-Dokument einbetten. |
+| [unembed_fonts](./unembed_fonts/) | Schriftarten aus einem PDF-Dokument entfernen. |
+| [optimize_file_size](./optimize_file_size/) | Größe des PDF-Dokuments mit Bildkomprimierungsqualität optimieren. |
+| [remove_text_headers](./remove_text_headers/) | Textkopfzeilen aus dem PDF-Dokument entfernen. |
+| [remove_text_footers](./remove_text_footers/) | Textfußzeilen aus dem PDF-Dokument entfernen. |
+| [crop](./crop/) | Seiten eines PDF-Dokuments zuschneiden. |
+| [replace_font](./replace_font/) | Schriftart in einem PDF-Dokument ersetzen. |
+| [convert](./convert/) | Ein PDF-Dokument in ein PDF-Dokument mit dem angegebenen PDF-Format konvertieren |
+| [validate](./validate/) | Ein PDF-Dokument auf Konformität mit dem PDF-Format prüfen |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | PDF/A-Konformität aus einem PDF-Dokument entfernen |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | PDF/UA-Konformität aus einem PDF-Dokument entfernen |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Ermitteln, ob ein PDF-Dokument PDF/A-konform ist |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Ermitteln, ob ein PDF-Dokument PDF/UA-konform ist |
+| [page_rotate](./page_rotate/) | Eine Seite im PDF-Dokument drehen. |
+| [page_set_size](./page_set_size/) | Die Größe einer Seite im PDF-Dokument festlegen. |
+| [page_grayscale](./page_grayscale/) | Seite in Schwarzweiß konvertieren. |
+| [page_add_text](./page_add_text/) | Text auf der Seite hinzufügen. |
+| [page_replace_text](./page_replace_text/) | Text auf der Seite ersetzen |
+| [page_add_page_num](./page_add_page_num/) | Seitennummer auf der Seite hinzufügen |
+| [page_add_text_header](./page_add_text_header/) | Text in der Seitenkopfzeile hinzufügen |
+| [page_add_text_footer](./page_add_text_footer/) | Text in der Seitenfußzeile hinzufügen |
+| [page_remove_annotations](./page_remove_annotations/) | Anmerkungen auf der Seite entfernen. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Versteckten Text auf der Seite entfernen. |
+| [page_remove_images](./page_remove_images/) | Bilder auf der Seite entfernen. |
+| [page_remove_tables](./page_remove_tables/) | Tabellen auf der Seite entfernen. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Wasserzeichen auf der Seite entfernen. |
+| [page_add_watermark](./page_add_watermark/) | Wasserzeichen auf der Seite hinzufügen. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Textkopfzeilen auf der Seite entfernen. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Textfußzeilen auf der Seite entfernen. |
+| [page_crop](./page_crop/) | Eine Seite zuschneiden. |
+| [page_replace_font](./page_replace_font/) | Schriftart auf der Seite ersetzen. |
+| [page_merge_layers](./page_merge_layers/) | Alle Ebenen auf der Seite zu einer einzigen Ebene mit dem angegebenen neuen Ebenennamen zusammenführen. |
+| [page_layers](./page_layers/) | Namen der Ebenen auf der Seite abrufen. |
+
+
+## Detailed Description
+
+Funktionen zum Organisieren von PDF-Dateien.

--- a/german/rust-cpp/organize/add_page_num/_index.md
+++ b/german/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt einer PDF-document Seitenzahl hinzu."
+type: docs
+url: /de/rust-cpp/organize/add_page_num/
+---
+
+_Fügt einer PDF-document Seitenzahl hinzu._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Fügen Sie einem PDF-Dokument eine Seitenzahl hinzu
+    pdf.add_page_num()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/add_text_footer/_index.md
+++ b/german/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt Text in die Fußzeile einer PDF-document ein."
+type: docs
+url: /de/rust-cpp/organize/add_text_footer/
+---
+
+_Fügt Text in die Fußzeile einer PDF-document ein._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Fügen Sie Text in die Fußzeile eines PDF-Dokuments ein
+    pdf.add_text_footer("FOOTER")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/add_text_header/_index.md
+++ b/german/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt Text in die Kopfzeile eines PDF-Dokuments ein."
+type: docs
+url: /de/rust-cpp/organize/add_text_header/
+---
+
+_Fügt Text in die Kopfzeile eines PDF-Dokuments ein._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Fügen Sie Text in die Kopfzeile eines PDF-Dokuments ein
+    pdf.add_text_header("HEADER")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/add_watermark/_index.md
+++ b/german/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt ein Wasserzeichen zu PDF-document hinzu."
+type: docs
+url: /de/rust-cpp/organize/add_watermark/
+---
+
+_Fügt ein Wasserzeichen zu PDF-document hinzu._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Wasserzeichen zu PDF-document hinzufügen
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/convert/_index.md
+++ b/german/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert ein PDF-document in ein PDF-document mit dem angegebenen PDF-Format."
+type: docs
+url: /de/rust-cpp/organize/convert/
+---
+
+_Konvertiert ein PDF-document in ein PDF-document mit dem angegebenen PDF-Format._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ein PDF-Dokument in ein PDF-Dokument mit dem angegebenen PDF-Format konvertieren
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Konvertierungsergebnis und vollständiges Protokoll ausgeben
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/crop/_index.md
+++ b/german/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "beschneiden"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Beschneidet Seiten eines PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/organize/crop/
+---
+
+_Beschneidet Seiten eines PDF-Dokuments._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Seiten eines PDF-Dokuments beschneiden
+    pdf.crop(10.5)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/embed_fonts/_index.md
+++ b/german/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Bettet Schriftarten in ein PDF-Dokument ein."
+type: docs
+url: /de/rust-cpp/organize/embed_fonts/
+---
+
+_Bettet Schriftarten in ein PDF-Dokument ein._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Schriftarten in ein PDF-Dokument einbetten
+    pdf.embed_fonts()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/flatten/_index.md
+++ b/german/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Flacht das PDF-Dokument ab."
+type: docs
+url: /de/rust-cpp/organize/flatten/
+---
+
+_Flacht das PDF-Dokument ab._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Gib den Inhalt des PDF-Dokuments als Klartext zurück
+    let txt = pdf.extract_text()?;
+
+    // Extrahierten Text ausgeben
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/grayscale/_index.md
+++ b/german/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert das PDF-Dokument in Schwarzweiß."
+type: docs
+url: /de/rust-cpp/organize/grayscale/
+---
+
+_Konvertiert das PDF-Dokument in Schwarzweiß._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertiere PDF-Dokument in Schwarzweiß
+    pdf.grayscale()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/german/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ermittelt, ob ein PDF-Dokument PDF/A-konform ist."
+type: docs
+url: /de/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Ermittelt, ob ein PDF-Dokument PDF/A-konform ist._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF/A-Konformitätsstatus des PDF-Dokuments abrufen
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/german/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ermittelt, ob ein PDF-Dokument PDF/UA-konform ist."
+type: docs
+url: /de/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Ermittelt, ob ein PDF-Dokument PDF/UA-konform ist._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Erhalte den PDF/UA-Konformitätsstatus des PDF-Dokuments
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/optimize/_index.md
+++ b/german/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Optimiert den Inhalt des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/organize/optimize/
+---
+
+_Optimiert den Inhalt des PDF-Dokuments._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimieren Sie den Inhalt des PDF-Dokuments
+    pdf.optimize()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/optimize_file_size/_index.md
+++ b/german/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Optimiert die Größe eines PDF-Dokuments mit Bildkomprimierungsqualität."
+type: docs
+url: /de/rust-cpp/organize/optimize_file_size/
+---
+
+_Optimiert die Größe eines PDF-Dokuments mit Bildkomprimierungsqualität._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimieren Sie die Größe eines PDF-Dokuments mit Bildkomprimierungsqualität
+    pdf.optimize_file_size(50)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/optimize_resource/_index.md
+++ b/german/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Optimiert Ressourcen des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/organize/optimize_resource/
+---
+
+_Optimiert Ressourcen des PDF-Dokuments._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ressourcen des PDF-Dokuments optimieren
+    pdf.optimize_resource()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_add_page_num/_index.md
+++ b/german/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt die Seitenzahl auf der Seite ein."
+type: docs
+url: /de/rust-cpp/organize/page_add_page_num/
+---
+
+_Fügt die Seitenzahl auf der Seite ein._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Seitennummer auf der Seite hinzufügen
+    pdf.page_add_page_num(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_add_text/_index.md
+++ b/german/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt einer Seite Text hinzu."
+type: docs
+url: /de/rust-cpp/organize/page_add_text/
+---
+
+_Fügt einer Seite Text hinzu._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Text auf Seite hinzufügen
+    pdf.page_add_text(1, "added text")?;
+
+    // Speichere das zuvor geöffnete PDF-document
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/german/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt Text in die Seitenfußzeile ein."
+type: docs
+url: /de/rust-cpp/organize/page_add_text_footer/
+---
+
+_Fügt Text in die Seitenfußzeile ein._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Text in der Seitenfußzeile hinzufügen
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_add_text_header/_index.md
+++ b/german/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt Text in die Seitenkopfzeile ein."
+type: docs
+url: /de/rust-cpp/organize/page_add_text_header/
+---
+
+_Fügt Text in die Seitenkopfzeile ein._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Text in der Seitenkopfzeile hinzufügen
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_add_watermark/_index.md
+++ b/german/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Fügt ein Wasserzeichen auf der Seite hinzu."
+type: docs
+url: /de/rust-cpp/organize/page_add_watermark/
+---
+
+_Fügt ein Wasserzeichen auf der Seite hinzu._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Wasserzeichen auf Seite hinzufügen
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_crop/_index.md
+++ b/german/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Beschneidet eine Seite."
+type: docs
+url: /de/rust-cpp/organize/page_crop/
+---
+
+_Beschneidet eine Seite._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eine Seite beschneiden
+    pdf.page_crop(1, 1.0)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_grayscale/_index.md
+++ b/german/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Konvertiert eine Seite in Schwarzweiß."
+type: docs
+url: /de/rust-cpp/organize/page_grayscale/
+---
+
+_Konvertiert eine Seite in Schwarzweiß._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Seite in Schwarzweiß konvertieren
+    pdf.page_grayscale(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_layers/_index.md
+++ b/german/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ermittelt die Namen der Ebenen auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_layers/
+---
+
+_Ermittelt die Namen der Ebenen auf der Seite._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Erhalte die Namen der Ebenen auf Seite 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_merge_layers/_index.md
+++ b/german/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Führt alle Ebenen auf der Seite zu einer einzigen Ebene mit dem angegebenen neuen Ebenennamen zusammen."
+type: docs
+url: /de/rust-cpp/organize/page_merge_layers/
+---
+
+_Führt alle Ebenen auf der Seite zu einer einzigen Ebene mit dem angegebenen neuen Ebenennamen zusammen._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Alle Ebenen auf der Seite zu einer einzigen Ebene mit dem angegebenen neuen Ebenennamen zusammenführen
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/german/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Anmerkungen auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_annotations/
+---
+
+_Entfernt Anmerkungen auf der Seite._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Anmerkungen auf der Seite entfernen
+    pdf.page_remove_annotations(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/german/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt versteckten Text auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Entfernt versteckten Text auf der Seite._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Versteckten Text auf der Seite entfernen
+    pdf.page_remove_hidden_text(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_images/_index.md
+++ b/german/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Bilder auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_images/
+---
+
+_Entfernt Bilder auf der Seite._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bilder auf der Seite entfernen
+    pdf.page_remove_images(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_tables/_index.md
+++ b/german/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Tabellen auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_tables/
+---
+
+_Entfernt Tabellen auf der Seite._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entferne Tabellen auf der Seite
+    pdf.page_remove_tables(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/german/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Textfußzeilen auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Entfernt Textfußzeilen auf der Seite._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entferne Textfußzeilen auf der Seite
+    pdf.page_remove_text_footers(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/german/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Textkopfzeilen in der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Entfernt Textkopfzeilen in der Seite._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entferne Textkopfzeilen in der Seite
+    pdf.page_remove_text_headers(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/german/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Wasserzeichen auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Entfernt Wasserzeichen auf der Seite._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entferne Wasserzeichen auf der Seite
+    pdf.page_remove_watermarks(1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_replace_font/_index.md
+++ b/german/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ersetzt die Schriftart auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_replace_font/
+---
+
+_Ersetzt die Schriftart auf der Seite._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Schriftart auf der Seite ersetzen
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_replace_text/_index.md
+++ b/german/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ersetzt Text auf der Seite."
+type: docs
+url: /de/rust-cpp/organize/page_replace_text/
+---
+
+_Ersetzt Text auf der Seite._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Text auf der Seite ersetzen
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_rotate/_index.md
+++ b/german/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Dreht eine Seite im PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/page_rotate/
+---
+
+_Dreht eine Seite im PDF-Dokument._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-document aus einer Datei
+    let pdf = Document::open("sample.pdf")?;
+
+    // Seite drehen
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/page_set_size/_index.md
+++ b/german/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Legt die Größe einer Seite im PDF-Dokument fest."
+type: docs
+url: /de/rust-cpp/organize/page_set_size/
+---
+
+_Legt die Größe einer Seite im PDF-Dokument fest._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Setze die Größe einer Seite im PDF-Dokument
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_annotations/_index.md
+++ b/german/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Anmerkungen aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_annotations/
+---
+
+_Entfernt Anmerkungen aus dem PDF-Dokument._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie Anmerkungen aus dem PDF-Dokument
+    pdf.remove_annotations()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_attachments/_index.md
+++ b/german/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Anhänge aus PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_attachments/
+---
+
+_Entfernt Anhänge aus PDF-document._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie Anhänge aus dem PDF-Dokument
+    pdf.remove_attachments()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/german/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt leere Seiten aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_blank_pages/
+---
+
+_Entfernt leere Seiten aus dem PDF-Dokument._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie leere Seiten aus dem PDF-Dokument
+    pdf.remove_blank_pages()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/german/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Lesezeichen aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_bookmarks/
+---
+
+_Entfernt Lesezeichen aus dem PDF-Dokument._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie Lesezeichen aus dem PDF-Dokument
+    pdf.remove_bookmarks()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/german/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt versteckten Text aus PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_hidden_text/
+---
+
+_Entfernt versteckten Text aus PDF-document._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie versteckten Text aus dem PDF-Dokument
+    pdf.remove_hidden_text()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_images/_index.md
+++ b/german/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Bilder aus PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_images/
+---
+
+_Entfernt Bilder aus PDF-document._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie Bilder aus dem PDF-Dokument
+    pdf.remove_images()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_javascripts/_index.md
+++ b/german/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Java-Skripte aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_javascripts/
+---
+
+_Entfernt Java-Skripte aus dem PDF-Dokument._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entfernen Sie JavaScript aus dem PDF-Dokument
+    pdf.remove_javascripts()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/german/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt PDF/A-Konformität aus einem PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Entferne die PDF/A-Konformität von einem PDF-Dokument._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF/A-Konformität aus einem PDF-Dokument entfernen
+    pdf.remove_pdfa_compliance()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/german/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt die PDF/UA-Konformität von einem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Entfernt die PDF/UA-Konformität von einem PDF-Dokument._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF/UA-Konformität aus einem PDF-Dokument entfernen
+    pdf.remove_pdfua_compliance()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_tables/_index.md
+++ b/german/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Tabellen aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_tables/
+---
+
+_Entfernt Tabellen aus dem PDF-Dokument._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Tabellen aus dem PDF-Dokument entfernen
+    pdf.remove_tables()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_text_footers/_index.md
+++ b/german/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Textfußzeilen aus dem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/remove_text_footers/
+---
+
+_Entfernt Textfußzeilen aus dem PDF-Dokument._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Entferne Textfußzeilen aus dem PDF-Dokument
+    pdf.remove_text_footers()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_text_headers/_index.md
+++ b/german/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Textköpfe aus PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_text_headers/
+---
+
+_Entfernt Textköpfe aus PDF-document._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Textköpfe aus PDF-document entfernen
+    pdf.remove_text_headers()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/remove_watermarks/_index.md
+++ b/german/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt Wasserzeichen aus PDF-document."
+type: docs
+url: /de/rust-cpp/organize/remove_watermarks/
+---
+
+_Entfernt Wasserzeichen aus PDF-document._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Wasserzeichen aus PDF-document entfernen
+    pdf.remove_watermarks()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/repair/_index.md
+++ b/german/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Repariert das PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/repair/
+---
+
+_Repariert das PDF-Dokument._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-Dokument reparieren
+    pdf.repair()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/replace_font/_index.md
+++ b/german/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ersetzt die Schriftart in einem PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/replace_font/
+---
+
+_Ersetzt die Schriftart in einem PDF-Dokument._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Schriftart in einem PDF-Dokument ersetzen.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/replace_text/_index.md
+++ b/german/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Ersetzt Text."
+type: docs
+url: /de/rust-cpp/organize/replace_text/
+---
+
+_Ersetzt Text._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ersetzen Sie Text im PDF-Dokument
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/rotate/_index.md
+++ b/german/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Dreht das PDF-Dokument."
+type: docs
+url: /de/rust-cpp/organize/rotate/
+---
+
+_Dreht das PDF-Dokument._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-Dokument drehen
+    pdf.rotate(Rotation::On270)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/set_background/_index.md
+++ b/german/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Setzt die Hintergrundfarbe des PDF-Dokuments mithilfe von RGB-Werten."
+type: docs
+url: /de/rust-cpp/organize/set_background/
+---
+
+_Setzt die Hintergrundfarbe des PDF-Dokuments mithilfe von RGB-Werten._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Setze die Hintergrundfarbe des PDF-Dokuments mithilfe von RGB-Werten
+    pdf.set_background(200, 100, 101)?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/unembed_fonts/_index.md
+++ b/german/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entfernt eingebettete Schriften aus einem PDF-document."
+type: docs
+url: /de/rust-cpp/organize/unembed_fonts/
+---
+
+_Entfernt eingebettete Schriften aus einem PDF-document._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Schriften aus einem PDF-document entfernen
+    pdf.unembed_fonts()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/organize/validate/_index.md
+++ b/german/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Validiert ein PDF-Dokument auf Konformität mit dem PDF-Format."
+type: docs
+url: /de/rust-cpp/organize/validate/
+---
+
+_Validiert ein PDF-Dokument auf Konformität mit dem PDF-Format._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ein PDF-Dokument auf Konformität mit dem PDF-Format prüfen
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Validierungsergebnis und vollständiges Protokoll ausgeben
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/_index.md
+++ b/german/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Sicherheitsfunktionen"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Sicherheitsfunktionen."
+type: docs
+url: /de/rust-cpp/security/
+---
+
+## Security
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Öffne ein passwortgeschütztes PDF-Dokument. |
+| [encrypt](./encrypt/) | Verschlüssele das PDF-Dokument. |
+| [decrypt](./decrypt/) | Entschlüssele das PDF-Dokument. |
+| [set_permissions](./set_permissions/) | Setze Berechtigungen für das PDF-Dokument. |
+| [get_permissions](./get_permissions/) | Erhalte die aktuellen Berechtigungen des PDF-Dokuments. |
+| [is_encrypted](./is_encrypted/) | Erhalte den verschlüsselten Status des PDF-Dokuments. |
+| [sign_pkcs7](./sign_pkcs7/) | Signiere ein PDF-Dokument mit PKCS#7-Digitalsignaturen. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Signiere ein PDF-Dokument mit PKCS#7-Detached-Digitalsignaturen. |
+| [is_signed](./is_signed/) | Erhalte den signierten Status des PDF-Dokuments. |
+| [remove_signs](./remove_signs/) | Entferne Signaturen vom PDF-Dokument. |
+
+
+## Detailed Description
+
+Sicherheitsfunktionen.
+

--- a/german/rust-cpp/security/decrypt/_index.md
+++ b/german/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "entschlüsseln"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entschlüssele das PDF-Dokument."
+type: docs
+url: /de/rust-cpp/security/decrypt/
+---
+
+_Entschlüsseln PDF-Dokument._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein passwortgeschütztes PDF-Dokument
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Entschlüsseln PDF-Dokument
+    pdf.decrypt()?;
+
+    // Das zuvor geöffnete PDF-Dokument mit neuem Dateinamen speichern
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/encrypt/_index.md
+++ b/german/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "verschlüsseln"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Verschlüssele das PDF-Dokument."
+type: docs
+url: /de/rust-cpp/security/encrypt/
+---
+
+_Verschlüsseln PDF-Dokument._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Verschlüsseln PDF-Dokument
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Speichern Sie das verschlüsselte PDF-Dokument
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/get_permissions/_index.md
+++ b/german/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erhalte die aktuellen Berechtigungen des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/security/get_permissions/
+---
+
+_Abrufen der aktuellen Berechtigungen des PDF-Dokuments._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein passwortgeschütztes PDF-Dokument
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Abrufen der aktuellen Berechtigungen des PDF-Dokuments
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Berechtigungen drucken
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/is_encrypted/_index.md
+++ b/german/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erhalte den verschlüsselten Status des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/security/is_encrypted/
+---
+
+_Abrufen des verschlüsselten Status des PDF-Dokuments._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein passwortgeschütztes PDF-Dokument
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Abrufen des verschlüsselten Status des PDF-Dokuments
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/is_signed/_index.md
+++ b/german/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Erhalte den signierten Status des PDF-Dokuments."
+type: docs
+url: /de/rust-cpp/security/is_signed/
+---
+
+_Den Signaturstatus des PDF-Dokuments abrufen._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein PDF-Dokument mit dem Namen "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Signaturstatus des PDF-Dokuments abrufen
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/open_with_password/_index.md
+++ b/german/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Öffne ein passwortgeschütztes PDF-Dokument."
+type: docs
+url: /de/rust-cpp/security/open_with_password/
+---
+
+_Öffnen Sie ein passwortgeschütztes PDF-Dokument._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein passwortgeschütztes PDF-Dokument
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // arbeitet...
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/remove_signs/_index.md
+++ b/german/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Entferne Signaturen vom PDF-Dokument."
+type: docs
+url: /de/rust-cpp/security/remove_signs/
+---
+
+_Entfernen von Signaturen aus dem PDF-Dokument._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öffnen Sie ein PDF-Dokument mit dem Namen "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Entfernen von Signaturen aus dem PDF-Dokument
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/set_permissions/_index.md
+++ b/german/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Setze Berechtigungen für das PDF-Dokument."
+type: docs
+url: /de/rust-cpp/security/set_permissions/
+---
+
+_Berechtigungen für PDF-Dokument festlegen._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Erstelle ein neues PDF-Dokument
+    let pdf = Document::new()?;
+
+    // Setze Berechtigungen für das PDF-Dokument.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Speichern Sie das PDF-Dokument mit den aktualisierten Berechtigungen
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/sign_pkcs7/_index.md
+++ b/german/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Signiere ein PDF-Dokument mit PKCS#7-Digitalsignaturen."
+type: docs
+url: /de/rust-cpp/security/sign_pkcs7/
+---
+
+_Signieren Sie ein PDF-Dokument mit PKCS#7-Digitalsignaturen._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Lesen Sie Zertifikats- und Bilddateien in Byte-Vektoren ein
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signieren Sie ein PDF-Dokument mit PKCS#7-Digitalsignaturen
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/german/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/german/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF für Rust über C++"
+description: "Signiere ein PDF-Dokument mit PKCS#7-Detached-Digitalsignaturen."
+type: docs
+url: /de/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Signieren Sie ein PDF-Dokument mit PKCS#7-Detached-Digitalsignaturen._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Lesen Sie Zertifikats- und Bilddateien in Byte-Vektoren ein
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Öffne ein PDF-Dokument mit Dateiname
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signieren Sie ein PDF-Dokument mit PKCS#7-Detached-Digitalsignaturen
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
🔄 **In progress** — incremental translation of RUST-CPP API Reference to **German** (`de`).

Updated at each cache checkpoint. Source: `english/rust-cpp`

🤖 Generated by RDA