### PR TITLE
[auto] Translate RUST-CPP API Reference to Korean

### DIFF
--- a/korean/rust-cpp/_index.md
+++ b/korean/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "C++를 통해 Rust용 Aspose.PDF"
+description: "C++를 통해 Rust용 Aspose.PDF"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /ko/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# 구조체
+
+## Document
+Document는 PDF-document를 나타냅니다.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | 이전에 열었던 PDF-document를 DocX-document로 변환하고 저장합니다. |
+| [save_doc](./convert/save_doc/) | 이전에 열었던 PDF-document를 Doc-document로 변환하고 저장합니다. |
+| [save_xlsx](./convert/save_xlsx/) | 이전에 열었던 PDF-document를 XlsX-document로 변환하고 저장합니다. |
+| [save_txt](./convert/save_txt/) | 이전에 열었던 PDF-document를 Txt-document로 변환하고 저장합니다. |
+| [save_pptx](./convert/save_pptx/) | 이전에 열었던 PDF-document를 PptX-document로 변환하고 저장합니다. |
+| [save_xps](./convert/save_xps/) | 이전에 열었던 PDF-document를 Xps-document로 변환하고 저장합니다. |
+| [save_tex](./convert/save_tex/) | 이전에 열었던 PDF-document를 TeX-document로 변환하고 저장합니다. |
+| [save_epub](./convert/save_epub/) | 이전에 열었던 PDF-document를 Epub-document로 변환하고 저장합니다. |
+| [save_booklet](./convert/save_booklet/) | 이전에 열었던 PDF-document를 소책자 PDF-document로 변환하고 저장합니다. |
+| [save_n_up](./convert/save_n_up/) | 이전에 열었던 PDF-document를 N-Up PDF-document로 변환하고 저장합니다. |
+| [save_markdown](./convert/save_markdown/) | 이전에 열었던 PDF-document를 Markdown-document로 변환하고 저장합니다. |
+| [save_tiff](./convert/save_tiff/) | 이전에 열었던 PDF-document를 Tiff-document로 변환하고 저장합니다. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | 이전에 열었던 PDF-document를 향상된 인식 모드가 적용된 DocX-document로 변환하고 저장합니다(완전히 편집 가능한 표와 단락). |
+| [save_svg_zip](./convert/save_svg_zip/) | 이전에 열었던 PDF-document를 SVG-archive로 변환하고 저장합니다. |
+| [export_fdf](./convert/export_fdf/) | AcroForm이 포함된 이전에 열었던 PDF-document를 FDF-document로 내보냅니다. |
+| [export_xfdf](./convert/export_xfdf/) | AcroForm이 포함된 이전에 열었던 PDF-document를 XFDF-document로 내보냅니다. |
+| [export_xml](./convert/export_xml/) | AcroForm이 포함된 이전에 열었던 PDF-document를 XML-document로 내보냅니다. |
+| [page_to_jpg](./convert/page_to_jpg/) | 지정된 페이지를 Jpg-image로 변환하고 저장합니다. |
+| [page_to_png](./convert/page_to_png/) | 지정된 페이지를 Png-image로 변환하고 저장합니다. |
+| [page_to_bmp](./convert/page_to_bmp/) | 지정된 페이지를 Bmp-image로 변환하고 저장합니다. |
+| [page_to_tiff](./convert/page_to_tiff/) | 지정된 페이지를 Tiff 이미지로 변환하고 저장합니다. |
+| [page_to_svg](./convert/page_to_svg/) | 지정된 페이지를 Svg 이미지로 변환하고 저장합니다. |
+| [page_to_pdf](./convert/page_to_pdf/) | 지정된 페이지를 PDF 문서로 변환하고 저장합니다. |
+| [page_to_dicom](./convert/page_to_dicom/) | 지정된 페이지를 DICOM 이미지로 변환하고 저장합니다. |
+
+
+## Organize PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | PDF 문서 내용을 최적화합니다. |
+| [optimize_resource](./organize/optimize_resource/) | PDF 문서의 리소스를 최적화합니다. |
+| [grayscale](./organize/grayscale/) | PDF 문서를 흑백으로 변환합니다. |
+| [rotate](./organize/rotate/) | PDF 문서를 회전합니다. |
+| [set_background](./organize/set_background/) | RGB 값을 사용하여 PDF 문서 배경 색을 설정합니다. |
+| [repair](./organize/repair/) | PDF 문서를 복구합니다. |
+| [replace_text](./organize/replace_text/) | PDF 문서의 텍스트를 교체합니다 |
+| [add_page_num](./organize/add_page_num/) | PDF 문서에 페이지 번호를 추가합니다 |
+| [add_text_header](./organize/add_text_header/) | PDF 문서 헤더에 텍스트를 추가합니다 |
+| [add_text_footer](./organize/add_text_footer/) | PDF 문서 푸터에 텍스트를 추가합니다 |
+| [flatten](./organize/flatten/) | PDF 문서를 평면화합니다 |
+| [remove_annotations](./organize/remove_annotations/) | PDF 문서에서 주석을 제거합니다 |
+| [remove_attachments](./organize/remove_attachments/) | PDF 문서에서 첨부 파일을 제거합니다 |
+| [remove_blank_pages](./organize/remove_blank_pages/) | PDF 문서에서 빈 페이지를 제거합니다 |
+| [remove_bookmarks](./organize/remove_bookmarks/) | PDF 문서에서 북마크를 제거합니다 |
+| [remove_hidden_text](./organize/remove_hidden_text/) | PDF 문서에서 숨겨진 텍스트를 제거합니다 |
+| [remove_images](./organize/remove_images/) | PDF 문서에서 이미지를 제거합니다 |
+| [remove_javascripts](./organize/remove_javascripts/) | PDF 문서에서 자바스크립트를 제거합니다 |
+| [remove_tables](./organize/remove_tables/) | PDF 문서에서 표를 제거합니다. |
+| [remove_watermarks](./organize/remove_watermarks/) | PDF 문서에서 워터마크를 제거합니다. |
+| [add_watermark](./organize/add_watermark/) | PDF 문서에 워터마크를 추가합니다. |
+| [embed_fonts](./organize/embed_fonts/) | PDF-document에 글꼴을 삽입합니다. |
+| [unembed_fonts](./organize/unembed_fonts/) | PDF-document에서 글꼴 삽입을 해제합니다. |
+| [optimize_file_size](./organize/optimize_file_size/) | 이미지 압축 품질을 사용하여 PDF-document의 크기를 최적화합니다. |
+| [remove_text_headers](./organize/remove_text_headers/) | PDF-document에서 텍스트 머리글을 제거합니다. |
+| [remove_text_footers](./organize/remove_text_footers/) | PDF-document에서 텍스트 바닥글을 제거합니다. |
+| [crop](./organize/crop/) | PDF-document의 페이지를 자릅니다. |
+| [replace_font](./organize/replace_font/) | PDF-document의 글꼴을 교체합니다. |
+| [convert](./organize/convert/) | PDF-document를 지정된 PDF 형식의 PDF-document로 변환합니다 |
+| [validate](./organize/validate/) | PDF-document가 PDF 형식에 준수하는지 검증합니다 |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | PDF-document에서 PDF/A 준수를 제거합니다 |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | PDF-document에서 PDF/UA 준수를 제거합니다 |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | PDF-document가 PDF/A 규격을 준수하는지 확인합니다 |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | PDF-document가 PDF/UA 규격을 준수하는지 확인합니다 |
+| [page_rotate](./organize/page_rotate/) | PDF-document의 페이지를 회전합니다. |
+| [page_set_size](./organize/page_set_size/) | PDF-document의 페이지 크기를 설정합니다. |
+| [page_grayscale](./organize/page_grayscale/) | 페이지를 흑백으로 변환합니다. |
+| [page_add_text](./organize/page_add_text/) | 페이지에 텍스트를 추가합니다. |
+| [page_replace_text](./organize/page_replace_text/) | 페이지의 텍스트를 교체합니다 |
+| [page_add_page_num](./organize/page_add_page_num/) | 페이지에 페이지 번호를 추가합니다 |
+| [page_add_text_header](./organize/page_add_text_header/) | 페이지 머리글에 텍스트를 추가합니다 |
+| [page_add_text_footer](./organize/page_add_text_footer/) | 페이지 바닥글에 텍스트를 추가합니다 |
+| [page_remove_annotations](./organize/page_remove_annotations/) | 페이지의 주석을 제거합니다. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | 페이지의 숨겨진 텍스트를 제거합니다. |
+| [page_remove_images](./organize/page_remove_images/) | 페이지의 이미지를 제거합니다. |
+| [page_remove_tables](./organize/page_remove_tables/) | 페이지의 표를 제거합니다. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | 페이지에서 워터마크를 제거합니다. |
+| [page_add_watermark](./organize/page_add_watermark/) | 페이지에 워터마크를 추가합니다. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | 페이지에서 텍스트 헤더를 제거합니다. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | 페이지에서 텍스트 푸터를 제거합니다. |
+| [page_crop](./organize/page_crop/) | 페이지를 자릅니다. |
+| [page_replace_font](./organize/page_replace_font/) | 페이지의 글꼴을 교체합니다. |
+| [page_merge_layers](./organize/page_merge_layers/) | 페이지의 모든 레이어를 지정된 새 레이어 이름으로 단일 레이어로 병합합니다. |
+| [page_layers](./organize/page_layers/) | 페이지의 레이어 이름을 가져옵니다. |
+
+
+## Core PDF functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [new](./core/new/) | 새 PDF 문서를 생성합니다. |
+| [open](./core/open/) | 파일 이름으로 PDF 문서를 엽니다. |
+| [save](./core/save/) | 이전에 연 PDF 문서를 저장합니다. |
+| [save_as](./core/save_as/) | 이전에 연 PDF 문서를 새 파일 이름으로 저장합니다. |
+| [set_license](./core/set_license/) | 파일 이름으로 라이선스를 설정합니다. |
+| [extract_text](./core/extract_text/) | PDF 문서 내용을 일반 텍스트로 반환합니다. |
+| [word_count](./core/word_count/) | PDF 문서의 단어 수를 반환합니다. |
+| [character_count](./core/character_count/) | PDF 문서의 문자 수를 반환합니다. |
+| [append](./core/append/) | 다른 PDF 문서에서 페이지를 추가합니다. |
+| [append_pages](./core/append_pages/) | 다른 PDF 문서에서 선택한 페이지를 추가합니다. |
+| [merge_documents](./core/merge_documents/) | 제공된 PDF 문서를 병합하여 새 PDF 문서를 생성합니다. |
+| [split_document](./core/split_document/) | 원본 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다. |
+| [split](./core/split/) | 현재 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다. |
+| [split_at_page](./core/split_at_page/) | PDF 문서를 두 개의 새 PDF 문서로 분할합니다. |
+| [split_at](./core/split_at/) | 현재 PDF 문서를 두 개의 새 PDF 문서로 분할합니다. |
+| [bytes](./core/bytes/) | PDF 문서의 내용을 바이트 벡터로 반환합니다. |
+| [get_meta_info](./core/get_meta_info/) | PDF 문서의 메타 정보 값을 가져옵니다. |
+| [set_meta_info](./core/set_meta_info/) | PDF-document의 메타 정보 값을 설정합니다. |
+| [clear_meta_info](./core/clear_meta_info/) | PDF-document의 모든 메타 정보 값을 지웁니다. |
+| [is_linearized](./core/is_linearized/) | 문서가 선형화되었는지 여부를 나타내는 값을 가져옵니다. |
+| [page_add](./core/page_add/) | PDF-document에 새 페이지를 추가합니다. |
+| [page_insert](./core/page_insert/) | PDF-document의 지정된 위치에 새 페이지를 삽입합니다. |
+| [page_delete](./core/page_delete/) | PDF-document에서 지정된 페이지를 삭제합니다. |
+| [page_count](./core/page_count/) | PDF-document의 페이지 수를 반환합니다. |
+| [page_word_count](./core/page_word_count/) | PDF-document의 지정된 페이지에서 단어 수를 반환합니다. |
+| [page_character_count](./core/page_character_count/) | PDF-document의 지정된 페이지에서 문자 수를 반환합니다. |
+| [page_is_blank](./core/page_is_blank/) | PDF-document에서 페이지가 비어 있는지 반환합니다. |
+
+
+## Security
+| 함수 | 설명 |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | 비밀번호로 보호된 PDF-document를 엽니다. |
+| [encrypt](./security/encrypt/) | PDF-document를 암호화합니다. |
+| [decrypt](./security/decrypt/) | PDF-document를 복호화합니다. |
+| [set_permissions](./security/set_permissions/) | PDF-document에 대한 권한을 설정합니다. |
+| [get_permissions](./security/get_permissions/) | PDF-document의 현재 권한을 가져옵니다. |
+| [is_encrypted](./security/is_encrypted/) | PDF-document의 암호화 상태를 가져옵니다. |
+| [sign_pkcs7](./security/sign_pkcs7/) | PKCS#7 디지털 서명을 사용하여 PDF-document에 서명합니다. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | PKCS#7 Detached 디지털 서명을 사용하여 PDF-document에 서명합니다. |
+| [is_signed](./security/is_signed/) | PDF-document의 서명 상태를 가져옵니다. |
+| [remove_signs](./security/remove_signs/) | PDF-document에서 서명을 제거합니다. |
+
+
+## Miscellaneous
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | C++를 통해 Aspose.PDF for Rust에 대한 메타데이터 정보를 반환합니다. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// PDF 권한 기능을 나타내는 비트플래그 집합.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// A0 크기.
+    A0 = 0,
+    /// A1 크기.
+    A1 = 1,
+    /// A2 크기.
+    A2 = 2,
+    /// A3 크기.
+    A3 = 3,
+    /// A4 크기.
+    A4 = 4,
+    /// A5 크기.
+    A5 = 5,
+    /// A6 크기.
+    A6 = 6,
+    /// B5 크기.
+    B5 = 7,
+    /// PageLetter 크기.
+    PageLetter = 8,
+    /// PageLegal 크기.
+    PageLegal = 9,
+    /// PageLedger 크기.
+    PageLedger = 10,
+    /// P11x17 크기.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// 회전되지 않음.
+    None = 0,
+    /// 시계 방향으로 90도 회전.
+    On90 = 1,
+    /// 180도 회전.
+    On180 = 2,
+    /// 시계 방향으로 270도 회전.
+    On270 = 3,
+    /// 시계 방향으로 360도 회전.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// 키 길이 40인 RC4.
+    RC4x40 = 0,
+    /// 키 길이 128인 RC4.
+    RC4x128 = 1,
+    /// 키 길이 128인 AES.
+    AESx128 = 2,
+    /// 키 길이 256인 AES.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// PDF/A-1a 형식.
+    PDF_A_1A = 0,
+    /// PDF/A-1b 형식.
+    PDF_A_1B = 1,
+    /// PDF/A-2a 형식.
+    PDF_A_2A = 2,
+    /// PDF/A-3a 형식.
+    PDF_A_3A = 3,
+    /// PDF/A-2b 형식.
+    PDF_A_2B = 4,
+    /// PDF/A-2u 형식.
+    PDF_A_2U = 5,
+    /// PDF/A-3b 형식.
+    PDF_A_3B = 6,
+    /// PDF/A-3u 형식.
+    PDF_A_3U = 7,
+    /// Adobe 버전 1.0.
+    V_1_0 = 8,
+    /// Adobe 버전 1.1.
+    V_1_1 = 9,
+    /// Adobe 버전 1.2.
+    V_1_2 = 10,
+    /// Adobe 버전 1.3.
+    V_1_3 = 11,
+    /// Adobe 버전 1.4.
+    V_1_4 = 12,
+    /// Adobe 버전 1.5.
+    V_1_5 = 13,
+    /// Adobe 버전 1.6.
+    V_1_6 = 14,
+    /// Adobe 버전 1.7.
+    V_1_7 = 15,
+    /// ISO 표준 PDF 2.0.
+    V_2_0 = 16,
+    /// PDF/UA-1 형식.
+    PDF_UA_1 = 17,
+    /// PDF/X-1a:2001 형식.
+    PDF_X_1A_2001 = 18,
+    /// PDF/X-1a 형식.
+    PDF_X_1A = 19,
+    /// PDF/X-3 형식.
+    PDF_X_3 = 20,
+    /// ZUGFeRD 형식.
+    ZUGFeRD = 21,
+    /// PDF/A-4 형식.
+    PDF_A_4 = 22,
+    /// PDF/A-4e 형식.
+    PDF_A_4E = 23,
+    /// PDF/A-4f 형식.
+    PDF_A_4F = 24,
+    /// PDF/X-4 형식.
+    PDF_X_4 = 25,
+    /// PDF/E-1 (PDF 1.6) 형식.
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// 비규격 요소 삭제.
+    Delete = 0,
+    /// 아무것도 하지 않음, 비규격 요소 유지.
+    None = 1,
+}
+```
+

--- a/korean/rust-cpp/convert/_index.md
+++ b/korean/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "PDF 함수 변환"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 파일에서 변환하기 위한 함수."
+type: docs
+url: /ko/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | 이전에 열었던 PDF-document를 DocX-document로 변환하고 저장합니다. |
+| [save_doc](./save_doc/) | 이전에 열었던 PDF-document를 Doc-document로 변환하고 저장합니다. |
+| [save_xlsx](./save_xlsx/) | 이전에 열었던 PDF-document를 XlsX-document로 변환하고 저장합니다. |
+| [save_txt](./save_txt/) | 이전에 열었던 PDF-document를 Txt-document로 변환하고 저장합니다. |
+| [save_pptx](./save_pptx/) | 이전에 열었던 PDF-document를 PptX-document로 변환하고 저장합니다. |
+| [save_xps](./save_xps/) | 이전에 열었던 PDF-document를 Xps-document로 변환하고 저장합니다. |
+| [save_tex](./save_tex/) | 이전에 열었던 PDF-document를 TeX-document로 변환하고 저장합니다. |
+| [save_epub](./save_epub/) | 이전에 열었던 PDF-document를 Epub-document로 변환하고 저장합니다. |
+| [save_booklet](./save_booklet/) | 이전에 열었던 PDF-document를 소책자 PDF-document로 변환하고 저장합니다. |
+| [save_n_up](./save_n_up/) | 이전에 열었던 PDF-document를 N-Up PDF-document로 변환하고 저장합니다. |
+| [save_markdown](./save_markdown/) | 이전에 열었던 PDF-document를 Markdown-document로 변환하고 저장합니다. |
+| [save_tiff](./save_tiff/) | 이전에 열었던 PDF-document를 Tiff-document로 변환하고 저장합니다. |
+| [save_docx_enhanced](./save_docx_enhanced/) | 이전에 열었던 PDF-document를 향상된 인식 모드가 적용된 DocX-document로 변환하고 저장합니다(완전히 편집 가능한 표와 단락). |
+| [save_svg_zip](./save_svg_zip/) | 이전에 열었던 PDF-document를 SVG-archive로 변환하고 저장합니다. |
+| [export_fdf](./export_fdf/) | AcroForm이 포함된 이전에 열었던 PDF-document를 FDF-document로 내보냅니다. |
+| [export_xfdf](./export_xfdf/) | AcroForm이 포함된 이전에 열었던 PDF-document를 XFDF-document로 내보냅니다. |
+| [export_xml](./export_xml/) | AcroForm이 포함된 이전에 열었던 PDF-document를 XML-document로 내보냅니다. |
+| [page_to_jpg](./page_to_jpg/) | 지정된 페이지를 Jpg-image로 변환하고 저장합니다. |
+| [page_to_png](./page_to_png/) | 지정된 페이지를 Png-image로 변환하고 저장합니다. |
+| [page_to_bmp](./page_to_bmp/) | 지정된 페이지를 Bmp-image로 변환하고 저장합니다. |
+| [page_to_tiff](./page_to_tiff/) | 지정된 페이지를 Tiff 이미지로 변환하고 저장합니다. |
+| [page_to_svg](./page_to_svg/) | 지정된 페이지를 Svg 이미지로 변환하고 저장합니다. |
+| [page_to_pdf](./page_to_pdf/) | 지정된 페이지를 PDF 문서로 변환하고 저장합니다. |
+| [page_to_dicom](./page_to_dicom/) | 지정된 페이지를 DICOM 이미지로 변환하고 저장합니다. |
+
+
+## Detailed Description
+
+PDF 파일에서 변환하기 위한 함수.
+

--- a/korean/rust-cpp/convert/export_fdf/_index.md
+++ b/korean/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "AcroForm이 포함된 이전에 연 PDF 문서를 파일 이름이 있는 FDF 문서로 내보냅니다."
+type: docs
+url: /ko/rust-cpp/convert/export_fdf/
+---
+
+_AcroForm이 포함된 이전에 연 PDF 문서를 파일 이름이 있는 FDF 문서로 내보냅니다._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // AcroForm이 포함된 이전에 연 PDF 문서를 FDF 문서로 내보냅니다
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/export_xfdf/_index.md
+++ b/korean/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열려 있던 PDF-document와 AcroForm을 사용하여 파일 이름이 있는 XFDF-document로 내보냅니다."
+type: docs
+url: /ko/rust-cpp/convert/export_xfdf/
+---
+
+_이전에 열려 있던 PDF-document와 AcroForm을 사용하여 파일 이름이 있는 XFDF-document로 내보냅니다._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열려 있던 PDF-document와 AcroForm을 사용하여 XFDF-document로 내보냅니다
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/export_xml/_index.md
+++ b/korean/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열려 있던 PDF-document와 AcroForm을 사용하여 파일 이름이 있는 XML-document으로 내보냅니다."
+type: docs
+url: /ko/rust-cpp/convert/export_xml/
+---
+
+_이전에 열려 있던 PDF-document와 AcroForm을 사용하여 파일 이름이 있는 XML-document으로 내보냅니다._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열려 있던 PDF-document와 AcroForm을 사용하여 XML-document로 내보냅니다
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_bmp/_index.md
+++ b/korean/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 BMP 이미지로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_bmp/
+---
+
+_지정된 페이지를 BMP 이미지로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 BMP 이미지로 변환하고 저장합니다
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_dicom/_index.md
+++ b/korean/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 DICOM-image로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_dicom/
+---
+
+_지정된 페이지를 DICOM-image로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 DICOM-image로 변환하고 저장합니다
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_jpg/_index.md
+++ b/korean/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 JPG-image로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_jpg/
+---
+
+_지정된 페이지를 JPG-image로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 Jpg-image로 변환하고 저장합니다
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_pdf/_index.md
+++ b/korean/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 PDF-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_pdf/
+---
+
+_지정된 페이지를 PDF-document로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 PDF-document로 변환하고 저장합니다
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_png/_index.md
+++ b/korean/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 PNG 이미지로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_png/
+---
+
+_지정된 페이지를 PNG 이미지로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 Png 이미지로 변환하고 저장합니다
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_svg/_index.md
+++ b/korean/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 SVG 이미지로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_svg/
+---
+
+_지정된 페이지를 SVG 이미지로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 SVG 이미지로 변환하고 저장합니다
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/page_to_tiff/_index.md
+++ b/korean/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 페이지를 TIFF 이미지로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/page_to_tiff/
+---
+
+_지정된 페이지를 TIFF 이미지로 변환하고 저장합니다._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 지정된 페이지를 Tiff 이미지로 변환하고 저장합니다
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_booklet/_index.md
+++ b/korean/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 소책자 PDF-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_booklet/
+---
+
+_이전에 열었던 PDF-document를 소책자 PDF-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 소책자 PDF-document로 변환하고 저장합니다
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/korean/rust-cpp/convert/save_doc/_index.md
+++ b/korean/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 DOC-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_doc/
+---
+
+_이전에 열었던 PDF-document를 DOC-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 Doc-document로 변환하고 저장합니다
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_docx/_index.md
+++ b/korean/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 DOCX-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_docx/
+---
+
+_이전에 열었던 PDF-document를 DOCX-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 DocX-document로 변환하고 저장합니다
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/korean/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열어둔 PDF 문서를 Enhanced Recognition Mode(완전 편집 가능한 표와 단락)를 사용한 DOCX 문서로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_docx_enhanced/
+---
+
+_이전에 열어둔 PDF 문서를 Enhanced Recognition Mode(완전 편집 가능한 표와 단락)를 사용한 DOCX 문서로 변환하고 저장합니다._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열어둔 PDF 문서를 Enhanced Recognition Mode(완전 편집 가능한 표와 단락)를 사용한 DOCX 문서로 변환하고 저장합니다
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_epub/_index.md
+++ b/korean/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열려 있던 PDF-document를 EPUB-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_epub/
+---
+
+_이전에 열었던 PDF-document를 EPUB-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 Epub-document로 변환하고 저장합니다
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_markdown/_index.md
+++ b/korean/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 연 PDF 문서를 Markdown 문서로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_markdown/
+---
+
+_이전에 연 PDF 문서를 Markdown 문서로 변환하고 저장합니다._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 연 PDF 문서를 Markdown 문서로 변환하고 저장합니다
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/korean/rust-cpp/convert/save_n_up/_index.md
+++ b/korean/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열어둔 PDF 문서를 N-Up PDF 문서로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_n_up/
+---
+
+_이전에 열어둔 PDF 문서를 N-Up PDF 문서로 변환하고 저장합니다._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열어둔 PDF 문서를 N-Up PDF 문서로 변환하고 저장합니다
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/korean/rust-cpp/convert/save_pptx/_index.md
+++ b/korean/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 PPTX-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_pptx/
+---
+
+_이전에 열었던 PDF-document를 PPTX-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 PptX-document로 변환하고 저장합니다
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_svg_zip/_index.md
+++ b/korean/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열려 있던 PDF-document를 SVG-archive로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_svg_zip/
+---
+
+_이전에 열려 있던 PDF-document를 SVG-archive로 변환하고 저장합니다._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열려 있던 PDF-document를 SVG-archive로 변환하고 저장합니다
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_tex/_index.md
+++ b/korean/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열어둔 PDF 문서를 TeX 문서로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_tex/
+---
+
+_이전에 열어둔 PDF 문서를 TeX 문서로 변환하고 저장합니다._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열어둔 PDF 문서를 TeX 문서로 변환하고 저장합니다
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_tiff/_index.md
+++ b/korean/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 Tiff-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_tiff/
+---
+
+_이전에 열었던 PDF-document를 Tiff-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 Tiff-document로 변환하고 저장합니다
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/korean/rust-cpp/convert/save_txt/_index.md
+++ b/korean/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열려 있던 PDF-document를 TXT-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_txt/
+---
+
+_이전에 열려 있던 PDF-document를 TXT-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열려 있던 PDF-document를 Txt-document로 변환하고 저장합니다
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_xlsx/_index.md
+++ b/korean/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF-document를 XLSX-document로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_xlsx/
+---
+
+_이전에 열었던 PDF-document를 XLSX-document로 변환하고 저장합니다._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 XlsX-document로 변환하고 저장합니다
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/convert/save_xps/_index.md
+++ b/korean/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열어둔 PDF 문서를 XPS 문서로 변환하고 저장합니다."
+type: docs
+url: /ko/rust-cpp/convert/save_xps/
+---
+
+_이전에 열어둔 PDF 문서를 XPS 문서로 변환하고 저장합니다._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열어둔 PDF 문서를 XPS 문서로 변환하고 저장합니다
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/_index.md
+++ b/korean/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "핵심 PDF 기능"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 파일 작업을 위한 핵심 기능."
+type: docs
+url: /ko/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [new](./new/) | 새 PDF 문서를 생성합니다. |
+| [open](./open/) | 파일 이름으로 PDF 문서를 엽니다. |
+| [save](./save/) | 이전에 연 PDF 문서를 저장합니다. |
+| [save_as](./save_as/) | 이전에 연 PDF 문서를 새 파일 이름으로 저장합니다. |
+| [set_license](./set_license/) | 파일 이름으로 라이선스를 설정합니다. |
+| [extract_text](./extract_text/) | PDF 문서 내용을 일반 텍스트로 반환합니다. |
+| [word_count](./word_count/) | PDF 문서의 단어 수를 반환합니다. |
+| [character_count](./character_count/) | PDF 문서의 문자 수를 반환합니다. |
+| [append](./append/) | 다른 PDF 문서에서 페이지를 추가합니다. |
+| [append_pages](./append_pages/) | 다른 PDF 문서에서 선택한 페이지를 추가합니다. |
+| [merge_documents](./merge_documents/) | 제공된 PDF 문서를 병합하여 새 PDF 문서를 생성합니다. |
+| [split_document](./split_document/) | 원본 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다. |
+| [split](./split/) | 현재 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다. |
+| [split_at_page](./split_at_page/) | PDF 문서를 두 개의 새 PDF 문서로 분할합니다. |
+| [split_at](./split_at/) | 현재 PDF 문서를 두 개의 새 PDF 문서로 분할합니다. |
+| [bytes](./bytes/) | PDF 문서의 내용을 바이트 벡터로 반환합니다. |
+| [get_meta_info](./get_meta_info/) | PDF 문서의 메타 정보 값을 가져옵니다. |
+| [set_meta_info](./set_meta_info/) | PDF-document의 메타 정보 값을 설정합니다. |
+| [clear_meta_info](./clear_meta_info/) | PDF-document의 모든 메타 정보 값을 지웁니다. |
+| [is_linearized](./is_linearized/) | 문서가 선형화되었는지 여부를 나타내는 값을 가져옵니다. |
+| [page_add](./page_add/) | PDF-document에 새 페이지를 추가합니다. |
+| [page_insert](./page_insert/) | PDF-document의 지정된 위치에 새 페이지를 삽입합니다. |
+| [page_delete](./page_delete/) | PDF-document에서 지정된 페이지를 삭제합니다. |
+| [page_count](./page_count/) | PDF-document의 페이지 수를 반환합니다. |
+| [page_word_count](./page_word_count/) | PDF-document의 지정된 페이지에서 단어 수를 반환합니다. |
+| [page_character_count](./page_character_count/) | PDF-document의 지정된 페이지에서 문자 수를 반환합니다. |
+| [page_is_blank](./page_is_blank/) | PDF-document에서 페이지가 비어 있는지 반환합니다. |
+
+
+## Detailed Description
+
+PDF 파일 작업을 위한 핵심 기능.
+

--- a/korean/rust-cpp/core/append/_index.md
+++ b/korean/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "다른 PDF-document의 페이지를 추가합니다."
+type: docs
+url: /ko/rust-cpp/core/append/
+---
+
+_다른 PDF-document의 페이지를 추가합니다._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 주요 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 다른 PDF-document을 추가하기 위해 엽니다
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // 다른 PDF-document에서 페이지를 추가합니다
+    pdf.append(&another_pdf)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/append_pages/_index.md
+++ b/korean/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "다른 PDF 문서에서 선택한 페이지를 추가합니다."
+type: docs
+url: /ko/rust-cpp/core/append_pages/
+---
+
+_다른 PDF 문서에서 선택한 페이지를 추가합니다._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 주요 PDF-document를 엽니다
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // 다른 PDF-document을 추가하기 위해 엽니다
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // 다른 PDF 문서에서 특정 페이지(1 및 3)를 추가합니다
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/bytes/_index.md
+++ b/korean/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "바이트"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 내용을 바이트 벡터로 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/bytes/
+---
+
+_PDF 문서의 내용을 바이트 벡터로 반환합니다._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // PDF 문서의 내용을 바이트 벡터로 반환
+    let data = pdf.bytes()?;
+
+    // 바이트 벡터의 길이를 출력
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/character_count/_index.md
+++ b/korean/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 문자 수를 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/character_count/
+---
+
+_PDF 문서의 문자 수를 반환합니다._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 문자 수를 반환
+    let count = pdf.character_count()?;
+
+    // 문자 수를 출력
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/clear_meta_info/_index.md
+++ b/korean/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 모든 메타 정보 값을 삭제합니다."
+type: docs
+url: /ko/rust-cpp/core/clear_meta_info/
+---
+
+_PDF 문서의 모든 메타 정보 값을 삭제합니다._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 모든 메타 정보 값을 삭제합니다
+    pdf.clear_meta_info()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/extract_text/_index.md
+++ b/korean/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document 내용을 일반 텍스트로 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/extract_text/
+---
+
+_PDF-document 내용을 일반 텍스트로 반환합니다._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document 내용을 일반 텍스트로 반환합니다
+    let txt = pdf.extract_text()?;
+
+    // 추출된 텍스트를 출력합니다
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/get_meta_info/_index.md
+++ b/korean/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 메타 정보 값을 가져옵니다."
+type: docs
+url: /ko/rust-cpp/core/get_meta_info/
+---
+
+_PDF-document의 메타 정보 값을 가져옵니다._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 메타 정보 값을 가져옵니다
+    let author = pdf.get_meta_info("Author")?;
+
+    // 결과를 출력합니다
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/is_linearized/_index.md
+++ b/korean/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "문서가 선형화되었는지 여부를 나타내는 값을 가져옵니다."
+type: docs
+url: /ko/rust-cpp/core/is_linearized/
+---
+
+_문서가 선형화되었는지 여부를 나타내는 값을 가져옵니다._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 문서가 선형화되었는지 여부를 나타내는 값을 가져옵니다
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/merge_documents/_index.md
+++ b/korean/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "제공된 PDF 문서를 병합하여 새 PDF 문서를 생성합니다."
+type: docs
+url: /ko/rust-cpp/core/merge_documents/
+---
+
+_제공된 PDF 문서를 병합하여 새 PDF 문서를 생성합니다._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf1 = Document::new()?;
+
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // 제공된 PDF 문서를 병합하여 새 PDF 문서를 생성합니다
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/new/_index.md
+++ b/korean/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "새"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "새 PDF 문서를 생성합니다."
+type: docs
+url: /ko/rust-cpp/core/new/
+---
+
+_새 PDF 문서를 생성합니다._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/open/_index.md
+++ b/korean/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "파일 이름으로 PDF-document을 엽니다."
+type: docs
+url: /ko/rust-cpp/core/open/
+---
+
+_파일 이름으로 PDF-document을 엽니다._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_add/_index.md
+++ b/korean/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에 새 페이지를 추가합니다."
+type: docs
+url: /ko/rust-cpp/core/page_add/
+---
+
+_PDF 문서에 새 페이지를 추가합니다._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에 새 페이지를 추가
+    pdf.page_add()?;
+
+    // 이전에 열었던 PDF-document를 저장합니다
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_character_count/_index.md
+++ b/korean/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 지정된 페이지에서 문자 수를 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/page_character_count/
+---
+
+_PDF 문서의 지정된 페이지에서 문자 수를 반환합니다._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 번호를 지정합니다 (1부터 시작하는 인덱스)
+    let page_number = 1;
+
+    // 지정된 페이지의 문자 수를 반환
+    let count = pdf.page_character_count(page_number)?;
+
+    // 문자 수를 출력
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_count/_index.md
+++ b/korean/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 페이지 수를 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/page_count/
+---
+
+_PDF 문서의 페이지 수를 반환합니다._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 페이지 수를 반환합니다
+    let count = pdf.page_count()?;
+
+    // 페이지 수를 출력합니다
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_delete/_index.md
+++ b/korean/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 지정된 페이지를 삭제합니다."
+type: docs
+url: /ko/rust-cpp/core/page_delete/
+---
+
+_PDF 문서에서 지정된 페이지를 삭제합니다._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 지정된 페이지를 삭제합니다
+    pdf.page_delete(1)?;
+
+    // 이전에 열었던 PDF-document를 저장합니다
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_insert/_index.md
+++ b/korean/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 지정된 위치에 새 페이지를 삽입합니다."
+type: docs
+url: /ko/rust-cpp/core/page_insert/
+---
+
+_PDF-document의 지정된 위치에 새 페이지를 삽입합니다._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 지정된 위치에 새 페이지를 삽입합니다
+    pdf.page_insert(1)?;
+
+    // 이전에 열었던 PDF-document를 저장합니다
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_is_blank/_index.md
+++ b/korean/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 페이지가 비어 있는지 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/page_is_blank/
+---
+
+_PDF-document에서 페이지가 비어 있음을 반환합니다._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 번호를 지정합니다 (1부터 시작하는 인덱스)
+    let page_number = 1;
+
+    // PDF-document에서 페이지가 비어 있음을 반환합니다
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // 지정된 페이지가 비어 있으면 출력합니다
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/page_word_count/_index.md
+++ b/korean/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 지정된 페이지에서 단어 수를 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/page_word_count/
+---
+
+_PDF 문서의 지정된 페이지에서 단어 수를 반환합니다._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 번호를 지정합니다 (1부터 시작하는 인덱스)
+    let page_number = 1;
+
+    // 지정된 페이지의 단어 수를 반환합니다
+    let count = pdf.page_word_count(page_number)?;
+
+    // 단어 수를 출력합니다
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/save/_index.md
+++ b/korean/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF 문서를 저장합니다."
+type: docs
+url: /ko/rust-cpp/core/save/
+---
+
+_이전에 열었던 PDF 문서를 저장합니다._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이전에 열었던 PDF-document를 저장합니다
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/save_as/_index.md
+++ b/korean/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이전에 열었던 PDF 문서를 새 파일 이름으로 저장합니다."
+type: docs
+url: /ko/rust-cpp/core/save_as/
+---
+
+_이전에 열었던 PDF 문서를 새 파일 이름으로 저장합니다._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // PDF 문서를 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/set_license/_index.md
+++ b/korean/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "파일 이름을 사용하여 라이선스를 설정합니다."
+type: docs
+url: /ko/rust-cpp/core/set_license/
+---
+
+_파일 이름을 사용하여 라이선스를 설정합니다._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 파일 이름으로 라이선스를 설정
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // 이제 라이선스가 있는 PDF 문서를 작업할 수 있습니다
+    // ...
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/set_meta_info/_index.md
+++ b/korean/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 메타 정보 값을 설정합니다."
+type: docs
+url: /ko/rust-cpp/core/set_meta_info/
+---
+
+_PDF 문서의 메타 정보 값을 설정합니다._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 메타 정보 값을 설정합니다
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/split/_index.md
+++ b/korean/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "현재 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다."
+type: docs
+url: /ko/rust-cpp/core/split/
+---
+
+_현재 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // 현재 PDF 문서에서 페이지를 추출하여 여러 개의 새 PDF 문서를 생성합니다
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // 각 분할된 부분을 별개의 PDF-document로 저장합니다
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/split_at/_index.md
+++ b/korean/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "현재 PDF 문서를 두 개의 새 PDF 문서로 분할합니다."
+type: docs
+url: /ko/rust-cpp/core/split_at/
+---
+
+_현재 PDF 문서를 두 개의 새 PDF 문서로 분할합니다._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // 현재 PDF 문서를 두 개의 새 PDF 문서로 분할합니다
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // 각 분할된 부분을 별개의 PDF-document로 저장합니다
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/split_at_page/_index.md
+++ b/korean/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document를 두 개의 새로운 PDF-documents로 분할합니다."
+type: docs
+url: /ko/rust-cpp/core/split_at_page/
+---
+
+_PDF-document를 두 개의 새로운 PDF-documents로 분할합니다._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // PDF-document를 두 개의 새로운 PDF-documents로 분할합니다
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // 각 분할된 부분을 별개의 PDF-document로 저장합니다
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/split_document/_index.md
+++ b/korean/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "원본 PDF-document에서 페이지를 추출하여 여러 개의 새로운 PDF-documents를 생성합니다."
+type: docs
+url: /ko/rust-cpp/core/split_document/
+---
+
+_원본 PDF-document에서 페이지를 추출하여 여러 개의 새로운 PDF-documents를 생성합니다._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf"라는 PDF-document를 엽니다
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // 원본 PDF-document에서 페이지를 추출하여 여러 개의 새로운 PDF-documents를 생성합니다
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // 각 분할된 부분을 별개의 PDF-document로 저장합니다
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/core/word_count/_index.md
+++ b/korean/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 단어 수를 반환합니다."
+type: docs
+url: /ko/rust-cpp/core/word_count/
+---
+
+_PDF 문서의 단어 수를 반환합니다._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 단어 수를 반환합니다
+    let count = pdf.word_count()?;
+
+    // 단어 수를 출력합니다
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/miscellaneous/_index.md
+++ b/korean/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "기타 기능"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "작업을 위한 기타 기능."
+type: docs
+url: /ko/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [about](./about/) | C++를 통해 Aspose.PDF for Rust에 대한 메타데이터 정보를 반환합니다. |
+
+
+## Detailed Description
+
+작업을 위한 기타 기능.
+

--- a/korean/rust-cpp/miscellaneous/about/_index.md
+++ b/korean/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "정보"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "C++를 통해 Aspose.PDF for Rust에 대한 메타데이터 정보를 반환합니다."
+type: docs
+url: /ko/rust-cpp/miscellaneous/about/
+---
+
+_C++를 통해 Aspose.PDF for Rust에 대한 메타데이터 정보를 반환합니다._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // C++를 통해 Aspose.PDF for Go에 대한 메타데이터 정보를 반환합니다.
+    let info = pdf.about()?;
+
+    // 메타데이터 필드 출력
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/_index.md
+++ b/korean/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PDF 정리 기능"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 파일 정리를 위한 기능."
+type: docs
+url: /ko/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [optimize](./optimize/) | PDF 문서 내용을 최적화합니다. |
+| [optimize_resource](./optimize_resource/) | PDF 문서의 리소스를 최적화합니다. |
+| [grayscale](./grayscale/) | PDF 문서를 흑백으로 변환합니다. |
+| [rotate](./rotate/) | PDF 문서를 회전합니다. |
+| [set_background](./set_background/) | RGB 값을 사용하여 PDF 문서 배경 색을 설정합니다. |
+| [repair](./repair/) | PDF 문서를 복구합니다. |
+| [replace_text](./replace_text/) | PDF 문서의 텍스트를 교체합니다 |
+| [add_page_num](./add_page_num/) | PDF 문서에 페이지 번호를 추가합니다 |
+| [add_text_header](./add_text_header/) | PDF 문서 헤더에 텍스트를 추가합니다 |
+| [add_text_footer](./add_text_footer/) | PDF 문서 푸터에 텍스트를 추가합니다 |
+| [flatten](./flatten/) | PDF 문서를 평면화합니다 |
+| [remove_annotations](./remove_annotations/) | PDF 문서에서 주석을 제거합니다 |
+| [remove_attachments](./remove_attachments/) | PDF 문서에서 첨부 파일을 제거합니다 |
+| [remove_blank_pages](./remove_blank_pages/) | PDF 문서에서 빈 페이지를 제거합니다 |
+| [remove_bookmarks](./remove_bookmarks/) | PDF 문서에서 북마크를 제거합니다 |
+| [remove_hidden_text](./remove_hidden_text/) | PDF 문서에서 숨겨진 텍스트를 제거합니다 |
+| [remove_images](./remove_images/) | PDF 문서에서 이미지를 제거합니다 |
+| [remove_javascripts](./remove_javascripts/) | PDF 문서에서 자바스크립트를 제거합니다 |
+| [remove_tables](./remove_tables/) | PDF 문서에서 표를 제거합니다. |
+| [remove_watermarks](./remove_watermarks/) | PDF 문서에서 워터마크를 제거합니다. |
+| [add_watermark](./add_watermark/) | PDF 문서에 워터마크를 추가합니다. |
+| [embed_fonts](./embed_fonts/) | PDF-document에 글꼴을 삽입합니다. |
+| [unembed_fonts](./unembed_fonts/) | PDF-document에서 글꼴 삽입을 해제합니다. |
+| [optimize_file_size](./optimize_file_size/) | 이미지 압축 품질을 사용하여 PDF-document의 크기를 최적화합니다. |
+| [remove_text_headers](./remove_text_headers/) | PDF-document에서 텍스트 머리글을 제거합니다. |
+| [remove_text_footers](./remove_text_footers/) | PDF-document에서 텍스트 바닥글을 제거합니다. |
+| [crop](./crop/) | PDF-document의 페이지를 자릅니다. |
+| [replace_font](./replace_font/) | PDF-document의 글꼴을 교체합니다. |
+| [convert](./convert/) | PDF-document를 지정된 PDF 형식의 PDF-document로 변환합니다 |
+| [validate](./validate/) | PDF-document가 PDF 형식에 준수하는지 검증합니다 |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | PDF-document에서 PDF/A 준수를 제거합니다 |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | PDF-document에서 PDF/UA 준수를 제거합니다 |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | PDF-document가 PDF/A 규격을 준수하는지 확인합니다 |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | PDF-document가 PDF/UA 규격을 준수하는지 확인합니다 |
+| [page_rotate](./page_rotate/) | PDF-document의 페이지를 회전합니다. |
+| [page_set_size](./page_set_size/) | PDF-document의 페이지 크기를 설정합니다. |
+| [page_grayscale](./page_grayscale/) | 페이지를 흑백으로 변환합니다. |
+| [page_add_text](./page_add_text/) | 페이지에 텍스트를 추가합니다. |
+| [page_replace_text](./page_replace_text/) | 페이지의 텍스트를 교체합니다 |
+| [page_add_page_num](./page_add_page_num/) | 페이지에 페이지 번호를 추가합니다 |
+| [page_add_text_header](./page_add_text_header/) | 페이지 머리글에 텍스트를 추가합니다 |
+| [page_add_text_footer](./page_add_text_footer/) | 페이지 바닥글에 텍스트를 추가합니다 |
+| [page_remove_annotations](./page_remove_annotations/) | 페이지의 주석을 제거합니다. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | 페이지의 숨겨진 텍스트를 제거합니다. |
+| [page_remove_images](./page_remove_images/) | 페이지의 이미지를 제거합니다. |
+| [page_remove_tables](./page_remove_tables/) | 페이지의 표를 제거합니다. |
+| [page_remove_watermarks](./page_remove_watermarks/) | 페이지에서 워터마크를 제거합니다. |
+| [page_add_watermark](./page_add_watermark/) | 페이지에 워터마크를 추가합니다. |
+| [page_remove_text_headers](./page_remove_text_headers/) | 페이지에서 텍스트 헤더를 제거합니다. |
+| [page_remove_text_footers](./page_remove_text_footers/) | 페이지에서 텍스트 푸터를 제거합니다. |
+| [page_crop](./page_crop/) | 페이지를 자릅니다. |
+| [page_replace_font](./page_replace_font/) | 페이지의 글꼴을 교체합니다. |
+| [page_merge_layers](./page_merge_layers/) | 페이지의 모든 레이어를 지정된 새 레이어 이름으로 단일 레이어로 병합합니다. |
+| [page_layers](./page_layers/) | 페이지의 레이어 이름을 가져옵니다. |
+
+
+## Detailed Description
+
+PDF 파일 정리를 위한 기능.

--- a/korean/rust-cpp/organize/add_page_num/_index.md
+++ b/korean/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에 페이지 번호를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/add_page_num/
+---
+
+_PDF-document에 페이지 번호를 추가합니다._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에 페이지 번호를 추가합니다
+    pdf.add_page_num()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/add_text_footer/_index.md
+++ b/korean/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 바닥글에 텍스트를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/add_text_footer/
+---
+
+_PDF-document의 바닥글에 텍스트를 추가합니다._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서 푸터에 텍스트를 추가합니다
+    pdf.add_text_footer("FOOTER")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/add_text_header/_index.md
+++ b/korean/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 헤더에 텍스트를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/add_text_header/
+---
+
+_PDF 문서의 헤더에 텍스트를 추가합니다._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서 헤더에 텍스트를 추가합니다
+    pdf.add_text_header("HEADER")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/add_watermark/_index.md
+++ b/korean/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에 워터마크를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/add_watermark/
+---
+
+_PDF-document에 워터마크를 추가합니다._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document에 워터마크를 추가합니다
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/convert/_index.md
+++ b/korean/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "지정된 PDF 형식으로 PDF-document를 PDF-document로 변환합니다."
+type: docs
+url: /ko/rust-cpp/organize/convert/
+---
+
+_지정된 PDF 형식으로 PDF-document를 PDF-document로 변환합니다._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document를 지정된 PDF 형식의 PDF-document로 변환합니다
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // 변환 결과와 전체 로그를 출력합니다
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/crop/_index.md
+++ b/korean/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "자르기"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 페이지를 자릅니다."
+type: docs
+url: /ko/rust-cpp/organize/crop/
+---
+
+_PDF-document의 페이지를 자릅니다._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 페이지를 자르기
+    pdf.crop(10.5)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/embed_fonts/_index.md
+++ b/korean/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에 글꼴을 포함합니다."
+type: docs
+url: /ko/rust-cpp/organize/embed_fonts/
+---
+
+_PDF 문서에 글꼴을 포함합니다._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에 글꼴 포함
+    pdf.embed_fonts()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/flatten/_index.md
+++ b/korean/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document을 평면화합니다."
+type: docs
+url: /ko/rust-cpp/organize/flatten/
+---
+
+_PDF-document을 평면화합니다._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document 내용을 일반 텍스트로 반환합니다
+    let txt = pdf.extract_text()?;
+
+    // 추출된 텍스트를 출력합니다
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/grayscale/_index.md
+++ b/korean/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document을 흑백으로 변환합니다."
+type: docs
+url: /ko/rust-cpp/organize/grayscale/
+---
+
+_PDF-document을 흑백으로 변환합니다._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document을 흑백으로 변환
+    pdf.grayscale()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/korean/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document가 PDF/A 준수인지 확인합니다."
+type: docs
+url: /ko/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_PDF-document가 PDF/A 준수인지 확인합니다._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 PDF/A 준수 상태를 가져오기
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/korean/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서가 PDF/UA 규격을 준수하는지 가져옵니다."
+type: docs
+url: /ko/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_PDF 문서가 PDF/UA 규격을 준수하는지 가져옵니다._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 PDF/UA 준수 상태를 가져옵니다
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/optimize/_index.md
+++ b/korean/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서 콘텐츠를 최적화합니다."
+type: docs
+url: /ko/rust-cpp/organize/optimize/
+---
+
+_PDF 문서 콘텐츠를 최적화합니다._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서 콘텐츠를 최적화합니다
+    pdf.optimize()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/optimize_file_size/_index.md
+++ b/korean/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "이미지 압축 품질을 사용하여 PDF 문서의 크기를 최적화합니다."
+type: docs
+url: /ko/rust-cpp/organize/optimize_file_size/
+---
+
+_이미지 압축 품질을 사용하여 PDF 문서의 크기를 최적화합니다._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 이미지 압축 품질을 사용하여 PDF 문서의 크기를 최적화
+    pdf.optimize_file_size(50)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/optimize_resource/_index.md
+++ b/korean/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 리소스를 최적화합니다."
+type: docs
+url: /ko/rust-cpp/organize/optimize_resource/
+---
+
+_PDF-document의 리소스를 최적화합니다._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 리소스를 최적화
+    pdf.optimize_resource()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_add_page_num/_index.md
+++ b/korean/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에 페이지 번호를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_add_page_num/
+---
+
+_페이지에 페이지 번호를 추가합니다._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에 페이지 번호를 추가합니다
+    pdf.page_add_page_num(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_add_text/_index.md
+++ b/korean/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에 텍스트를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_add_text/
+---
+
+_페이지에 텍스트를 추가합니다._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에 텍스트를 추가합니다
+    pdf.page_add_text(1, "added text")?;
+
+    // 이전에 열었던 PDF-document를 저장합니다
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/korean/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지 바닥글에 �스트를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_add_text_footer/
+---
+
+_페이지 바닥글에 �스트를 추가합니다._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 바닥글에 텍스트를 추가합니다
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_add_text_header/_index.md
+++ b/korean/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지 헤더에 텍스트를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_add_text_header/
+---
+
+_페이지 헤더에 텍스트를 추가합니다._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 머리글에 텍스트를 추가합니다
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_add_watermark/_index.md
+++ b/korean/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에 워터마크를 추가합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_add_watermark/
+---
+
+_페이지에 워터마크를 추가합니다._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에 워터마크 추가
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_crop/_index.md
+++ b/korean/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지를 자릅니다."
+type: docs
+url: /ko/rust-cpp/organize/page_crop/
+---
+
+_페이지를 자릅니다._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지를 자르기
+    pdf.page_crop(1, 1.0)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_grayscale/_index.md
+++ b/korean/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지를 흑백으로 변환합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_grayscale/
+---
+
+_페이지를 흑백으로 변환합니다._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지를 흑백으로 변환
+    pdf.page_grayscale(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_layers/_index.md
+++ b/korean/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 레이어 이름을 가져옵니다."
+type: docs
+url: /ko/rust-cpp/organize/page_layers/
+---
+
+_페이지의 레이어 이름을 가져옵니다._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // 페이지 1의 레이어 이름을 가져옵니다
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_merge_layers/_index.md
+++ b/korean/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 모든 레이어를 지정된 새 레이어 이름으로 단일 레이어에 병합합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_merge_layers/
+---
+
+_페이지의 모든 레이어를 지정된 새 레이어 이름으로 단일 레이어에 병합합니다._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 모든 레이어를 지정된 새 레이어 이름으로 단일 레이어에 병합
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/korean/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 주석을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_annotations/
+---
+
+_페이지의 주석을 제거합니다._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 주석을 제거
+    pdf.page_remove_annotations(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/korean/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에서 숨겨진 텍스트를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_페이지에서 숨겨진 텍스트를 제거합니다._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에서 숨겨진 텍스트를 제거합니다
+    pdf.page_remove_hidden_text(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_images/_index.md
+++ b/korean/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 이미지를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_images/
+---
+
+_페이지의 이미지를 제거합니다._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 이미지 제거
+    pdf.page_remove_images(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_tables/_index.md
+++ b/korean/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에서 표를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_tables/
+---
+
+_페이지에서 표를 제거합니다._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에서 표 제거
+    pdf.page_remove_tables(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/korean/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 텍스트 바닥글을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_text_footers/
+---
+
+_페이지의 텍스트 바닥글을 제거합니다._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 텍스트 바닥글을 제거합니다
+    pdf.page_remove_text_footers(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/korean/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에서 텍스트 머리글을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_text_headers/
+---
+
+_페이지에서 텍스트 머리글을 제거합니다._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에서 텍스트 머리글을 제거합니다
+    pdf.page_remove_text_headers(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/korean/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지에서 워터마크를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_remove_watermarks/
+---
+
+_페이지에서 워터마크를 제거합니다._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지에서 워터마크 제거
+    pdf.page_remove_watermarks(1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_replace_font/_index.md
+++ b/korean/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 글꼴을 교체합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_replace_font/
+---
+
+_페이지의 글꼴을 교체합니다._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 글꼴을 교체
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_replace_text/_index.md
+++ b/korean/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "페이지의 텍스트를 교체합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_replace_text/
+---
+
+_페이지의 텍스트를 교체합니다._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지의 텍스트를 교체합니다
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_rotate/_index.md
+++ b/korean/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 페이지를 회전합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_rotate/
+---
+
+_PDF 문서에서 페이지를 회전합니다._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일에서 PDF-document를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // 페이지 회전
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/page_set_size/_index.md
+++ b/korean/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 페이지의 크기를 설정합니다."
+type: docs
+url: /ko/rust-cpp/organize/page_set_size/
+---
+
+_PDF 문서에서 페이지의 크기를 설정합니다._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 페이지의 크기를 설정합니다
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_annotations/_index.md
+++ b/korean/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 주석을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_annotations/
+---
+
+_PDF-document에서 주석을 제거합니다._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 주석을 제거합니다
+    pdf.remove_annotations()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_attachments/_index.md
+++ b/korean/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 첨부 파일을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_attachments/
+---
+
+_PDF 문서에서 첨부 파일을 제거합니다._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 첨부 파일을 제거합니다
+    pdf.remove_attachments()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/korean/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 빈 페이지를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_blank_pages/
+---
+
+_PDF 문서에서 빈 페이지를 제거합니다._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 빈 페이지를 제거합니다
+    pdf.remove_blank_pages()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/korean/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 북마크를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_bookmarks/
+---
+
+_PDF-document에서 북마크를 제거합니다._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 북마크를 제거합니다
+    pdf.remove_bookmarks()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/korean/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 숨겨진 텍스트를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_hidden_text/
+---
+
+_PDF 문서에서 숨겨진 텍스트를 제거합니다._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 숨겨진 텍스트를 제거합니다
+    pdf.remove_hidden_text()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_images/_index.md
+++ b/korean/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 이미지를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_images/
+---
+
+_PDF 문서에서 이미지를 제거합니다._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 이미지를 제거합니다
+    pdf.remove_images()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_javascripts/_index.md
+++ b/korean/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 Java 스크립트를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_javascripts/
+---
+
+_PDF 문서에서 Java 스크립트를 제거합니다._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 자바스크립트를 제거합니다
+    pdf.remove_javascripts()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/korean/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 PDF/A 호환성을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_PDF-document에서 PDF/A 준수를 제거합니다._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document에서 PDF/A 준수를 제거합니다
+    pdf.remove_pdfa_compliance()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/korean/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 PDF/UA 준수를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_PDF 문서에서 PDF/UA 준수를 제거합니다._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document에서 PDF/UA 준수를 제거합니다
+    pdf.remove_pdfua_compliance()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_tables/_index.md
+++ b/korean/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 테이블을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_tables/
+---
+
+_PDF-document에서 테이블을 제거합니다._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document에서 테이블을 제거합니다
+    pdf.remove_tables()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_text_footers/_index.md
+++ b/korean/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 텍스트 바닥글을 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_text_footers/
+---
+
+_PDF 문서에서 텍스트 바닥글을 제거합니다._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 텍스트 바닥글을 제거합니다
+    pdf.remove_text_footers()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_text_headers/_index.md
+++ b/korean/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 텍스트 헤더를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_text_headers/
+---
+
+_PDF 문서에서 텍스트 헤더를 제거합니다._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 텍스트 헤더 제거
+    pdf.remove_text_headers()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/remove_watermarks/_index.md
+++ b/korean/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서에서 워터마크를 제거합니다."
+type: docs
+url: /ko/rust-cpp/organize/remove_watermarks/
+---
+
+_PDF 문서에서 워터마크를 제거합니다._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서에서 워터마크 제거
+    pdf.remove_watermarks()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/repair/_index.md
+++ b/korean/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서를 복구합니다."
+type: docs
+url: /ko/rust-cpp/organize/repair/
+---
+
+_PDF 문서를 복구합니다._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서 복구
+    pdf.repair()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/replace_font/_index.md
+++ b/korean/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서의 글꼴을 교체합니다."
+type: docs
+url: /ko/rust-cpp/organize/replace_font/
+---
+
+_PDF 문서의 글꼴을 교체합니다._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document의 글꼴을 교체합니다.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/replace_text/_index.md
+++ b/korean/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "텍스트를 교체합니다."
+type: docs
+url: /ko/rust-cpp/organize/replace_text/
+---
+
+_텍스트를 교체합니다._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서의 텍스트를 교체합니다
+    pdf.replace_text("PDF", "TXT")?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/rotate/_index.md
+++ b/korean/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 문서를 회전합니다."
+type: docs
+url: /ko/rust-cpp/organize/rotate/
+---
+
+_PDF 문서를 회전합니다._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF 문서 회전
+    pdf.rotate(Rotation::On270)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/set_background/_index.md
+++ b/korean/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "RGB 값을 사용하여 PDF 문서 배경 색상을 설정합니다."
+type: docs
+url: /ko/rust-cpp/organize/set_background/
+---
+
+_RGB 값을 사용하여 PDF 문서 배경 색상을 설정합니다._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // RGB 값을 사용하여 PDF 문서 배경 색상을 설정
+    pdf.set_background(200, 100, 101)?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/unembed_fonts/_index.md
+++ b/korean/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 글꼴 포함을 해제합니다."
+type: docs
+url: /ko/rust-cpp/organize/unembed_fonts/
+---
+
+_PDF-document에서 글꼴 포함을 해제합니다._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document에서 글꼴 포함 해제
+    pdf.unembed_fonts()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/organize/validate/_index.md
+++ b/korean/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF 형식 준수를 위해 PDF 문서를 검증합니다."
+type: docs
+url: /ko/rust-cpp/organize/validate/
+---
+
+_PDF 형식 준수를 위해 PDF 문서를 검증합니다._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document가 PDF 형식에 준수하는지 검증합니다
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // 검증 결과와 전체 로그를 출력합니다
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/_index.md
+++ b/korean/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "보안 기능"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "보안 기능."
+type: docs
+url: /ko/rust-cpp/security/
+---
+
+## Security
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | 비밀번호로 보호된 PDF-document를 엽니다. |
+| [encrypt](./encrypt/) | PDF-document를 암호화합니다. |
+| [decrypt](./decrypt/) | PDF-document를 복호화합니다. |
+| [set_permissions](./set_permissions/) | PDF-document에 대한 권한을 설정합니다. |
+| [get_permissions](./get_permissions/) | PDF-document의 현재 권한을 가져옵니다. |
+| [is_encrypted](./is_encrypted/) | PDF-document의 암호화 상태를 가져옵니다. |
+| [sign_pkcs7](./sign_pkcs7/) | PKCS#7 디지털 서명을 사용하여 PDF-document에 서명합니다. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | PKCS#7 Detached 디지털 서명을 사용하여 PDF-document에 서명합니다. |
+| [is_signed](./is_signed/) | PDF-document의 서명 상태를 가져옵니다. |
+| [remove_signs](./remove_signs/) | PDF-document에서 서명을 제거합니다. |
+
+
+## Detailed Description
+
+보안 기능.
+

--- a/korean/rust-cpp/security/decrypt/_index.md
+++ b/korean/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "복호화"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document를 복호화합니다."
+type: docs
+url: /ko/rust-cpp/security/decrypt/
+---
+
+_PDF 문서를 복호화합니다._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 비밀번호로 보호된 PDF 문서를 엽니다
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // PDF 문서 복호화
+    pdf.decrypt()?;
+
+    // 이전에 열었던 PDF-document을 새 파일 이름으로 저장합니다
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/encrypt/_index.md
+++ b/korean/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "암호화"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document를 암호화합니다."
+type: docs
+url: /ko/rust-cpp/security/encrypt/
+---
+
+_PDF-document을 암호화합니다._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // PDF-document을 암호화합니다
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // 암호화된 PDF-document을 저장합니다
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/get_permissions/_index.md
+++ b/korean/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 현재 권한을 가져옵니다."
+type: docs
+url: /ko/rust-cpp/security/get_permissions/
+---
+
+_PDF 문서의 현재 권한을 가져옵니다._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 비밀번호로 보호된 PDF 문서를 엽니다
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // PDF 문서의 현재 권한 가져오기
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // 권한 출력
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/is_encrypted/_index.md
+++ b/korean/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 암호화 상태를 가져옵니다."
+type: docs
+url: /ko/rust-cpp/security/is_encrypted/
+---
+
+_PDF 문서의 암호화 상태를 가져옵니다._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 비밀번호로 보호된 PDF 문서를 엽니다
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // PDF 문서의 암호화 상태 가져오기
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/is_signed/_index.md
+++ b/korean/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document의 서명 상태를 가져옵니다."
+type: docs
+url: /ko/rust-cpp/security/is_signed/
+---
+
+_PDF-document의 서명 상태를 가져옵니다._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample_with_sign.pdf"라는 PDF 문서를 엽니다
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // PDF-document의 서명 상태를 가져옵니다
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/open_with_password/_index.md
+++ b/korean/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "비밀번호로 보호된 PDF-document를 엽니다."
+type: docs
+url: /ko/rust-cpp/security/open_with_password/
+---
+
+_비밀번호로 보호된 PDF 문서를 엽니다._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 비밀번호로 보호된 PDF 문서를 엽니다
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // 작업 중...
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/remove_signs/_index.md
+++ b/korean/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에서 서명을 제거합니다."
+type: docs
+url: /ko/rust-cpp/security/remove_signs/
+---
+
+_PDF 문서에서 서명을 제거합니다._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample_with_sign.pdf"라는 PDF 문서를 엽니다
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // PDF 문서에서 서명 제거
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/set_permissions/_index.md
+++ b/korean/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PDF-document에 대한 권한을 설정합니다."
+type: docs
+url: /ko/rust-cpp/security/set_permissions/
+---
+
+_PDF-document에 대한 권한을 설정합니다._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 새 PDF 문서를 생성합니다
+    let pdf = Document::new()?;
+
+    // PDF-document에 대한 권한을 설정합니다.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // 업데이트된 권한으로 PDF-document을 저장합니다
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/sign_pkcs7/_index.md
+++ b/korean/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PKCS#7 디지털 서명을 사용하여 PDF-document에 서명합니다."
+type: docs
+url: /ko/rust-cpp/security/sign_pkcs7/
+---
+
+_PKCS#7 디지털 서명을 사용하여 PDF-document에 서명합니다._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 인증서 및 이미지 파일을 바이트 벡터로 읽어들입니다
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PKCS#7 디지털 서명을 사용하여 PDF-document에 서명합니다
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/korean/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/korean/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "C++를 통해 Rust용 Aspose.PDF"
+description: "PKCS#7 Detached 디지털 서명을 사용하여 PDF-document에 서명합니다."
+type: docs
+url: /ko/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_PKCS#7 Detached 디지털 서명을 사용하여 PDF-document에 서명합니다._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 인증서 및 이미지 파일을 바이트 벡터로 읽어들입니다
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // 파일 이름으로 PDF 문서를 엽니다
+    let pdf = Document::open("sample.pdf")?;
+
+    // PKCS#7 Detached 디지털 서명을 사용하여 PDF-document에 서명합니다
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Automated translation of the RUST-CPP API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 122/122
- Errors: 0
- Source: `english/rust-cpp`
- Output: `korean/rust-cpp`

🤖 Generated by RDA