### PR TITLE
[draft] Translate RUST-CPP API Reference to Italian

### DIFF
--- a/italian/rust-cpp/_index.md
+++ b/italian/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF per Rust tramite C++"
+description: "Aspose.PDF per Rust tramite C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /it/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Strutture
+
+## Document
+Document rappresenta un documento PDF.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Converti e salva il PDF-document precedentemente aperto come documento DocX. |
+| [save_doc](./convert/save_doc/) | Converti e salva il PDF-document precedentemente aperto come documento Doc. |
+| [save_xlsx](./convert/save_xlsx/) | Converti e salva il PDF-document precedentemente aperto come documento XlsX. |
+| [save_txt](./convert/save_txt/) | Converti e salva il PDF-document precedentemente aperto come documento Txt. |
+| [save_pptx](./convert/save_pptx/) | Converti e salva il PDF-document precedentemente aperto come documento PptX. |
+| [save_xps](./convert/save_xps/) | Converti e salva il PDF-document precedentemente aperto come documento Xps. |
+| [save_tex](./convert/save_tex/) | Converti e salva il PDF-document precedentemente aperto come documento TeX. |
+| [save_epub](./convert/save_epub/) | Converti e salva il PDF-document precedentemente aperto come documento Epub. |
+| [save_booklet](./convert/save_booklet/) | Converti e salva il PDF-document precedentemente aperto come documento PDF a libretto. |
+| [save_n_up](./convert/save_n_up/) | Converti e salva il PDF-document precedentemente aperto come documento PDF N-Up. |
+| [save_markdown](./convert/save_markdown/) | Converti e salva il PDF-document precedentemente aperto come documento Markdown. |
+| [save_tiff](./convert/save_tiff/) | Converti e salva il PDF-document precedentemente aperto come documento Tiff. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Converti e salva il PDF-document precedentemente aperto come documento DocX con Modalità di Riconoscimento Avanzata (tabelle e paragrafi completamente modificabili). |
+| [save_svg_zip](./convert/save_svg_zip/) | Converti e salva il PDF-document precedentemente aperto come archivio SVG. |
+| [export_fdf](./convert/export_fdf/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento FDF. |
+| [export_xfdf](./convert/export_xfdf/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento XFDF. |
+| [export_xml](./convert/export_xml/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento XML. |
+| [page_to_jpg](./convert/page_to_jpg/) | Converti e salva la pagina specificata come immagine Jpg. |
+| [page_to_png](./convert/page_to_png/) | Converti e salva la pagina specificata come immagine Png. |
+| [page_to_bmp](./convert/page_to_bmp/) | Converti e salva la pagina specificata come immagine Bmp. |
+| [page_to_tiff](./convert/page_to_tiff/) | Converti e salva la pagina specificata come immagine Tiff. |
+| [page_to_svg](./convert/page_to_svg/) | Converti e salva la pagina specificata come immagine Svg. |
+| [page_to_pdf](./convert/page_to_pdf/) | Converti e salva la pagina specificata come documento PDF. |
+| [page_to_dicom](./convert/page_to_dicom/) | Converti e salva la pagina specificata come immagine DICOM. |
+
+
+## Organize PDF functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Ottimizza il contenuto del documento PDF. |
+| [optimize_resource](./organize/optimize_resource/) | Ottimizza le risorse del documento PDF. |
+| [grayscale](./organize/grayscale/) | Converti il documento PDF in bianco e nero. |
+| [rotate](./organize/rotate/) | Ruota il documento PDF. |
+| [set_background](./organize/set_background/) | Imposta il colore di sfondo del documento PDF usando valori RGB. |
+| [repair](./organize/repair/) | Ripara il documento PDF. |
+| [replace_text](./organize/replace_text/) | Sostituisci il testo nel documento PDF |
+| [add_page_num](./organize/add_page_num/) | Aggiungi il numero di pagina a un documento PDF |
+| [add_text_header](./organize/add_text_header/) | Aggiungi testo nell'intestazione di un documento PDF |
+| [add_text_footer](./organize/add_text_footer/) | Aggiungi testo nel piè di pagina di un documento PDF |
+| [flatten](./organize/flatten/) | Appiattisci il documento PDF |
+| [remove_annotations](./organize/remove_annotations/) | Rimuovi le annotazioni dal documento PDF |
+| [remove_attachments](./organize/remove_attachments/) | Rimuovi gli allegati dal documento PDF |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Rimuovi le pagine vuote dal documento PDF |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Rimuovi i segnalibri dal documento PDF |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Rimuovi il testo nascosto dal documento PDF |
+| [remove_images](./organize/remove_images/) | Rimuovi le immagini dal documento PDF |
+| [remove_javascripts](./organize/remove_javascripts/) | Rimuovi gli script Java dal documento PDF |
+| [remove_tables](./organize/remove_tables/) | Rimuovi le tabelle da un documento PDF. |
+| [remove_watermarks](./organize/remove_watermarks/) | Rimuovi le filigrane dal documento PDF. |
+| [add_watermark](./organize/add_watermark/) | Aggiungi una filigrana al documento PDF. |
+| [embed_fonts](./organize/embed_fonts/) | Incorpora i caratteri in un documento PDF. |
+| [unembed_fonts](./organize/unembed_fonts/) | Rimuovi l'incorporamento dei caratteri da un documento PDF. |
+| [optimize_file_size](./organize/optimize_file_size/) | Ottimizza le dimensioni del documento PDF con la qualità di compressione delle immagini. |
+| [remove_text_headers](./organize/remove_text_headers/) | Rimuovi le intestazioni di testo dal documento PDF. |
+| [remove_text_footers](./organize/remove_text_footers/) | Rimuovi i piè di pagina di testo dal documento PDF. |
+| [crop](./organize/crop/) | Ritaglia le pagine di un documento PDF. |
+| [replace_font](./organize/replace_font/) | Sostituisci il carattere in un documento PDF. |
+| [convert](./organize/convert/) | Converti un documento PDF in un documento PDF con il formato PDF specificato |
+| [validate](./organize/validate/) | Convalida un documento PDF per la conformità al formato PDF |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Rimuovi la conformità PDF/A da un documento PDF |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Rimuovi la conformità PDF/UA da un documento PDF |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Verifica se un documento PDF è conforme a PDF/A |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Verifica se un documento PDF è conforme a PDF/UA |
+| [page_rotate](./organize/page_rotate/) | Ruota una pagina nel documento PDF. |
+| [page_set_size](./organize/page_set_size/) | Imposta le dimensioni di una pagina nel documento PDF. |
+| [page_grayscale](./organize/page_grayscale/) | Converti la pagina in bianco e nero. |
+| [page_add_text](./organize/page_add_text/) | Aggiungi testo sulla pagina. |
+| [page_replace_text](./organize/page_replace_text/) | Sostituisci il testo sulla pagina |
+| [page_add_page_num](./organize/page_add_page_num/) | Aggiungi il numero di pagina sulla pagina |
+| [page_add_text_header](./organize/page_add_text_header/) | Aggiungi testo nell'intestazione della pagina |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Aggiungi testo nel piè di pagina della pagina |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Rimuovi le annotazioni nella pagina. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Rimuovi il testo nascosto nella pagina. |
+| [page_remove_images](./organize/page_remove_images/) | Rimuovi le immagini nella pagina. |
+| [page_remove_tables](./organize/page_remove_tables/) | Rimuovi le tabelle nella pagina. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Rimuovi le filigrane nella pagina. |
+| [page_add_watermark](./organize/page_add_watermark/) | Aggiungi una filigrana nella pagina. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Rimuovi le intestazioni di testo nella pagina. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Rimuovi i piè di pagina di testo nella pagina. |
+| [page_crop](./organize/page_crop/) | Ritaglia una pagina. |
+| [page_replace_font](./organize/page_replace_font/) | Sostituisci il carattere nella pagina. |
+| [page_merge_layers](./organize/page_merge_layers/) | Unisci tutti i livelli nella pagina in un unico livello con il nome del nuovo livello specificato. |
+| [page_layers](./organize/page_layers/) | Ottieni i nomi dei livelli nella pagina. |
+
+
+## Core PDF functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [new](./core/new/) | Crea un nuovo documento PDF. |
+| [open](./core/open/) | Apri un documento PDF con il nome file. |
+| [save](./core/save/) | Salva il documento PDF precedentemente aperto. |
+| [save_as](./core/save_as/) | Salva il documento PDF precedentemente aperto con un nuovo nome file. |
+| [set_license](./core/set_license/) | Imposta la licenza con il nome file. |
+| [extract_text](./core/extract_text/) | Restituisci il contenuto del documento PDF come testo semplice. |
+| [word_count](./core/word_count/) | Restituisci il conteggio delle parole nel documento PDF. |
+| [character_count](./core/character_count/) | Restituisci il conteggio dei caratteri nel documento PDF. |
+| [append](./core/append/) | Aggiungi pagine da un altro documento PDF. |
+| [append_pages](./core/append_pages/) | Aggiungi le pagine selezionate da un altro documento PDF. |
+| [merge_documents](./core/merge_documents/) | Crea un nuovo documento PDF unendo i documenti PDF forniti. |
+| [split_document](./core/split_document/) | Crea più nuovi documenti PDF estraendo pagine dal documento PDF sorgente. |
+| [split](./core/split/) | Crea più nuovi documenti PDF estraendo pagine dal documento PDF corrente. |
+| [split_at_page](./core/split_at_page/) | Dividi il documento PDF in due nuovi documenti PDF. |
+| [split_at](./core/split_at/) | Dividi il documento PDF corrente in due nuovi documenti PDF. |
+| [bytes](./core/bytes/) | Restituisci il contenuto del documento PDF come un vettore di byte. |
+| [get_meta_info](./core/get_meta_info/) | Ottieni il valore delle informazioni meta del documento PDF. |
+| [set_meta_info](./core/set_meta_info/) | Imposta il valore delle meta‑informazioni del PDF-document. |
+| [clear_meta_info](./core/clear_meta_info/) | Cancella tutti i valori delle meta‑informazioni del PDF-document. |
+| [is_linearized](./core/is_linearized/) | Ottieni un valore che indica se il documento è linearizzato. |
+| [page_add](./core/page_add/) | Aggiungi una nuova pagina nel PDF-document. |
+| [page_insert](./core/page_insert/) | Inserisci una nuova pagina nella posizione specificata nel PDF-document. |
+| [page_delete](./core/page_delete/) | Elimina la pagina specificata nel PDF-document. |
+| [page_count](./core/page_count/) | Restituisci il numero di pagine nel PDF-document. |
+| [page_word_count](./core/page_word_count/) | Restituisci il conteggio delle parole nella pagina specificata del PDF-document. |
+| [page_character_count](./core/page_character_count/) | Restituisci il conteggio dei caratteri nella pagina specificata del PDF-document. |
+| [page_is_blank](./core/page_is_blank/) | Restituisci se la pagina è vuota nel PDF-document. |
+
+
+## Security
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Apri un PDF-document protetto da password. |
+| [encrypt](./security/encrypt/) | Cifra il PDF-document. |
+| [decrypt](./security/decrypt/) | Decifra il PDF-document. |
+| [set_permissions](./security/set_permissions/) | Imposta i permessi per il PDF-document. |
+| [get_permissions](./security/get_permissions/) | Ottieni i permessi attuali del PDF-document. |
+| [is_encrypted](./security/is_encrypted/) | Ottieni lo stato di cifratura del PDF-document. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Firma un PDF-document usando firme digitali PKCS#7. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Firma un PDF-document usando firme digitali PKCS#7 Detached. |
+| [is_signed](./security/is_signed/) | Ottieni lo stato di firma del PDF-document. |
+| [remove_signs](./security/remove_signs/) | Rimuovi le firme dal PDF-document. |
+
+
+## Miscellaneous
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Restituisci le informazioni dei metadati su Aspose.PDF per Rust via C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Insieme di bitflag che rappresenta le capacità di permesso PDF.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// Dimensione A0.
+    A0 = 0,
+    /// Dimensione A1.
+    A1 = 1,
+    /// Dimensione A2.
+    A2 = 2,
+    /// dimensione A3.
+    A3 = 3,
+    /// dimensione A4.
+    A4 = 4,
+    /// dimensione A5.
+    A5 = 5,
+    /// dimensione A6.
+    A6 = 6,
+    /// dimensione B5.
+    B5 = 7,
+    /// dimensione PageLetter.
+    PageLetter = 8,
+    /// dimensione PageLegal.
+    PageLegal = 9,
+    /// dimensione PageLedger.
+    PageLedger = 10,
+    /// dimensione P11x17.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Non ruotato.
+    None = 0,
+    /// Ruotato di 90 gradi in senso orario.
+    On90 = 1,
+    /// Ruotato di 180 gradi.
+    On180 = 2,
+    /// Ruotato di 270 gradi in senso orario.
+    On270 = 3,
+    /// Ruotato di 360 gradi in senso orario.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 con lunghezza chiave 40.
+    RC4x40 = 0,
+    /// RC4 con lunghezza chiave 128.
+    RC4x128 = 1,
+    /// AES con lunghezza chiave 128.
+    AESx128 = 2,
+    /// AES con lunghezza chiave 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// formato PDF/A-1a.
+    PDF_A_1A = 0,
+    /// formato PDF/A-1b.
+    PDF_A_1B = 1,
+    /// formato PDF/A-2a.
+    PDF_A_2A = 2,
+    /// formato PDF/A-3a.
+    PDF_A_3A = 3,
+    /// formato PDF/A-2b.
+    PDF_A_2B = 4,
+    /// formato PDF/A-2u.
+    PDF_A_2U = 5,
+    /// formato PDF/A-3b.
+    PDF_A_3B = 6,
+    /// PDF/A-3u formato.
+    PDF_A_3U = 7,
+    /// Adobe versione 1.0.
+    V_1_0 = 8,
+    /// Adobe versione 1.1.
+    V_1_1 = 9,
+    /// Adobe versione 1.2.
+    V_1_2 = 10,
+    /// Adobe versione 1.3.
+    V_1_3 = 11,
+    /// Adobe versione 1.4.
+    V_1_4 = 12,
+    /// Adobe versione 1.5.
+    V_1_5 = 13,
+    /// Adobe versione 1.6.
+    V_1_6 = 14,
+    /// Adobe versione 1.7.
+    V_1_7 = 15,
+    /// Standard ISO PDF 2.0.
+    V_2_0 = 16,
+    /// PDF/UA-1 formato.
+    PDF_UA_1 = 17,
+    /// PDF/X-1a:2001 formato.
+    PDF_X_1A_2001 = 18,
+    /// PDF/X-1a formato.
+    PDF_X_1A = 19,
+    /// PDF/X-3 formato.
+    PDF_X_3 = 20,
+    /// ZUGFeRD formato.
+    ZUGFeRD = 21,
+    /// PDF/A-4 formato.
+    PDF_A_4 = 22,
+    /// PDF/A-4e formato.
+    PDF_A_4E = 23,
+    /// PDF/A-4f formato.
+    PDF_A_4F = 24,
+    /// PDF/X-4 formato.
+    PDF_X_4 = 25,
+    /// PDF/E-1 (PDF 1.6) formato.
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Elimina gli elementi non conformi.
+    Delete = 0,
+    /// Non fare nulla, mantieni gli elementi non conformi.
+    None = 1,
+}
+```
+

--- a/italian/rust-cpp/convert/_index.md
+++ b/italian/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Converti dalle funzioni PDF"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Funzioni per la conversione da file PDF."
+type: docs
+url: /it/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Converti e salva il PDF-document precedentemente aperto come documento DocX. |
+| [save_doc](./save_doc/) | Converti e salva il PDF-document precedentemente aperto come documento Doc. |
+| [save_xlsx](./save_xlsx/) | Converti e salva il PDF-document precedentemente aperto come documento XlsX. |
+| [save_txt](./save_txt/) | Converti e salva il PDF-document precedentemente aperto come documento Txt. |
+| [save_pptx](./save_pptx/) | Converti e salva il PDF-document precedentemente aperto come documento PptX. |
+| [save_xps](./save_xps/) | Converti e salva il PDF-document precedentemente aperto come documento Xps. |
+| [save_tex](./save_tex/) | Converti e salva il PDF-document precedentemente aperto come documento TeX. |
+| [save_epub](./save_epub/) | Converti e salva il PDF-document precedentemente aperto come documento Epub. |
+| [save_booklet](./save_booklet/) | Converti e salva il PDF-document precedentemente aperto come documento PDF a libretto. |
+| [save_n_up](./save_n_up/) | Converti e salva il PDF-document precedentemente aperto come documento PDF N-Up. |
+| [save_markdown](./save_markdown/) | Converti e salva il PDF-document precedentemente aperto come documento Markdown. |
+| [save_tiff](./save_tiff/) | Converti e salva il PDF-document precedentemente aperto come documento Tiff. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Converti e salva il PDF-document precedentemente aperto come documento DocX con Modalità di Riconoscimento Avanzata (tabelle e paragrafi completamente modificabili). |
+| [save_svg_zip](./save_svg_zip/) | Converti e salva il PDF-document precedentemente aperto come archivio SVG. |
+| [export_fdf](./export_fdf/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento FDF. |
+| [export_xfdf](./export_xfdf/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento XFDF. |
+| [export_xml](./export_xml/) | Esporta dal PDF-document precedentemente aperto con AcroForm in documento XML. |
+| [page_to_jpg](./page_to_jpg/) | Converti e salva la pagina specificata come immagine Jpg. |
+| [page_to_png](./page_to_png/) | Converti e salva la pagina specificata come immagine Png. |
+| [page_to_bmp](./page_to_bmp/) | Converti e salva la pagina specificata come immagine Bmp. |
+| [page_to_tiff](./page_to_tiff/) | Converti e salva la pagina specificata come immagine Tiff. |
+| [page_to_svg](./page_to_svg/) | Converti e salva la pagina specificata come immagine Svg. |
+| [page_to_pdf](./page_to_pdf/) | Converti e salva la pagina specificata come documento PDF. |
+| [page_to_dicom](./page_to_dicom/) | Converti e salva la pagina specificata come immagine DICOM. |
+
+
+## Detailed Description
+
+Funzioni per la conversione da file PDF.
+

--- a/italian/rust-cpp/convert/export_fdf/_index.md
+++ b/italian/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Esporta dal documento PDF precedentemente aperto con AcroForm a documento FDF con nome file."
+type: docs
+url: /it/rust-cpp/convert/export_fdf/
+---
+
+_Esporta dal documento PDF precedentemente aperto con AcroForm a documento FDF con nome file._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Esporta dal documento PDF precedentemente aperto con AcroForm a documento FDF
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/export_xfdf/_index.md
+++ b/italian/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Esporta dal PDF-document precedentemente aperto con AcroForm in XFDF-document con nome file."
+type: docs
+url: /it/rust-cpp/convert/export_xfdf/
+---
+
+_Esporta dal PDF-document precedentemente aperto con AcroForm in XFDF-document con nome file._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Esporta dal PDF-document precedentemente aperto con AcroForm in XFDF-document
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/export_xml/_index.md
+++ b/italian/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Esporta dal PDF-document precedentemente aperto con AcroForm in XML-document con nome file."
+type: docs
+url: /it/rust-cpp/convert/export_xml/
+---
+
+_Esporta dal PDF-document precedentemente aperto con AcroForm in XML-document con nome file._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Esporta dal PDF-document precedentemente aperto con AcroForm in XML-document
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_bmp/_index.md
+++ b/italian/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come immagine BMP."
+type: docs
+url: /it/rust-cpp/convert/page_to_bmp/
+---
+
+_Converte e salva la pagina specificata come immagine BMP._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come immagine Bmp
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_dicom/_index.md
+++ b/italian/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come DICOM-image."
+type: docs
+url: /it/rust-cpp/convert/page_to_dicom/
+---
+
+_Converte e salva la pagina specificata come DICOM-image._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come DICOM-image
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_jpg/_index.md
+++ b/italian/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come immagine JPG."
+type: docs
+url: /it/rust-cpp/convert/page_to_jpg/
+---
+
+_Converte e salva la pagina specificata come immagine JPG._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come immagine Jpg
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_pdf/_index.md
+++ b/italian/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come PDF-document."
+type: docs
+url: /it/rust-cpp/convert/page_to_pdf/
+---
+
+_Converte e salva la pagina specificata come PDF-document._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come PDF-document
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_png/_index.md
+++ b/italian/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come immagine PNG."
+type: docs
+url: /it/rust-cpp/convert/page_to_png/
+---
+
+_Converte e salva la pagina specificata come immagine PNG._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come immagine Png
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_svg/_index.md
+++ b/italian/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come immagine SVG."
+type: docs
+url: /it/rust-cpp/convert/page_to_svg/
+---
+
+_Converte e salva la pagina specificata come immagine SVG._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come immagine Svg
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/page_to_tiff/_index.md
+++ b/italian/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva la pagina specificata come immagine TIFF."
+type: docs
+url: /it/rust-cpp/convert/page_to_tiff/
+---
+
+_Converte e salva la pagina specificata come immagine TIFF._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva la pagina specificata come immagine Tiff
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_booklet/_index.md
+++ b/italian/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come PDF-document booklet."
+type: docs
+url: /it/rust-cpp/convert/save_booklet/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come PDF-document booklet._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come PDF-document booklet
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/italian/rust-cpp/convert/save_doc/_index.md
+++ b/italian/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come documento DOC."
+type: docs
+url: /it/rust-cpp/convert/save_doc/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come documento DOC._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come documento Doc
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_docx/_index.md
+++ b/italian/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come documento DOCX."
+type: docs
+url: /it/rust-cpp/convert/save_docx/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come documento DOCX._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come documento DocX
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/italian/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come DOCX-document con Modalità di Riconoscimento Avanzata (tabelle e paragrafi completamente modificabili)."
+type: docs
+url: /it/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come DOCX-document con Modalità di Riconoscimento Avanzata (tabelle e paragrafi completamente modificabili)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come DocX-document con Modalità di Riconoscimento Avanzata (tabelle e paragrafi completamente modificabili)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_epub/_index.md
+++ b/italian/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come EPUB-document."
+type: docs
+url: /it/rust-cpp/convert/save_epub/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come documento EPUB._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come documento Epub
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_markdown/_index.md
+++ b/italian/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il documento PDF precedentemente aperto come documento Markdown."
+type: docs
+url: /it/rust-cpp/convert/save_markdown/
+---
+
+_Converte e salva il documento PDF precedentemente aperto come documento Markdown._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il documento PDF precedentemente aperto come documento Markdown
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/italian/rust-cpp/convert/save_n_up/_index.md
+++ b/italian/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come N-Up PDF-document."
+type: docs
+url: /it/rust-cpp/convert/save_n_up/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come N-Up PDF-document._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come N-Up PDF-document
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/italian/rust-cpp/convert/save_pptx/_index.md
+++ b/italian/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come documento PPTX."
+type: docs
+url: /it/rust-cpp/convert/save_pptx/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come documento PPTX._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come documento PptX
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_svg_zip/_index.md
+++ b/italian/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come SVG-archive."
+type: docs
+url: /it/rust-cpp/convert/save_svg_zip/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come SVG-archive._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come SVG-archive
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_tex/_index.md
+++ b/italian/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come TeX-document."
+type: docs
+url: /it/rust-cpp/convert/save_tex/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come TeX-document._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come TeX-document
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_tiff/_index.md
+++ b/italian/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come documento Tiff."
+type: docs
+url: /it/rust-cpp/convert/save_tiff/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come documento Tiff._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come documento Tiff
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/italian/rust-cpp/convert/save_txt/_index.md
+++ b/italian/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come TXT-document."
+type: docs
+url: /it/rust-cpp/convert/save_txt/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come TXT-document._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come Txt-document
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_xlsx/_index.md
+++ b/italian/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come XLSX-document."
+type: docs
+url: /it/rust-cpp/convert/save_xlsx/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come XLSX-document._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come XlsX-document
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/convert/save_xps/_index.md
+++ b/italian/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte e salva il PDF-document precedentemente aperto come XPS-document."
+type: docs
+url: /it/rust-cpp/convert/save_xps/
+---
+
+_Converte e salva il PDF-document precedentemente aperto come XPS-document._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti e salva il PDF-document precedentemente aperto come Xps-document
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/_index.md
+++ b/italian/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Funzioni PDF di base"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Funzioni di base per lavorare con file PDF."
+type: docs
+url: /it/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [new](./new/) | Crea un nuovo documento PDF. |
+| [open](./open/) | Apri un documento PDF con il nome file. |
+| [save](./save/) | Salva il documento PDF precedentemente aperto. |
+| [save_as](./save_as/) | Salva il documento PDF precedentemente aperto con un nuovo nome file. |
+| [set_license](./set_license/) | Imposta la licenza con il nome file. |
+| [extract_text](./extract_text/) | Restituisci il contenuto del documento PDF come testo semplice. |
+| [word_count](./word_count/) | Restituisci il conteggio delle parole nel documento PDF. |
+| [character_count](./character_count/) | Restituisci il conteggio dei caratteri nel documento PDF. |
+| [append](./append/) | Aggiungi pagine da un altro documento PDF. |
+| [append_pages](./append_pages/) | Aggiungi le pagine selezionate da un altro documento PDF. |
+| [merge_documents](./merge_documents/) | Crea un nuovo documento PDF unendo i documenti PDF forniti. |
+| [split_document](./split_document/) | Crea più nuovi documenti PDF estraendo pagine dal documento PDF sorgente. |
+| [split](./split/) | Crea più nuovi documenti PDF estraendo pagine dal documento PDF corrente. |
+| [split_at_page](./split_at_page/) | Dividi il documento PDF in due nuovi documenti PDF. |
+| [split_at](./split_at/) | Dividi il documento PDF corrente in due nuovi documenti PDF. |
+| [bytes](./bytes/) | Restituisci il contenuto del documento PDF come un vettore di byte. |
+| [get_meta_info](./get_meta_info/) | Ottieni il valore delle informazioni meta del documento PDF. |
+| [set_meta_info](./set_meta_info/) | Imposta il valore delle meta‑informazioni del PDF-document. |
+| [clear_meta_info](./clear_meta_info/) | Cancella tutti i valori delle meta‑informazioni del PDF-document. |
+| [is_linearized](./is_linearized/) | Ottieni un valore che indica se il documento è linearizzato. |
+| [page_add](./page_add/) | Aggiungi una nuova pagina nel PDF-document. |
+| [page_insert](./page_insert/) | Inserisci una nuova pagina nella posizione specificata nel PDF-document. |
+| [page_delete](./page_delete/) | Elimina la pagina specificata nel PDF-document. |
+| [page_count](./page_count/) | Restituisci il numero di pagine nel PDF-document. |
+| [page_word_count](./page_word_count/) | Restituisci il conteggio delle parole nella pagina specificata del PDF-document. |
+| [page_character_count](./page_character_count/) | Restituisci il conteggio dei caratteri nella pagina specificata del PDF-document. |
+| [page_is_blank](./page_is_blank/) | Restituisci se la pagina è vuota nel PDF-document. |
+
+
+## Detailed Description
+
+Funzioni di base per lavorare con file PDF.
+

--- a/italian/rust-cpp/core/append/_index.md
+++ b/italian/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge pagine da un altro PDF-document."
+type: docs
+url: /it/rust-cpp/core/append/
+---
+
+_Aggiunge pagine da un altro PDF-document._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri il PDF-document principale
+    let pdf = Document::open("sample.pdf")?;
+
+    // Apri un altro PDF-document da aggiungere
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Aggiungi pagine da un altro PDF-document
+    pdf.append(&another_pdf)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/append_pages/_index.md
+++ b/italian/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge le pagine selezionate da un altro PDF-document."
+type: docs
+url: /it/rust-cpp/core/append_pages/
+---
+
+_Aggiunge le pagine selezionate da un altro PDF-document._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri il PDF-document principale
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Apri un altro PDF-document da aggiungere
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi le pagine specifiche (1 e 3) da un altro PDF-document
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/bytes/_index.md
+++ b/italian/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "byte"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il contenuto del documento PDF come un vettore di byte."
+type: docs
+url: /it/rust-cpp/core/bytes/
+---
+
+_Restituisce il contenuto del documento PDF come un vettore di byte._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Restituisci il contenuto del documento PDF come un vettore di byte
+    let data = pdf.bytes()?;
+
+    // Stampa la lunghezza del vettore di byte
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/character_count/_index.md
+++ b/italian/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il conteggio dei caratteri nel documento PDF."
+type: docs
+url: /it/rust-cpp/core/character_count/
+---
+
+_Restituisce il conteggio dei caratteri nel documento PDF._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Restituisci il conteggio dei caratteri nel documento PDF
+    let count = pdf.character_count()?;
+
+    // Stampa il conteggio dei caratteri
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/clear_meta_info/_index.md
+++ b/italian/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Cancella tutti i valori delle meta informazioni del PDF-document."
+type: docs
+url: /it/rust-cpp/core/clear_meta_info/
+---
+
+_Cancella tutti i valori delle meta informazioni del PDF-document._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Cancella tutti i valori delle meta informazioni del PDF-document
+    pdf.clear_meta_info()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/extract_text/_index.md
+++ b/italian/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il contenuto del PDF-document come testo semplice."
+type: docs
+url: /it/rust-cpp/core/extract_text/
+---
+
+_Restituisce il contenuto del PDF-document come testo semplice._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Restituisci il contenuto del PDF-document come testo semplice
+    let txt = pdf.extract_text()?;
+
+    // Stampa il testo estratto
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/get_meta_info/_index.md
+++ b/italian/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il valore delle informazioni meta del PDF-document."
+type: docs
+url: /it/rust-cpp/core/get_meta_info/
+---
+
+_Restituisce il valore delle informazioni meta del PDF-document._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottieni il valore delle informazioni meta del PDF-document
+    let author = pdf.get_meta_info("Author")?;
+
+    // Stampa il risultato
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/is_linearized/_index.md
+++ b/italian/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce un valore che indica se il documento è linearizzato."
+type: docs
+url: /it/rust-cpp/core/is_linearized/
+---
+
+_Restituisce un valore che indica se il documento è linearizzato._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottieni un valore che indica se il documento è linearizzato
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/merge_documents/_index.md
+++ b/italian/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Crea un nuovo PDF-document unendo i PDF-documents forniti."
+type: docs
+url: /it/rust-cpp/core/merge_documents/
+---
+
+_Crea un nuovo PDF-document unendo i PDF-documents forniti._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf1 = Document::new()?;
+
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Crea un nuovo PDF-document unendo i PDF-documents forniti
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/new/_index.md
+++ b/italian/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "nuovo"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Crea un nuovo documento PDF."
+type: docs
+url: /it/rust-cpp/core/new/
+---
+
+_Crea un nuovo documento PDF._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/open/_index.md
+++ b/italian/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Apre un PDF-document con nome file."
+type: docs
+url: /it/rust-cpp/core/open/
+---
+
+_Apre un PDF-document con nome file._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_add/_index.md
+++ b/italian/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge una nuova pagina al documento PDF."
+type: docs
+url: /it/rust-cpp/core/page_add/
+---
+
+_Aggiunge una nuova pagina al documento PDF._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi una nuova pagina nel documento PDF
+    pdf.page_add()?;
+
+    // Salva il PDF-document precedentemente aperto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_character_count/_index.md
+++ b/italian/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il conteggio dei caratteri nella pagina specificata del documento PDF."
+type: docs
+url: /it/rust-cpp/core/page_character_count/
+---
+
+_Restituisce il conteggio dei caratteri nella pagina specificata del documento PDF._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Specifica il numero di pagina (indice a partire da 1)
+    let page_number = 1;
+
+    // Restituisci il conteggio dei caratteri nella pagina specificata
+    let count = pdf.page_character_count(page_number)?;
+
+    // Stampa il conteggio dei caratteri
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_count/_index.md
+++ b/italian/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il numero di pagine nel PDF-document."
+type: docs
+url: /it/rust-cpp/core/page_count/
+---
+
+_Restituisce il numero di pagine nel PDF-document._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Restituisci il numero di pagine nel PDF-document
+    let count = pdf.page_count()?;
+
+    // Stampa il numero di pagine
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_delete/_index.md
+++ b/italian/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Elimina la pagina specificata dal PDF-document."
+type: docs
+url: /it/rust-cpp/core/page_delete/
+---
+
+_Elimina la pagina specificata dal PDF-document._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Elimina la pagina specificata nel PDF-document
+    pdf.page_delete(1)?;
+
+    // Salva il PDF-document precedentemente aperto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_insert/_index.md
+++ b/italian/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Inserisce una nuova pagina nella posizione specificata nel PDF-document."
+type: docs
+url: /it/rust-cpp/core/page_insert/
+---
+
+_Inserisce una nuova pagina nella posizione specificata nel PDF-document._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Inserisci una nuova pagina nella posizione specificata nel PDF-document
+    pdf.page_insert(1)?;
+
+    // Salva il PDF-document precedentemente aperto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_is_blank/_index.md
+++ b/italian/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisci se la pagina è vuota nel PDF-document."
+type: docs
+url: /it/rust-cpp/core/page_is_blank/
+---
+
+_Restituisci pagina vuota nel PDF-document._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Specifica il numero di pagina (indice a partire da 1)
+    let page_number = 1;
+
+    // Restituisci pagina vuota nel PDF-document
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Stampa se la pagina specificata è vuota
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/page_word_count/_index.md
+++ b/italian/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il conteggio delle parole nella pagina specificata nel PDF-document."
+type: docs
+url: /it/rust-cpp/core/page_word_count/
+---
+
+_Restituisce il conteggio delle parole nella pagina specificata nel PDF-document._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Specifica il numero di pagina (indice a partire da 1)
+    let page_number = 1;
+
+    // Restituisci il conteggio delle parole nella pagina specificata
+    let count = pdf.page_word_count(page_number)?;
+
+    // Stampa il conteggio delle parole
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/save/_index.md
+++ b/italian/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Salva il PDF-document precedentemente aperto."
+type: docs
+url: /it/rust-cpp/core/save/
+---
+
+_Salva il PDF-document precedentemente aperto._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Salva il PDF-document precedentemente aperto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/save_as/_index.md
+++ b/italian/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Salva il PDF-document precedentemente aperto con un nuovo nome di file."
+type: docs
+url: /it/rust-cpp/core/save_as/
+---
+
+_Salva il PDF-document precedentemente aperto con un nuovo nome di file._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Salva il PDF-document con un nuovo nome di file
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/set_license/_index.md
+++ b/italian/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Imposta la licenza usando il nome file."
+type: docs
+url: /it/rust-cpp/core/set_license/
+---
+
+_Imposta la licenza usando il nome file._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Imposta la licenza con il nome file
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Ora puoi lavorare con il documento PDF con licenza
+    // ...
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/set_meta_info/_index.md
+++ b/italian/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Imposta il valore delle meta informazioni del PDF-document."
+type: docs
+url: /it/rust-cpp/core/set_meta_info/
+---
+
+_Imposta il valore delle meta informazioni del PDF-document._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Imposta il valore delle meta informazioni del PDF-document
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/split/_index.md
+++ b/italian/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Crea più nuovi PDF-documents estraendo pagine dal PDF-document corrente."
+type: docs
+url: /it/rust-cpp/core/split/
+---
+
+_Crea più nuovi PDF-documents estraendo pagine dal PDF-document corrente._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Crea più nuovi PDF-documents estraendo pagine dal PDF-document corrente
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Salva ogni parte divisa come un PDF-document separato
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/split_at/_index.md
+++ b/italian/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Dividi il PDF-document corrente in due nuovi PDF-documents."
+type: docs
+url: /it/rust-cpp/core/split_at/
+---
+
+_Dividi il PDF-document corrente in due nuovi PDF-documents._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dividi il PDF-document corrente in due nuovi PDF-documents
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Salva ogni parte divisa come un PDF-document separato
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/split_at_page/_index.md
+++ b/italian/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Divide il PDF-document in due nuovi PDF-documents."
+type: docs
+url: /it/rust-cpp/core/split_at_page/
+---
+
+_Divide il PDF-document in due nuovi PDF-documents._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dividi il PDF-document in due nuovi PDF-documents
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Salva ogni parte divisa come un PDF-document separato
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/split_document/_index.md
+++ b/italian/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Crea più PDF-documents nuovi estraendo pagine dal PDF-document di origine."
+type: docs
+url: /it/rust-cpp/core/split_document/
+---
+
+_Crea più PDF-documents nuovi estraendo pagine dal PDF-document di origine._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Crea più PDF-documents nuovi estraendo pagine dal PDF-document di origine
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Salva ogni parte divisa come un PDF-document separato
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/core/word_count/_index.md
+++ b/italian/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce il conteggio delle parole nel PDF-document."
+type: docs
+url: /it/rust-cpp/core/word_count/
+---
+
+_Restituisce il conteggio delle parole nel PDF-document._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Restituisci il conteggio delle parole nel PDF-document
+    let count = pdf.word_count()?;
+
+    // Stampa il conteggio delle parole
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/miscellaneous/_index.md
+++ b/italian/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funzioni varie"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Funzioni varie per lavorare."
+type: docs
+url: /it/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [about](./about/) | Restituisci le informazioni dei metadati su Aspose.PDF per Rust via C++. |
+
+
+## Detailed Description
+
+Funzioni varie per lavorare.
+

--- a/italian/rust-cpp/miscellaneous/about/_index.md
+++ b/italian/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "informazioni"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce informazioni sui metadati di Aspose.PDF per Rust tramite C++."
+type: docs
+url: /it/rust-cpp/miscellaneous/about/
+---
+
+_Restituisce informazioni sui metadati di Aspose.PDF per Rust tramite C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Restituisci informazioni sui metadati di Aspose.PDF per Go tramite C++.
+    let info = pdf.about()?;
+
+    // Stampa i campi dei metadati
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/_index.md
+++ b/italian/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Funzioni per organizzare PDF"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Funzioni per organizzare file PDF."
+type: docs
+url: /it/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Ottimizza il contenuto del documento PDF. |
+| [optimize_resource](./optimize_resource/) | Ottimizza le risorse del documento PDF. |
+| [grayscale](./grayscale/) | Converti il documento PDF in bianco e nero. |
+| [rotate](./rotate/) | Ruota il documento PDF. |
+| [set_background](./set_background/) | Imposta il colore di sfondo del documento PDF usando valori RGB. |
+| [repair](./repair/) | Ripara il documento PDF. |
+| [replace_text](./replace_text/) | Sostituisci il testo nel documento PDF |
+| [add_page_num](./add_page_num/) | Aggiungi il numero di pagina a un documento PDF |
+| [add_text_header](./add_text_header/) | Aggiungi testo nell'intestazione di un documento PDF |
+| [add_text_footer](./add_text_footer/) | Aggiungi testo nel piè di pagina di un documento PDF |
+| [flatten](./flatten/) | Appiattisci il documento PDF |
+| [remove_annotations](./remove_annotations/) | Rimuovi le annotazioni dal documento PDF |
+| [remove_attachments](./remove_attachments/) | Rimuovi gli allegati dal documento PDF |
+| [remove_blank_pages](./remove_blank_pages/) | Rimuovi le pagine vuote dal documento PDF |
+| [remove_bookmarks](./remove_bookmarks/) | Rimuovi i segnalibri dal documento PDF |
+| [remove_hidden_text](./remove_hidden_text/) | Rimuovi il testo nascosto dal documento PDF |
+| [remove_images](./remove_images/) | Rimuovi le immagini dal documento PDF |
+| [remove_javascripts](./remove_javascripts/) | Rimuovi gli script Java dal documento PDF |
+| [remove_tables](./remove_tables/) | Rimuovi le tabelle da un documento PDF. |
+| [remove_watermarks](./remove_watermarks/) | Rimuovi le filigrane dal documento PDF. |
+| [add_watermark](./add_watermark/) | Aggiungi una filigrana al documento PDF. |
+| [embed_fonts](./embed_fonts/) | Incorpora i caratteri in un documento PDF. |
+| [unembed_fonts](./unembed_fonts/) | Rimuovi l'incorporamento dei caratteri da un documento PDF. |
+| [optimize_file_size](./optimize_file_size/) | Ottimizza le dimensioni del documento PDF con la qualità di compressione delle immagini. |
+| [remove_text_headers](./remove_text_headers/) | Rimuovi le intestazioni di testo dal documento PDF. |
+| [remove_text_footers](./remove_text_footers/) | Rimuovi i piè di pagina di testo dal documento PDF. |
+| [crop](./crop/) | Ritaglia le pagine di un documento PDF. |
+| [replace_font](./replace_font/) | Sostituisci il carattere in un documento PDF. |
+| [convert](./convert/) | Converti un documento PDF in un documento PDF con il formato PDF specificato |
+| [validate](./validate/) | Convalida un documento PDF per la conformità al formato PDF |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Rimuovi la conformità PDF/A da un documento PDF |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Rimuovi la conformità PDF/UA da un documento PDF |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Verifica se un documento PDF è conforme a PDF/A |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Verifica se un documento PDF è conforme a PDF/UA |
+| [page_rotate](./page_rotate/) | Ruota una pagina nel documento PDF. |
+| [page_set_size](./page_set_size/) | Imposta le dimensioni di una pagina nel documento PDF. |
+| [page_grayscale](./page_grayscale/) | Converti la pagina in bianco e nero. |
+| [page_add_text](./page_add_text/) | Aggiungi testo sulla pagina. |
+| [page_replace_text](./page_replace_text/) | Sostituisci il testo sulla pagina |
+| [page_add_page_num](./page_add_page_num/) | Aggiungi il numero di pagina sulla pagina |
+| [page_add_text_header](./page_add_text_header/) | Aggiungi testo nell'intestazione della pagina |
+| [page_add_text_footer](./page_add_text_footer/) | Aggiungi testo nel piè di pagina della pagina |
+| [page_remove_annotations](./page_remove_annotations/) | Rimuovi le annotazioni nella pagina. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Rimuovi il testo nascosto nella pagina. |
+| [page_remove_images](./page_remove_images/) | Rimuovi le immagini nella pagina. |
+| [page_remove_tables](./page_remove_tables/) | Rimuovi le tabelle nella pagina. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Rimuovi le filigrane nella pagina. |
+| [page_add_watermark](./page_add_watermark/) | Aggiungi una filigrana nella pagina. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Rimuovi le intestazioni di testo nella pagina. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Rimuovi i piè di pagina di testo nella pagina. |
+| [page_crop](./page_crop/) | Ritaglia una pagina. |
+| [page_replace_font](./page_replace_font/) | Sostituisci il carattere nella pagina. |
+| [page_merge_layers](./page_merge_layers/) | Unisci tutti i livelli nella pagina in un unico livello con il nome del nuovo livello specificato. |
+| [page_layers](./page_layers/) | Ottieni i nomi dei livelli nella pagina. |
+
+
+## Detailed Description
+
+Funzioni per organizzare file PDF.

--- a/italian/rust-cpp/organize/add_page_num/_index.md
+++ b/italian/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge il numero di pagina a un documento PDF."
+type: docs
+url: /it/rust-cpp/organize/add_page_num/
+---
+
+_Aggiunge il numero di pagina a un documento PDF._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi il numero di pagina a un documento PDF
+    pdf.add_page_num()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/add_text_footer/_index.md
+++ b/italian/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge testo nel piè di pagina di un documento PDF."
+type: docs
+url: /it/rust-cpp/organize/add_text_footer/
+---
+
+_Aggiunge testo nel piè di pagina di un documento PDF._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi testo nel piè di pagina di un documento PDF
+    pdf.add_text_footer("FOOTER")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/add_text_header/_index.md
+++ b/italian/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge testo nell'intestazione di un PDF-document."
+type: docs
+url: /it/rust-cpp/organize/add_text_header/
+---
+
+_Aggiunge testo nell'intestazione di un PDF-document._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi testo nell'intestazione di un documento PDF
+    pdf.add_text_header("HEADER")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/add_watermark/_index.md
+++ b/italian/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge una filigrana al documento PDF."
+type: docs
+url: /it/rust-cpp/organize/add_watermark/
+---
+
+_Aggiunge una filigrana al documento PDF._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi filigrana al documento PDF
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/convert/_index.md
+++ b/italian/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte un documento PDF in un documento PDF con il formato PDF specificato."
+type: docs
+url: /it/rust-cpp/organize/convert/
+---
+
+_Converte un documento PDF in un documento PDF con il formato PDF specificato._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti un documento PDF in un documento PDF con il formato PDF specificato
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Stampa il risultato della conversione e il registro completo
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/crop/_index.md
+++ b/italian/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "ritaglia"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ritaglia le pagine di un documento PDF."
+type: docs
+url: /it/rust-cpp/organize/crop/
+---
+
+_Ritaglia le pagine di un documento PDF._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ritaglia le pagine di un documento PDF
+    pdf.crop(10.5)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/embed_fonts/_index.md
+++ b/italian/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Incorpora caratteri in un PDF-document."
+type: docs
+url: /it/rust-cpp/organize/embed_fonts/
+---
+
+_Incorpora caratteri in un PDF-document._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Incorpora caratteri in un PDF-document
+    pdf.embed_fonts()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/flatten/_index.md
+++ b/italian/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Appiattisce il documento PDF."
+type: docs
+url: /it/rust-cpp/organize/flatten/
+---
+
+_Appiattisce il documento PDF._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Restituisci il contenuto del PDF-document come testo semplice
+    let txt = pdf.extract_text()?;
+
+    // Stampa il testo estratto
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/grayscale/_index.md
+++ b/italian/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte il documento PDF in bianco e nero."
+type: docs
+url: /it/rust-cpp/organize/grayscale/
+---
+
+_Converte il documento PDF in bianco e nero._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti il documento PDF in bianco e nero
+    pdf.grayscale()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/italian/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Restituisce se un documento PDF è conforme a PDF/A."
+type: docs
+url: /it/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Restituisce se un documento PDF è conforme a PDF/A._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottieni lo stato di conformità PDF/A del documento PDF
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/italian/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottiene se un PDF-document è conforme a PDF/UA."
+type: docs
+url: /it/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Ottiene se un PDF-document è conforme a PDF/UA._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottieni lo stato di conformità PDF/UA del PDF-document
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/optimize/_index.md
+++ b/italian/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottimizza il contenuto del PDF-document."
+type: docs
+url: /it/rust-cpp/organize/optimize/
+---
+
+_Ottimizza il contenuto del PDF-document._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottimizza il contenuto del PDF-document
+    pdf.optimize()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/optimize_file_size/_index.md
+++ b/italian/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottimizza le dimensioni del PDF-document con la qualità di compressione dell'immagine."
+type: docs
+url: /it/rust-cpp/organize/optimize_file_size/
+---
+
+_Ottimizza le dimensioni del PDF-document con la qualità di compressione dell'immagine._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottimizza le dimensioni del PDF-document con la qualità di compressione dell'immagine
+    pdf.optimize_file_size(50)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/optimize_resource/_index.md
+++ b/italian/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottimizza le risorse del documento PDF."
+type: docs
+url: /it/rust-cpp/organize/optimize_resource/
+---
+
+_Ottimizza le risorse del documento PDF._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ottimizza le risorse del documento PDF
+    pdf.optimize_resource()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_add_page_num/_index.md
+++ b/italian/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge il numero di pagina sulla pagina."
+type: docs
+url: /it/rust-cpp/organize/page_add_page_num/
+---
+
+_Aggiunge il numero di pagina sulla pagina._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi il numero di pagina sulla pagina
+    pdf.page_add_page_num(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_add_text/_index.md
+++ b/italian/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge testo a una pagina."
+type: docs
+url: /it/rust-cpp/organize/page_add_text/
+---
+
+_Aggiunge testo a una pagina._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi testo sulla pagina
+    pdf.page_add_text(1, "added text")?;
+
+    // Salva il PDF-document precedentemente aperto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/italian/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge testo nel piè di pagina della pagina."
+type: docs
+url: /it/rust-cpp/organize/page_add_text_footer/
+---
+
+_Aggiunge testo nel piè di pagina della pagina._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi testo nel piè di pagina della pagina
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_add_text_header/_index.md
+++ b/italian/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge testo nell'intestazione della pagina."
+type: docs
+url: /it/rust-cpp/organize/page_add_text_header/
+---
+
+_Aggiunge testo nell'intestazione della pagina._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi testo nell'intestazione della pagina
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_add_watermark/_index.md
+++ b/italian/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Aggiunge una filigrana sulla pagina."
+type: docs
+url: /it/rust-cpp/organize/page_add_watermark/
+---
+
+_Aggiunge una filigrana sulla pagina._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Aggiungi filigrana sulla pagina
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_crop/_index.md
+++ b/italian/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ritaglia una pagina."
+type: docs
+url: /it/rust-cpp/organize/page_crop/
+---
+
+_Ritaglia una pagina._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ritaglia una pagina
+    pdf.page_crop(1, 1.0)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_grayscale/_index.md
+++ b/italian/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Converte una pagina in bianco e nero."
+type: docs
+url: /it/rust-cpp/organize/page_grayscale/
+---
+
+_Converte una pagina in bianco e nero._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converti la pagina in bianco e nero
+    pdf.page_grayscale(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_layers/_index.md
+++ b/italian/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottiene i nomi dei livelli nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_layers/
+---
+
+_Ottiene i nomi dei livelli nella pagina._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Ottieni i nomi dei livelli nella pagina 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_merge_layers/_index.md
+++ b/italian/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Unisce tutti i livelli nella pagina in un unico livello con il nome del nuovo livello specificato."
+type: docs
+url: /it/rust-cpp/organize/page_merge_layers/
+---
+
+_Unisce tutti i livelli nella pagina in un unico livello con il nome del nuovo livello specificato._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Unisci tutti i livelli nella pagina in un unico livello con il nome del nuovo livello specificato
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/italian/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le annotazioni nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_annotations/
+---
+
+_Rimuove le annotazioni nella pagina._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le annotazioni nella pagina
+    pdf.page_remove_annotations(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/italian/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove il testo nascosto nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Rimuove il testo nascosto nella pagina._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi il testo nascosto nella pagina
+    pdf.page_remove_hidden_text(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_images/_index.md
+++ b/italian/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le immagini nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_images/
+---
+
+_Rimuove le immagini nella pagina._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le immagini nella pagina
+    pdf.page_remove_images(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_tables/_index.md
+++ b/italian/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le tabelle nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_tables/
+---
+
+_Rimuove le tabelle nella pagina._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le tabelle nella pagina
+    pdf.page_remove_tables(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/italian/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove i piè di pagina di testo nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Rimuove i piè di pagina di testo nella pagina._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi i piè di pagina di testo nella pagina
+    pdf.page_remove_text_footers(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/italian/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le intestazioni di testo nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Rimuove le intestazioni di testo nella pagina._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le intestazioni di testo nella pagina
+    pdf.page_remove_text_headers(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/italian/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le filigrane nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Rimuove le filigrane nella pagina._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le filigrane nella pagina
+    pdf.page_remove_watermarks(1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_replace_font/_index.md
+++ b/italian/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Sostituisce il carattere nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_replace_font/
+---
+
+_Sostituisce il carattere nella pagina._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sostituisci il carattere nella pagina
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_replace_text/_index.md
+++ b/italian/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Sostituisce il testo nella pagina."
+type: docs
+url: /it/rust-cpp/organize/page_replace_text/
+---
+
+_Sostituisce il testo nella pagina._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sostituisci il testo sulla pagina
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_rotate/_index.md
+++ b/italian/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ruota una pagina nel documento PDF."
+type: docs
+url: /it/rust-cpp/organize/page_rotate/
+---
+
+_Ruota una pagina nel documento PDF._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document da file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ruota pagina
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/page_set_size/_index.md
+++ b/italian/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Imposta le dimensioni di una pagina nel PDF-document."
+type: docs
+url: /it/rust-cpp/organize/page_set_size/
+---
+
+_Imposta le dimensioni di una pagina nel PDF-document._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Imposta le dimensioni di una pagina nel PDF-document
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_annotations/_index.md
+++ b/italian/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le annotazioni dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_annotations/
+---
+
+_Rimuove le annotazioni dal documento PDF._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le annotazioni dal documento PDF
+    pdf.remove_annotations()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_attachments/_index.md
+++ b/italian/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove gli allegati dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_attachments/
+---
+
+_Rimuove gli allegati dal documento PDF._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi gli allegati dal documento PDF
+    pdf.remove_attachments()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/italian/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le pagine vuote dal PDF-document."
+type: docs
+url: /it/rust-cpp/organize/remove_blank_pages/
+---
+
+_Rimuove le pagine vuote dal PDF-document._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le pagine vuote dal documento PDF
+    pdf.remove_blank_pages()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/italian/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove i segnalibri dal PDF-document."
+type: docs
+url: /it/rust-cpp/organize/remove_bookmarks/
+---
+
+_Rimuove i segnalibri dal PDF-document._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi i segnalibri dal documento PDF
+    pdf.remove_bookmarks()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/italian/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove il testo nascosto dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_hidden_text/
+---
+
+_Rimuove il testo nascosto dal documento PDF._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi il testo nascosto dal documento PDF
+    pdf.remove_hidden_text()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_images/_index.md
+++ b/italian/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le immagini dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_images/
+---
+
+_Rimuove le immagini dal documento PDF._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le immagini dal documento PDF
+    pdf.remove_images()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_javascripts/_index.md
+++ b/italian/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove gli script Java dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_javascripts/
+---
+
+_Rimuove gli script Java dal documento PDF._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi gli script Java dal documento PDF
+    pdf.remove_javascripts()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/italian/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove la conformità PDF/A da un documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Rimuovi la conformità PDF/A da un documento PDF._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi la conformità PDF/A da un documento PDF
+    pdf.remove_pdfa_compliance()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/italian/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuovi la conformità PDF/UA da un PDF-document."
+type: docs
+url: /it/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Rimuovi la conformità PDF/UA da un PDF-document._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi la conformità PDF/UA da un documento PDF
+    pdf.remove_pdfua_compliance()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_tables/_index.md
+++ b/italian/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le tabelle dal PDF-document."
+type: docs
+url: /it/rust-cpp/organize/remove_tables/
+---
+
+_Rimuove le tabelle dal PDF-document._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le tabelle dal PDF-document
+    pdf.remove_tables()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_text_footers/_index.md
+++ b/italian/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove i piè di pagina di testo dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_text_footers/
+---
+
+_Rimuove i piè di pagina di testo dal documento PDF._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi i piè di pagina di testo dal documento PDF
+    pdf.remove_text_footers()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_text_headers/_index.md
+++ b/italian/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le intestazioni di testo dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_text_headers/
+---
+
+_Rimuove le intestazioni di testo dal documento PDF._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le intestazioni di testo dal documento PDF
+    pdf.remove_text_headers()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/remove_watermarks/_index.md
+++ b/italian/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove le filigrane dal documento PDF."
+type: docs
+url: /it/rust-cpp/organize/remove_watermarks/
+---
+
+_Rimuove le filigrane dal documento PDF._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi le filigrane dal documento PDF
+    pdf.remove_watermarks()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/repair/_index.md
+++ b/italian/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ripara il PDF-document."
+type: docs
+url: /it/rust-cpp/organize/repair/
+---
+
+_Ripara il PDF-document._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ripara PDF-document
+    pdf.repair()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/replace_font/_index.md
+++ b/italian/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Sostituisce il carattere in un PDF-document."
+type: docs
+url: /it/rust-cpp/organize/replace_font/
+---
+
+_Sostituisce il carattere in un PDF-document._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sostituisci il carattere in un documento PDF.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/replace_text/_index.md
+++ b/italian/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Sostituisce il testo."
+type: docs
+url: /it/rust-cpp/organize/replace_text/
+---
+
+_Sostituisce il testo._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sostituisci il testo nel documento PDF
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/rotate/_index.md
+++ b/italian/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ruota il PDF-document."
+type: docs
+url: /it/rust-cpp/organize/rotate/
+---
+
+_Ruota il PDF-document._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ruota PDF-document
+    pdf.rotate(Rotation::On270)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/set_background/_index.md
+++ b/italian/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Imposta il colore di sfondo del PDF-document usando valori RGB."
+type: docs
+url: /it/rust-cpp/organize/set_background/
+---
+
+_Imposta il colore di sfondo del PDF-document usando valori RGB._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Imposta il colore di sfondo del PDF-document usando valori RGB
+    pdf.set_background(200, 100, 101)?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/unembed_fonts/_index.md
+++ b/italian/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuove i font da un documento PDF."
+type: docs
+url: /it/rust-cpp/organize/unembed_fonts/
+---
+
+_Rimuove i font da un documento PDF._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rimuovi i font da un documento PDF
+    pdf.unembed_fonts()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/organize/validate/_index.md
+++ b/italian/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Convalida un PDF-document per la conformità al formato PDF."
+type: docs
+url: /it/rust-cpp/organize/validate/
+---
+
+_Convalida un PDF-document per la conformità al formato PDF._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convalida un documento PDF per la conformità al formato PDF
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Stampa il risultato della convalida e il registro completo
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/_index.md
+++ b/italian/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funzioni di sicurezza"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Funzioni di sicurezza."
+type: docs
+url: /it/rust-cpp/security/
+---
+
+## Security
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Apri un PDF-document protetto da password. |
+| [encrypt](./encrypt/) | Cifra il PDF-document. |
+| [decrypt](./decrypt/) | Decifra il PDF-document. |
+| [set_permissions](./set_permissions/) | Imposta i permessi per il PDF-document. |
+| [get_permissions](./get_permissions/) | Ottieni i permessi attuali del PDF-document. |
+| [is_encrypted](./is_encrypted/) | Ottieni lo stato di cifratura del PDF-document. |
+| [sign_pkcs7](./sign_pkcs7/) | Firma un PDF-document usando firme digitali PKCS#7. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Firma un PDF-document usando firme digitali PKCS#7 Detached. |
+| [is_signed](./is_signed/) | Ottieni lo stato di firma del PDF-document. |
+| [remove_signs](./remove_signs/) | Rimuovi le firme dal PDF-document. |
+
+
+## Detailed Description
+
+Funzioni di sicurezza.
+

--- a/italian/rust-cpp/security/decrypt/_index.md
+++ b/italian/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "decrittare"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Decifra il PDF-document."
+type: docs
+url: /it/rust-cpp/security/decrypt/
+---
+
+_Decripta PDF-document._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document protetto da password
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Decripta PDF-document
+    pdf.decrypt()?;
+
+    // Salva il PDF-document precedentemente aperto con un nuovo nome di file
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/encrypt/_index.md
+++ b/italian/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "cifra"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Cifra il PDF-document."
+type: docs
+url: /it/rust-cpp/security/encrypt/
+---
+
+_Cifra PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Cifra PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Salva il PDF-document cifrato
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/get_permissions/_index.md
+++ b/italian/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottieni i permessi attuali del PDF-document."
+type: docs
+url: /it/rust-cpp/security/get_permissions/
+---
+
+_Ottieni le autorizzazioni correnti del PDF-document._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document protetto da password
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Ottieni le autorizzazioni correnti del PDF-document
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Stampa le autorizzazioni
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/is_encrypted/_index.md
+++ b/italian/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottieni lo stato di cifratura del PDF-document."
+type: docs
+url: /it/rust-cpp/security/is_encrypted/
+---
+
+_Ottieni lo stato di crittografia del PDF-document._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document protetto da password
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Ottieni lo stato di crittografia del PDF-document
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/is_signed/_index.md
+++ b/italian/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Ottieni lo stato di firma del PDF-document."
+type: docs
+url: /it/rust-cpp/security/is_signed/
+---
+
+_Ottieni lo stato di firma del PDF-document._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Ottieni lo stato di firma del PDF-document
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/open_with_password/_index.md
+++ b/italian/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Apri un PDF-document protetto da password."
+type: docs
+url: /it/rust-cpp/security/open_with_password/
+---
+
+_Apri un PDF-document protetto da password._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document protetto da password
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // elaborazione...
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/remove_signs/_index.md
+++ b/italian/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Rimuovi le firme dal PDF-document."
+type: docs
+url: /it/rust-cpp/security/remove_signs/
+---
+
+_Rimuovi le firme dal PDF-document._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Apri un PDF-document chiamato "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Rimuovi le firme dal PDF-document
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/set_permissions/_index.md
+++ b/italian/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Imposta i permessi per il PDF-document."
+type: docs
+url: /it/rust-cpp/security/set_permissions/
+---
+
+_Imposta i permessi per PDF-document._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crea un nuovo PDF-document
+    let pdf = Document::new()?;
+
+    // Imposta i permessi per il PDF-document.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Salva il PDF-document con i permessi aggiornati
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/sign_pkcs7/_index.md
+++ b/italian/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Firma un PDF-document usando firme digitali PKCS#7."
+type: docs
+url: /it/rust-cpp/security/sign_pkcs7/
+---
+
+_Firma un PDF-document usando firme digitali PKCS#7._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Leggi i file di certificato e immagine in vettori di byte
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Firma un PDF-document usando firme digitali PKCS#7
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/italian/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/italian/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF per Rust tramite C++"
+description: "Firma un PDF-document usando firme digitali PKCS#7 Detached."
+type: docs
+url: /it/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Firma un PDF-document usando firme digitali PKCS#7 Detached._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Leggi i file di certificato e immagine in vettori di byte
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Apri un documento PDF con nome file
+    let pdf = Document::open("sample.pdf")?;
+
+    // Firma un PDF-document usando firme digitali PKCS#7 Detached
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
🔄 **In progress** — incremental translation of RUST-CPP API Reference to **Italian** (`it`).

Updated at each cache checkpoint. Source: `english/rust-cpp`

🤖 Generated by RDA