### PR TITLE
[auto] Translate RUST-CPP API Reference to Portuguese

### DIFF
--- a/portuguese/rust-cpp/_index.md
+++ b/portuguese/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF para Rust via C++"
+description: "Aspose.PDF para Rust via C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /pt/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Estruturas
+
+## Document
+Document representa um documento PDF.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Função | Descrição |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Converter e salvar o PDF-documento previamente aberto como documento DocX. |
+| [save_doc](./convert/save_doc/) | Converter e salvar o PDF-documento previamente aberto como documento Doc. |
+| [save_xlsx](./convert/save_xlsx/) | Converter e salvar o PDF-documento previamente aberto como documento XlsX. |
+| [save_txt](./convert/save_txt/) | Converter e salvar o PDF-documento previamente aberto como documento Txt. |
+| [save_pptx](./convert/save_pptx/) | Converter e salvar o PDF-documento previamente aberto como documento PptX. |
+| [save_xps](./convert/save_xps/) | Converter e salvar o PDF-documento previamente aberto como documento Xps. |
+| [save_tex](./convert/save_tex/) | Converter e salvar o PDF-documento previamente aberto como documento TeX. |
+| [save_epub](./convert/save_epub/) | Converter e salvar o PDF-documento previamente aberto como documento Epub. |
+| [save_booklet](./convert/save_booklet/) | Converter e salvar o PDF-documento previamente aberto como PDF em formato de livreto. |
+| [save_n_up](./convert/save_n_up/) | Converter e salvar o PDF-documento previamente aberto como PDF N-Up. |
+| [save_markdown](./convert/save_markdown/) | Converter e salvar o PDF-documento previamente aberto como documento Markdown. |
+| [save_tiff](./convert/save_tiff/) | Converter e salvar o PDF-documento previamente aberto como documento Tiff. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Converter e salvar o PDF-documento previamente aberto como documento DocX com Modo de Reconhecimento Avançado (tabelas e parágrafos totalmente editáveis). |
+| [save_svg_zip](./convert/save_svg_zip/) | Converter e salvar o PDF-documento previamente aberto como arquivo SVG. |
+| [export_fdf](./convert/export_fdf/) | Exportar do PDF-documento previamente aberto com AcroForm para documento FDF. |
+| [export_xfdf](./convert/export_xfdf/) | Exportar do PDF-documento previamente aberto com AcroForm para documento XFDF. |
+| [export_xml](./convert/export_xml/) | Exportar do PDF-documento previamente aberto com AcroForm para documento XML. |
+| [page_to_jpg](./convert/page_to_jpg/) | Converter e salvar a página especificada como imagem Jpg. |
+| [page_to_png](./convert/page_to_png/) | Converter e salvar a página especificada como imagem Png. |
+| [page_to_bmp](./convert/page_to_bmp/) | Converter e salvar a página especificada como imagem Bmp. |
+| [page_to_tiff](./convert/page_to_tiff/) | Converter e salvar a página especificada como imagem Tiff. |
+| [page_to_svg](./convert/page_to_svg/) | Converter e salvar a página especificada como imagem Svg. |
+| [page_to_pdf](./convert/page_to_pdf/) | Converter e salvar a página especificada como documento PDF. |
+| [page_to_dicom](./convert/page_to_dicom/) | Converter e salvar a página especificada como imagem DICOM. |
+
+
+## Organize PDF functions
+
+| Função | Descrição |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Otimizar o conteúdo do documento PDF. |
+| [optimize_resource](./organize/optimize_resource/) | Otimizar os recursos do documento PDF. |
+| [grayscale](./organize/grayscale/) | Converter documento PDF para preto e branco. |
+| [rotate](./organize/rotate/) | Rotacionar documento PDF. |
+| [set_background](./organize/set_background/) | Definir a cor de fundo do documento PDF usando valores RGB. |
+| [repair](./organize/repair/) | Reparar documento PDF. |
+| [replace_text](./organize/replace_text/) | Substituir texto no documento PDF |
+| [add_page_num](./organize/add_page_num/) | Adicionar número de página a um documento PDF |
+| [add_text_header](./organize/add_text_header/) | Adicionar texto no cabeçalho de um documento PDF |
+| [add_text_footer](./organize/add_text_footer/) | Adicionar texto no rodapé de um documento PDF |
+| [flatten](./organize/flatten/) | Aplanar documento PDF |
+| [remove_annotations](./organize/remove_annotations/) | Remover anotações do documento PDF |
+| [remove_attachments](./organize/remove_attachments/) | Remover anexos do documento PDF |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Remover páginas em branco do documento PDF |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Remover marcadores do documento PDF |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Remover texto oculto do documento PDF |
+| [remove_images](./organize/remove_images/) | Remover imagens do documento PDF |
+| [remove_javascripts](./organize/remove_javascripts/) | Remover scripts Java do documento PDF |
+| [remove_tables](./organize/remove_tables/) | Remover tabelas de um documento PDF. |
+| [remove_watermarks](./organize/remove_watermarks/) | Remover marcas d'água do documento PDF. |
+| [add_watermark](./organize/add_watermark/) | Adicionar marca d'água ao documento PDF. |
+| [embed_fonts](./organize/embed_fonts/) | Incorporar fontes a um documento PDF. |
+| [unembed_fonts](./organize/unembed_fonts/) | Desincorporar fontes de um documento PDF. |
+| [optimize_file_size](./organize/optimize_file_size/) | Otimizar o tamanho do documento PDF com qualidade de compressão de imagem. |
+| [remove_text_headers](./organize/remove_text_headers/) | Remover cabeçalhos de texto de um documento PDF. |
+| [remove_text_footers](./organize/remove_text_footers/) | Remover rodapés de texto de um documento PDF. |
+| [crop](./organize/crop/) | Cortar páginas de um documento PDF. |
+| [replace_font](./organize/replace_font/) | Substituir fonte em um documento PDF. |
+| [convert](./organize/convert/) | Converter um documento PDF em um documento PDF com o formato PDF especificado |
+| [validate](./organize/validate/) | Validar um documento PDF quanto à conformidade com o formato PDF |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Remover a conformidade PDF/A de um documento PDF |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Remover a conformidade PDF/UA de um documento PDF |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Obter se um documento PDF está em conformidade PDF/A |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Obter se um documento PDF está em conformidade PDF/UA |
+| [page_rotate](./organize/page_rotate/) | Rotacionar uma página no documento PDF. |
+| [page_set_size](./organize/page_set_size/) | Definir o tamanho de uma página no documento PDF. |
+| [page_grayscale](./organize/page_grayscale/) | Converter página para preto e branco. |
+| [page_add_text](./organize/page_add_text/) | Adicionar texto na página. |
+| [page_replace_text](./organize/page_replace_text/) | Substituir texto na página |
+| [page_add_page_num](./organize/page_add_page_num/) | Adicionar número da página na página |
+| [page_add_text_header](./organize/page_add_text_header/) | Adicionar texto no cabeçalho da página |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Adicionar texto no rodapé da página |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Remover anotações na página. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Remover texto oculto na página. |
+| [page_remove_images](./organize/page_remove_images/) | Remover imagens na página. |
+| [page_remove_tables](./organize/page_remove_tables/) | Remover tabelas na página. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Remover marcas d'água na página. |
+| [page_add_watermark](./organize/page_add_watermark/) | Adicionar marca d'água na página. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Remover cabeçalhos de texto na página. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Remover rodapés de texto na página. |
+| [page_crop](./organize/page_crop/) | Cortar uma página. |
+| [page_replace_font](./organize/page_replace_font/) | Substituir fonte na página. |
+| [page_merge_layers](./organize/page_merge_layers/) | Mesclar todas as camadas na página em uma única camada com o nome da nova camada especificado. |
+| [page_layers](./organize/page_layers/) | Obter nomes das camadas na página. |
+
+
+## Core PDF functions
+
+| Função | Descrição |
+| -------- | ----------- |
+| [new](./core/new/) | Criar um novo documento PDF. |
+| [open](./core/open/) | Abrir um documento PDF com nome de arquivo. |
+| [save](./core/save/) | Salvar o documento PDF aberto anteriormente. |
+| [save_as](./core/save_as/) | Salvar o documento PDF aberto anteriormente com novo nome de arquivo. |
+| [set_license](./core/set_license/) | Definir licença com nome de arquivo. |
+| [extract_text](./core/extract_text/) | Retornar o conteúdo do documento PDF como texto simples. |
+| [word_count](./core/word_count/) | Retornar a contagem de palavras no documento PDF. |
+| [character_count](./core/character_count/) | Retornar a contagem de caracteres no documento PDF. |
+| [append](./core/append/) | Anexar páginas de outro documento PDF. |
+| [append_pages](./core/append_pages/) | Anexar páginas selecionadas de outro documento PDF. |
+| [merge_documents](./core/merge_documents/) | Criar um novo documento PDF mesclando os documentos PDF fornecidos. |
+| [split_document](./core/split_document/) | Criar vários novos documentos PDF extraindo páginas do documento PDF fonte. |
+| [split](./core/split/) | Criar vários novos documentos PDF extraindo páginas do documento PDF atual. |
+| [split_at_page](./core/split_at_page/) | Dividir o documento PDF em dois novos documentos PDF. |
+| [split_at](./core/split_at/) | Dividir o documento PDF atual em dois novos documentos PDF. |
+| [bytes](./core/bytes/) | Retornar o conteúdo do documento PDF como um vetor de bytes. |
+| [get_meta_info](./core/get_meta_info/) | Obter o valor da informação de metadados do documento PDF. |
+| [set_meta_info](./core/set_meta_info/) | Definir valor da informação de metadados do PDF-document. |
+| [clear_meta_info](./core/clear_meta_info/) | Limpar todos os valores de informação de metadados do PDF-document. |
+| [is_linearized](./core/is_linearized/) | Obter um valor que indica se o documento está linearizado. |
+| [page_add](./core/page_add/) | Adicionar nova página no PDF-document. |
+| [page_insert](./core/page_insert/) | Inserir nova página na posição especificada no PDF-document. |
+| [page_delete](./core/page_delete/) | Excluir página especificada no PDF-document. |
+| [page_count](./core/page_count/) | Retornar o número de páginas no PDF-document. |
+| [page_word_count](./core/page_word_count/) | Retornar a contagem de palavras na página especificada do PDF-document. |
+| [page_character_count](./core/page_character_count/) | Retornar a contagem de caracteres na página especificada do PDF-document. |
+| [page_is_blank](./core/page_is_blank/) | Retornar se a página está em branco no PDF-document. |
+
+
+## Security
+| Função | Descrição |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Abrir um PDF-document protegido por senha. |
+| [encrypt](./security/encrypt/) | Criptografar PDF-document. |
+| [decrypt](./security/decrypt/) | Descriptografar PDF-document. |
+| [set_permissions](./security/set_permissions/) | Definir permissões para PDF-document. |
+| [get_permissions](./security/get_permissions/) | Obter permissões atuais do PDF-document. |
+| [is_encrypted](./security/is_encrypted/) | Obter status de criptografia do PDF-document. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Assinar um PDF-document usando assinaturas digitais PKCS#7. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Assinar um PDF-document usando assinaturas digitais PKCS#7 Detached. |
+| [is_signed](./security/is_signed/) | Obter status de assinatura do PDF-document. |
+| [remove_signs](./security/remove_signs/) | Remover assinaturas do PDF-document. |
+
+
+## Miscellaneous
+
+| Função | Descrição |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Retornar informações de metadados sobre o Aspose.PDF para Rust via C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Conjunto de bitflags que representa as capacidades de permissão de PDF.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// Tamanho A0.
+    A0 = 0,
+    /// Tamanho A1.
+    A1 = 1,
+    /// Tamanho A2.
+    A2 = 2,
+    /// tamanho A3.
+    A3 = 3,
+    /// tamanho A4.
+    A4 = 4,
+    /// tamanho A5.
+    A5 = 5,
+    /// tamanho A6.
+    A6 = 6,
+    /// tamanho B5.
+    B5 = 7,
+    /// tamanho PageLetter.
+    PageLetter = 8,
+    /// tamanho PageLegal.
+    PageLegal = 9,
+    /// tamanho PageLedger.
+    PageLedger = 10,
+    /// tamanho P11x17.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Não rotacionado.
+    None = 0,
+    /// Rotacionado em 90 graus no sentido horário.
+    On90 = 1,
+    /// Rotacionado em 180 graus.
+    On180 = 2,
+    /// Rotacionado em 270 graus no sentido horário.
+    On270 = 3,
+    /// Rotacionado em 360 graus no sentido horário.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 com comprimento de chave 40.
+    RC4x40 = 0,
+    /// RC4 com comprimento de chave 128.
+    RC4x128 = 1,
+    /// AES com comprimento de chave 128.
+    AESx128 = 2,
+    /// AES com comprimento de chave 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// formato PDF/A-1a.
+    PDF_A_1A = 0,
+    /// formato PDF/A-1b.
+    PDF_A_1B = 1,
+    /// formato PDF/A-2a.
+    PDF_A_2A = 2,
+    /// formato PDF/A-3a.
+    PDF_A_3A = 3,
+    /// formato PDF/A-2b.
+    PDF_A_2B = 4,
+    /// formato PDF/A-2u.
+    PDF_A_2U = 5,
+    /// formato PDF/A-3b.
+    PDF_A_3B = 6,
+    /// formato PDF/A-3u.
+    PDF_A_3U = 7,
+    /// versão Adobe 1.0.
+    V_1_0 = 8,
+    /// versão Adobe 1.1.
+    V_1_1 = 9,
+    /// versão Adobe 1.2.
+    V_1_2 = 10,
+    /// versão Adobe 1.3.
+    V_1_3 = 11,
+    /// versão Adobe 1.4.
+    V_1_4 = 12,
+    /// versão Adobe 1.5.
+    V_1_5 = 13,
+    /// versão Adobe 1.6.
+    V_1_6 = 14,
+    /// versão Adobe 1.7.
+    V_1_7 = 15,
+    /// Padrão ISO PDF 2.0.
+    V_2_0 = 16,
+    /// formato PDF/UA-1.
+    PDF_UA_1 = 17,
+    /// formato PDF/X-1a:2001.
+    PDF_X_1A_2001 = 18,
+    /// formato PDF/X-1a.
+    PDF_X_1A = 19,
+    /// formato PDF/X-3.
+    PDF_X_3 = 20,
+    /// formato ZUGFeRD.
+    ZUGFeRD = 21,
+    /// formato PDF/A-4.
+    PDF_A_4 = 22,
+    /// formato PDF/A-4e.
+    PDF_A_4E = 23,
+    /// formato PDF/A-4f.
+    PDF_A_4F = 24,
+    /// formato PDF/X-4.
+    PDF_X_4 = 25,
+    /// formato PDF/E-1 (PDF 1.6).
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Excluir elementos não conformes.
+    Delete = 0,
+    /// Não fazer nada, manter elementos não conformes.
+    None = 1,
+}
+```
+

--- a/portuguese/rust-cpp/convert/_index.md
+++ b/portuguese/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Converter funções de PDF"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Funções para converter arquivos PDF."
+type: docs
+url: /pt/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Nome | Descrição |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Converter e salvar o PDF-documento previamente aberto como documento DocX. |
+| [save_doc](./save_doc/) | Converter e salvar o PDF-documento previamente aberto como documento Doc. |
+| [save_xlsx](./save_xlsx/) | Converter e salvar o PDF-documento previamente aberto como documento XlsX. |
+| [save_txt](./save_txt/) | Converter e salvar o PDF-documento previamente aberto como documento Txt. |
+| [save_pptx](./save_pptx/) | Converter e salvar o PDF-documento previamente aberto como documento PptX. |
+| [save_xps](./save_xps/) | Converter e salvar o PDF-documento previamente aberto como documento Xps. |
+| [save_tex](./save_tex/) | Converter e salvar o PDF-documento previamente aberto como documento TeX. |
+| [save_epub](./save_epub/) | Converter e salvar o PDF-documento previamente aberto como documento Epub. |
+| [save_booklet](./save_booklet/) | Converter e salvar o PDF-documento previamente aberto como PDF em formato de livreto. |
+| [save_n_up](./save_n_up/) | Converter e salvar o PDF-documento previamente aberto como PDF N-Up. |
+| [save_markdown](./save_markdown/) | Converter e salvar o PDF-documento previamente aberto como documento Markdown. |
+| [save_tiff](./save_tiff/) | Converter e salvar o PDF-documento previamente aberto como documento Tiff. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Converter e salvar o PDF-documento previamente aberto como documento DocX com Modo de Reconhecimento Avançado (tabelas e parágrafos totalmente editáveis). |
+| [save_svg_zip](./save_svg_zip/) | Converter e salvar o PDF-documento previamente aberto como arquivo SVG. |
+| [export_fdf](./export_fdf/) | Exportar do PDF-documento previamente aberto com AcroForm para documento FDF. |
+| [export_xfdf](./export_xfdf/) | Exportar do PDF-documento previamente aberto com AcroForm para documento XFDF. |
+| [export_xml](./export_xml/) | Exportar do PDF-documento previamente aberto com AcroForm para documento XML. |
+| [page_to_jpg](./page_to_jpg/) | Converter e salvar a página especificada como imagem Jpg. |
+| [page_to_png](./page_to_png/) | Converter e salvar a página especificada como imagem Png. |
+| [page_to_bmp](./page_to_bmp/) | Converter e salvar a página especificada como imagem Bmp. |
+| [page_to_tiff](./page_to_tiff/) | Converter e salvar a página especificada como imagem Tiff. |
+| [page_to_svg](./page_to_svg/) | Converter e salvar a página especificada como imagem Svg. |
+| [page_to_pdf](./page_to_pdf/) | Converter e salvar a página especificada como documento PDF. |
+| [page_to_dicom](./page_to_dicom/) | Converter e salvar a página especificada como imagem DICOM. |
+
+
+## Detailed Description
+
+Funções para converter arquivos PDF.
+

--- a/portuguese/rust-cpp/convert/export_fdf/_index.md
+++ b/portuguese/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Exporta do documento PDF previamente aberto com AcroForm para documento FDF com nome de arquivo."
+type: docs
+url: /pt/rust-cpp/convert/export_fdf/
+---
+
+_Exporta do documento PDF previamente aberto com AcroForm para documento FDF com nome de arquivo._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar do documento PDF previamente aberto com AcroForm para documento FDF
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/export_xfdf/_index.md
+++ b/portuguese/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Exporta do PDF-documento previamente aberto com AcroForm para XFDF-documento com nome de arquivo."
+type: docs
+url: /pt/rust-cpp/convert/export_xfdf/
+---
+
+_Exporta do PDF-documento previamente aberto com AcroForm para XFDF-documento com nome de arquivo._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar do PDF-documento previamente aberto com AcroForm para XFDF-documento
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/export_xml/_index.md
+++ b/portuguese/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Exporta do PDF-documento previamente aberto com AcroForm para XML-documento com nome de arquivo."
+type: docs
+url: /pt/rust-cpp/convert/export_xml/
+---
+
+_Exporta do PDF-documento previamente aberto com AcroForm para XML-documento com nome de arquivo._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar do PDF-documento previamente aberto com AcroForm para XML-documento
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_bmp/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como uma imagem BMP."
+type: docs
+url: /pt/rust-cpp/convert/page_to_bmp/
+---
+
+_Converte e salva a página especificada como uma imagem BMP._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como imagem BMP
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_dicom/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como uma DICOM-image."
+type: docs
+url: /pt/rust-cpp/convert/page_to_dicom/
+---
+
+_Converte e salva a página especificada como uma DICOM-image._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como DICOM-image
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_jpg/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como uma imagem JPG."
+type: docs
+url: /pt/rust-cpp/convert/page_to_jpg/
+---
+
+_Converte e salva a página especificada como uma imagem JPG._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como imagem Jpg
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_pdf/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como um PDF-document."
+type: docs
+url: /pt/rust-cpp/convert/page_to_pdf/
+---
+
+_Converte e salva a página especificada como um PDF-document._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como PDF-document
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_png/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como imagem PNG."
+type: docs
+url: /pt/rust-cpp/convert/page_to_png/
+---
+
+_Converte e salva a página especificada como imagem PNG._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como imagem Png
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_svg/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como uma imagem SVG."
+type: docs
+url: /pt/rust-cpp/convert/page_to_svg/
+---
+
+_Converte e salva a página especificada como uma imagem SVG._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como imagem SVG
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/page_to_tiff/_index.md
+++ b/portuguese/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva a página especificada como imagem TIFF."
+type: docs
+url: /pt/rust-cpp/convert/page_to_tiff/
+---
+
+_Converte e salva a página especificada como imagem TIFF._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar a página especificada como imagem Tiff
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_booklet/_index.md
+++ b/portuguese/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um PDF-document em formato de folheto."
+type: docs
+url: /pt/rust-cpp/convert/save_booklet/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um PDF-document em formato de folheto._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como PDF-document em formato de folheto
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/portuguese/rust-cpp/convert/save_doc/_index.md
+++ b/portuguese/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um documento DOC."
+type: docs
+url: /pt/rust-cpp/convert/save_doc/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um documento DOC._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como Doc-document
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_docx/_index.md
+++ b/portuguese/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um documento DOCX."
+type: docs
+url: /pt/rust-cpp/convert/save_docx/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um documento DOCX._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como DocX-document
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/portuguese/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o documento PDF aberto anteriormente como um documento DOCX com Modo de Reconhecimento Avançado (tabelas e parágrafos totalmente editáveis)."
+type: docs
+url: /pt/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Converte e salva o documento PDF aberto anteriormente como um documento DOCX com Modo de Reconhecimento Avançado (tabelas e parágrafos totalmente editáveis)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o documento PDF aberto anteriormente como documento DocX com Modo de Reconhecimento Avançado (tabelas e parágrafos totalmente editáveis)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_epub/_index.md
+++ b/portuguese/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-documento previamente aberto como um EPUB-document."
+type: docs
+url: /pt/rust-cpp/convert/save_epub/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um documento EPUB._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como Epub-document
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_markdown/_index.md
+++ b/portuguese/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o documento PDF previamente aberto como documento Markdown."
+type: docs
+url: /pt/rust-cpp/convert/save_markdown/
+---
+
+_Converte e salva o documento PDF previamente aberto como documento Markdown._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o documento PDF previamente aberto como documento Markdown
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/portuguese/rust-cpp/convert/save_n_up/_index.md
+++ b/portuguese/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o documento PDF aberto anteriormente como um documento PDF N-Up."
+type: docs
+url: /pt/rust-cpp/convert/save_n_up/
+---
+
+_Converte e salva o documento PDF aberto anteriormente como um documento PDF N-Up._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o documento PDF aberto anteriormente como documento PDF N-Up
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/portuguese/rust-cpp/convert/save_pptx/_index.md
+++ b/portuguese/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um documento PPTX."
+type: docs
+url: /pt/rust-cpp/convert/save_pptx/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um documento PPTX._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como PptX-document
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_svg_zip/_index.md
+++ b/portuguese/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-documento previamente aberto como um SVG-archive."
+type: docs
+url: /pt/rust-cpp/convert/save_svg_zip/
+---
+
+_Converte e salva o PDF-documento previamente aberto como um SVG-archive._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o PDF-documento previamente aberto como SVG-archive
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_tex/_index.md
+++ b/portuguese/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o documento PDF aberto anteriormente como um documento TeX."
+type: docs
+url: /pt/rust-cpp/convert/save_tex/
+---
+
+_Converte e salva o documento PDF aberto anteriormente como um documento TeX._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o documento PDF aberto anteriormente como documento TeX
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_tiff/_index.md
+++ b/portuguese/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um documento Tiff."
+type: docs
+url: /pt/rust-cpp/convert/save_tiff/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um documento Tiff._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converta e salve o PDF-document aberto anteriormente como Tiff-document
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/portuguese/rust-cpp/convert/save_txt/_index.md
+++ b/portuguese/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-documento previamente aberto como um TXT-document."
+type: docs
+url: /pt/rust-cpp/convert/save_txt/
+---
+
+_Converte e salva o PDF-documento previamente aberto como um TXT-document._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o PDF-documento previamente aberto como Txt-document
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_xlsx/_index.md
+++ b/portuguese/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o PDF-document aberto anteriormente como um XLSX-document."
+type: docs
+url: /pt/rust-cpp/convert/save_xlsx/
+---
+
+_Converte e salva o PDF-document aberto anteriormente como um XLSX-document._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o PDF-document aberto anteriormente como um XlsX-document
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/convert/save_xps/_index.md
+++ b/portuguese/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte e salva o documento PDF aberto anteriormente como um documento XPS."
+type: docs
+url: /pt/rust-cpp/convert/save_xps/
+---
+
+_Converte e salva o documento PDF aberto anteriormente como um documento XPS._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter e salvar o documento PDF aberto anteriormente como documento XPS
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/_index.md
+++ b/portuguese/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Funções principais de PDF"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Funções principais para trabalhar com arquivos PDF."
+type: docs
+url: /pt/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Nome | Descrição |
+| -------------- | -------------- |
+| [new](./new/) | Criar um novo documento PDF. |
+| [open](./open/) | Abrir um documento PDF com nome de arquivo. |
+| [save](./save/) | Salvar o documento PDF aberto anteriormente. |
+| [save_as](./save_as/) | Salvar o documento PDF aberto anteriormente com novo nome de arquivo. |
+| [set_license](./set_license/) | Definir licença com nome de arquivo. |
+| [extract_text](./extract_text/) | Retornar o conteúdo do documento PDF como texto simples. |
+| [word_count](./word_count/) | Retornar a contagem de palavras no documento PDF. |
+| [character_count](./character_count/) | Retornar a contagem de caracteres no documento PDF. |
+| [append](./append/) | Anexar páginas de outro documento PDF. |
+| [append_pages](./append_pages/) | Anexar páginas selecionadas de outro documento PDF. |
+| [merge_documents](./merge_documents/) | Criar um novo documento PDF mesclando os documentos PDF fornecidos. |
+| [split_document](./split_document/) | Criar vários novos documentos PDF extraindo páginas do documento PDF fonte. |
+| [split](./split/) | Criar vários novos documentos PDF extraindo páginas do documento PDF atual. |
+| [split_at_page](./split_at_page/) | Dividir o documento PDF em dois novos documentos PDF. |
+| [split_at](./split_at/) | Dividir o documento PDF atual em dois novos documentos PDF. |
+| [bytes](./bytes/) | Retornar o conteúdo do documento PDF como um vetor de bytes. |
+| [get_meta_info](./get_meta_info/) | Obter o valor da informação de metadados do documento PDF. |
+| [set_meta_info](./set_meta_info/) | Definir valor da informação de metadados do PDF-document. |
+| [clear_meta_info](./clear_meta_info/) | Limpar todos os valores de informação de metadados do PDF-document. |
+| [is_linearized](./is_linearized/) | Obter um valor que indica se o documento está linearizado. |
+| [page_add](./page_add/) | Adicionar nova página no PDF-document. |
+| [page_insert](./page_insert/) | Inserir nova página na posição especificada no PDF-document. |
+| [page_delete](./page_delete/) | Excluir página especificada no PDF-document. |
+| [page_count](./page_count/) | Retornar o número de páginas no PDF-document. |
+| [page_word_count](./page_word_count/) | Retornar a contagem de palavras na página especificada do PDF-document. |
+| [page_character_count](./page_character_count/) | Retornar a contagem de caracteres na página especificada do PDF-document. |
+| [page_is_blank](./page_is_blank/) | Retornar se a página está em branco no PDF-document. |
+
+
+## Detailed Description
+
+Funções principais para trabalhar com arquivos PDF.
+

--- a/portuguese/rust-cpp/core/append/_index.md
+++ b/portuguese/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Anexa páginas de outro PDF-document."
+type: docs
+url: /pt/rust-cpp/core/append/
+---
+
+_Anexa páginas de outro PDF-document._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir o PDF-document principal
+    let pdf = Document::open("sample.pdf")?;
+
+    // Abrir outro documento PDF para anexar
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Anexar páginas de outro documento PDF
+    pdf.append(&another_pdf)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/append_pages/_index.md
+++ b/portuguese/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Anexa páginas selecionadas de outro PDF-document."
+type: docs
+url: /pt/rust-cpp/core/append_pages/
+---
+
+_Anexa páginas selecionadas de outro PDF-document._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir o PDF-document principal
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Abrir outro documento PDF para anexar
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Anexar páginas específicas (1 e 3) de outro PDF-document
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/bytes/_index.md
+++ b/portuguese/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "bytes"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna o conteúdo do documento PDF como um vetor de bytes."
+type: docs
+url: /pt/rust-cpp/core/bytes/
+---
+
+_Retorna o conteúdo do documento PDF como um vetor de bytes._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Retornar o conteúdo do documento PDF como um vetor de bytes
+    let data = pdf.bytes()?;
+
+    // Imprimir o comprimento do vetor de bytes
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/character_count/_index.md
+++ b/portuguese/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna a contagem de caracteres no documento PDF."
+type: docs
+url: /pt/rust-cpp/core/character_count/
+---
+
+_Retorna a contagem de caracteres no documento PDF._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Retornar a contagem de caracteres no documento PDF
+    let count = pdf.character_count()?;
+
+    // Imprimir a contagem de caracteres
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/clear_meta_info/_index.md
+++ b/portuguese/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Limpa todos os valores de meta-informação do PDF-document."
+type: docs
+url: /pt/rust-cpp/core/clear_meta_info/
+---
+
+_Limpa todos os valores de meta-informação do PDF-document._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Limpar todos os valores de meta-informação do PDF-document
+    pdf.clear_meta_info()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/extract_text/_index.md
+++ b/portuguese/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna o conteúdo do documento PDF como texto simples."
+type: docs
+url: /pt/rust-cpp/core/extract_text/
+---
+
+_Retorna o conteúdo do documento PDF como texto simples._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Retornar o conteúdo do documento PDF como texto simples
+    let txt = pdf.extract_text()?;
+
+    // Imprimir texto extraído
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/get_meta_info/_index.md
+++ b/portuguese/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obtém o valor da informação meta do documento PDF."
+type: docs
+url: /pt/rust-cpp/core/get_meta_info/
+---
+
+_Obtém o valor da informação meta do documento PDF._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obter valor da informação meta do documento PDF
+    let author = pdf.get_meta_info("Author")?;
+
+    // Imprimir o resultado
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/is_linearized/_index.md
+++ b/portuguese/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obtém um valor que indica se o documento está linearizado."
+type: docs
+url: /pt/rust-cpp/core/is_linearized/
+---
+
+_Obtém um valor que indica se o documento está linearizado._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obter um valor que indica se o documento está linearizado
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/merge_documents/_index.md
+++ b/portuguese/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Cria um novo PDF-document mesclando os PDF-documents fornecidos."
+type: docs
+url: /pt/rust-cpp/core/merge_documents/
+---
+
+_Cria um novo PDF-document mesclando os PDF-documents fornecidos._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf1 = Document::new()?;
+
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Criar um novo PDF-document mesclando os PDF-documents fornecidos
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/new/_index.md
+++ b/portuguese/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "novo"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Cria um novo documento PDF."
+type: docs
+url: /pt/rust-cpp/core/new/
+---
+
+_Cria um novo documento PDF._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/open/_index.md
+++ b/portuguese/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "abrir"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Abre um documento PDF com o nome de arquivo."
+type: docs
+url: /pt/rust-cpp/core/open/
+---
+
+_Abre um documento PDF com o nome de arquivo._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_add/_index.md
+++ b/portuguese/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona uma nova página ao documento PDF."
+type: docs
+url: /pt/rust-cpp/core/page_add/
+---
+
+_Adiciona uma nova página ao documento PDF._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar nova página no documento PDF
+    pdf.page_add()?;
+
+    // Salvar o PDF-document aberto anteriormente
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_character_count/_index.md
+++ b/portuguese/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna a contagem de caracteres na página especificada do documento PDF."
+type: docs
+url: /pt/rust-cpp/core/page_character_count/
+---
+
+_Retorna a contagem de caracteres na página especificada do documento PDF._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifique o número da página (índice baseado em 1)
+    let page_number = 1;
+
+    // Retornar a contagem de caracteres na página especificada
+    let count = pdf.page_character_count(page_number)?;
+
+    // Imprimir a contagem de caracteres
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_count/_index.md
+++ b/portuguese/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna o número de páginas no PDF-document."
+type: docs
+url: /pt/rust-cpp/core/page_count/
+---
+
+_Retorna o número de páginas no PDF-document._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Retornar contagem de páginas no PDF-document
+    let count = pdf.page_count()?;
+
+    // Imprimir a contagem de páginas
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_delete/_index.md
+++ b/portuguese/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Exclui a página especificada do PDF-document."
+type: docs
+url: /pt/rust-cpp/core/page_delete/
+---
+
+_Exclui a página especificada do PDF-document._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Excluir página especificada no PDF-document
+    pdf.page_delete(1)?;
+
+    // Salvar o PDF-document aberto anteriormente
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_insert/_index.md
+++ b/portuguese/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Insere uma nova página na posição especificada no PDF-document."
+type: docs
+url: /pt/rust-cpp/core/page_insert/
+---
+
+_Insere uma nova página na posição especificada no PDF-document._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Inserir nova página na posição especificada no PDF-document
+    pdf.page_insert(1)?;
+
+    // Salvar o PDF-document aberto anteriormente
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_is_blank/_index.md
+++ b/portuguese/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retornar se a página está em branco no PDF-document."
+type: docs
+url: /pt/rust-cpp/core/page_is_blank/
+---
+
+_Retornar página está em branco no documento PDF._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifique o número da página (índice baseado em 1)
+    let page_number = 1;
+
+    // Retornar página está em branco no documento PDF
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Imprimir se a página especificada estiver em branco
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/page_word_count/_index.md
+++ b/portuguese/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna a contagem de palavras na página especificada no PDF-document."
+type: docs
+url: /pt/rust-cpp/core/page_word_count/
+---
+
+_Retorna a contagem de palavras na página especificada no PDF-document._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifique o número da página (índice baseado em 1)
+    let page_number = 1;
+
+    // Retorne a contagem de palavras na página especificada
+    let count = pdf.page_word_count(page_number)?;
+
+    // Imprima a contagem de palavras
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/save/_index.md
+++ b/portuguese/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Salva o PDF-document aberto anteriormente."
+type: docs
+url: /pt/rust-cpp/core/save/
+---
+
+_Salva o PDF-document aberto anteriormente._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Salvar o PDF-document aberto anteriormente
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/save_as/_index.md
+++ b/portuguese/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Salva o PDF-document aberto anteriormente com um novo nome de arquivo."
+type: docs
+url: /pt/rust-cpp/core/save_as/
+---
+
+_Salva o PDF-document aberto anteriormente com um novo nome de arquivo._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Salve o PDF-document com um novo nome de arquivo
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/set_license/_index.md
+++ b/portuguese/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Define a licença usando o nome do arquivo."
+type: docs
+url: /pt/rust-cpp/core/set_license/
+---
+
+_Define a licença usando o nome do arquivo._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Definir licença com nome do arquivo
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Agora você pode trabalhar com o documento PDF licenciado
+    // ...
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/set_meta_info/_index.md
+++ b/portuguese/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Define o valor da meta-informação do PDF-document."
+type: docs
+url: /pt/rust-cpp/core/set_meta_info/
+---
+
+_Define o valor da meta-informação do PDF-document._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Definir o valor da meta-informação do PDF-document
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/split/_index.md
+++ b/portuguese/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Cria vários novos PDF-documents extraindo páginas do PDF-document atual."
+type: docs
+url: /pt/rust-cpp/core/split/
+---
+
+_Cria vários novos PDF-documents extraindo páginas do PDF-document atual._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Criar vários novos PDF-documents extraindo páginas do PDF-document atual
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Salvar cada parte dividida como um PDF-document separado
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/split_at/_index.md
+++ b/portuguese/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Divide o PDF-document atual em dois novos PDF-documents."
+type: docs
+url: /pt/rust-cpp/core/split_at/
+---
+
+_Divide o PDF-document atual em dois novos PDF-documents._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Divida o PDF-document atual em dois novos PDF-documents
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Salvar cada parte dividida como um PDF-document separado
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/split_at_page/_index.md
+++ b/portuguese/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Divide o PDF-document em dois novos PDF-documents."
+type: docs
+url: /pt/rust-cpp/core/split_at_page/
+---
+
+_Divide o PDF-document em dois novos PDF-documents._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dividir o PDF-document em dois novos PDF-documents
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Salvar cada parte dividida como um PDF-document separado
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/split_document/_index.md
+++ b/portuguese/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Cria vários novos PDF-documents extraindo páginas do PDF-document fonte."
+type: docs
+url: /pt/rust-cpp/core/split_document/
+---
+
+_Cria vários novos PDF-documents extraindo páginas do PDF-document fonte._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document chamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Cria vários novos PDF-documents extraindo páginas do PDF-document fonte
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Salvar cada parte dividida como um PDF-document separado
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/core/word_count/_index.md
+++ b/portuguese/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna a contagem de palavras no PDF-document."
+type: docs
+url: /pt/rust-cpp/core/word_count/
+---
+
+_Retorna a contagem de palavras no PDF-document._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Retorne a contagem de palavras no PDF-document
+    let count = pdf.word_count()?;
+
+    // Imprima a contagem de palavras
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/miscellaneous/_index.md
+++ b/portuguese/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funções diversas"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Funções diversas para trabalhar."
+type: docs
+url: /pt/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Função | Descrição |
+| -------- | ----------- |
+| [about](./about/) | Retornar informações de metadados sobre o Aspose.PDF para Rust via C++. |
+
+
+## Detailed Description
+
+Funções diversas para trabalhar.
+

--- a/portuguese/rust-cpp/miscellaneous/about/_index.md
+++ b/portuguese/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "sobre"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Retorna informações de metadados sobre o Aspose.PDF para Rust via C++."
+type: docs
+url: /pt/rust-cpp/miscellaneous/about/
+---
+
+_Retorna informações de metadados sobre o Aspose.PDF para Rust via C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Retorna informações de metadados sobre o Aspose.PDF para Go via C++.
+    let info = pdf.about()?;
+
+    // Imprimir campos de metadados
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/_index.md
+++ b/portuguese/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Funções de organização de PDF"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Funções para organizar arquivos PDF."
+type: docs
+url: /pt/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Nome | Descrição |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Otimizar o conteúdo do documento PDF. |
+| [optimize_resource](./optimize_resource/) | Otimizar os recursos do documento PDF. |
+| [grayscale](./grayscale/) | Converter documento PDF para preto e branco. |
+| [rotate](./rotate/) | Rotacionar documento PDF. |
+| [set_background](./set_background/) | Definir a cor de fundo do documento PDF usando valores RGB. |
+| [repair](./repair/) | Reparar documento PDF. |
+| [replace_text](./replace_text/) | Substituir texto no documento PDF |
+| [add_page_num](./add_page_num/) | Adicionar número de página a um documento PDF |
+| [add_text_header](./add_text_header/) | Adicionar texto no cabeçalho de um documento PDF |
+| [add_text_footer](./add_text_footer/) | Adicionar texto no rodapé de um documento PDF |
+| [flatten](./flatten/) | Aplanar documento PDF |
+| [remove_annotations](./remove_annotations/) | Remover anotações do documento PDF |
+| [remove_attachments](./remove_attachments/) | Remover anexos do documento PDF |
+| [remove_blank_pages](./remove_blank_pages/) | Remover páginas em branco do documento PDF |
+| [remove_bookmarks](./remove_bookmarks/) | Remover marcadores do documento PDF |
+| [remove_hidden_text](./remove_hidden_text/) | Remover texto oculto do documento PDF |
+| [remove_images](./remove_images/) | Remover imagens do documento PDF |
+| [remove_javascripts](./remove_javascripts/) | Remover scripts Java do documento PDF |
+| [remove_tables](./remove_tables/) | Remover tabelas de um documento PDF. |
+| [remove_watermarks](./remove_watermarks/) | Remover marcas d'água do documento PDF. |
+| [add_watermark](./add_watermark/) | Adicionar marca d'água ao documento PDF. |
+| [embed_fonts](./embed_fonts/) | Incorporar fontes a um documento PDF. |
+| [unembed_fonts](./unembed_fonts/) | Desincorporar fontes de um documento PDF. |
+| [optimize_file_size](./optimize_file_size/) | Otimizar o tamanho do documento PDF com qualidade de compressão de imagem. |
+| [remove_text_headers](./remove_text_headers/) | Remover cabeçalhos de texto de um documento PDF. |
+| [remove_text_footers](./remove_text_footers/) | Remover rodapés de texto de um documento PDF. |
+| [crop](./crop/) | Cortar páginas de um documento PDF. |
+| [replace_font](./replace_font/) | Substituir fonte em um documento PDF. |
+| [convert](./convert/) | Converter um documento PDF em um documento PDF com o formato PDF especificado |
+| [validate](./validate/) | Validar um documento PDF quanto à conformidade com o formato PDF |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Remover a conformidade PDF/A de um documento PDF |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Remover a conformidade PDF/UA de um documento PDF |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Obter se um documento PDF está em conformidade PDF/A |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Obter se um documento PDF está em conformidade PDF/UA |
+| [page_rotate](./page_rotate/) | Rotacionar uma página no documento PDF. |
+| [page_set_size](./page_set_size/) | Definir o tamanho de uma página no documento PDF. |
+| [page_grayscale](./page_grayscale/) | Converter página para preto e branco. |
+| [page_add_text](./page_add_text/) | Adicionar texto na página. |
+| [page_replace_text](./page_replace_text/) | Substituir texto na página |
+| [page_add_page_num](./page_add_page_num/) | Adicionar número da página na página |
+| [page_add_text_header](./page_add_text_header/) | Adicionar texto no cabeçalho da página |
+| [page_add_text_footer](./page_add_text_footer/) | Adicionar texto no rodapé da página |
+| [page_remove_annotations](./page_remove_annotations/) | Remover anotações na página. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Remover texto oculto na página. |
+| [page_remove_images](./page_remove_images/) | Remover imagens na página. |
+| [page_remove_tables](./page_remove_tables/) | Remover tabelas na página. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Remover marcas d'água na página. |
+| [page_add_watermark](./page_add_watermark/) | Adicionar marca d'água na página. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Remover cabeçalhos de texto na página. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Remover rodapés de texto na página. |
+| [page_crop](./page_crop/) | Cortar uma página. |
+| [page_replace_font](./page_replace_font/) | Substituir fonte na página. |
+| [page_merge_layers](./page_merge_layers/) | Mesclar todas as camadas na página em uma única camada com o nome da nova camada especificado. |
+| [page_layers](./page_layers/) | Obter nomes das camadas na página. |
+
+
+## Detailed Description
+
+Funções para organizar arquivos PDF.

--- a/portuguese/rust-cpp/organize/add_page_num/_index.md
+++ b/portuguese/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona número de página a um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/add_page_num/
+---
+
+_Adiciona número de página a um PDF-document._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar número de página a um documento PDF
+    pdf.add_page_num()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/add_text_footer/_index.md
+++ b/portuguese/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona texto no rodapé de um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/add_text_footer/
+---
+
+_Adiciona texto no rodapé de um PDF-document._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar texto no rodapé de um documento PDF
+    pdf.add_text_footer("FOOTER")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/add_text_header/_index.md
+++ b/portuguese/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona texto no cabeçalho de um documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/add_text_header/
+---
+
+_Adiciona texto no cabeçalho de um documento PDF._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar texto no cabeçalho de um documento PDF
+    pdf.add_text_header("HEADER")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/add_watermark/_index.md
+++ b/portuguese/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona marca d'água ao PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/add_watermark/
+---
+
+_Adiciona marca d'água ao PDF-document._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar marca d'água ao PDF-document
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/convert/_index.md
+++ b/portuguese/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte um PDF-document em um PDF-document com o formato PDF especificado."
+type: docs
+url: /pt/rust-cpp/organize/convert/
+---
+
+_Converte um PDF-document em um PDF-document com o formato PDF especificado._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter um documento PDF em um documento PDF com o formato PDF especificado
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Imprime o resultado da conversão e o log completo
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/crop/_index.md
+++ b/portuguese/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "cortar"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Recorta páginas de um documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/crop/
+---
+
+_Recorta páginas de um documento PDF._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recortar páginas de um documento PDF
+    pdf.crop(10.5)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/embed_fonts/_index.md
+++ b/portuguese/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Incorpora fontes em um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/embed_fonts/
+---
+
+_Incorpora fontes em um PDF-document._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Incorporar fontes em um PDF-document
+    pdf.embed_fonts()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/flatten/_index.md
+++ b/portuguese/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Achata PDF-documento."
+type: docs
+url: /pt/rust-cpp/organize/flatten/
+---
+
+_Achata PDF-documento._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Retornar o conteúdo do documento PDF como texto simples
+    let txt = pdf.extract_text()?;
+
+    // Imprimir texto extraído
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/grayscale/_index.md
+++ b/portuguese/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte o PDF-documento para preto e branco."
+type: docs
+url: /pt/rust-cpp/organize/grayscale/
+---
+
+_Converte o PDF-documento para preto e branco._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter PDF-documento para preto e branco
+    pdf.grayscale()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/portuguese/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obtém se um documento PDF está em conformidade PDF/A."
+type: docs
+url: /pt/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Obtém se um documento PDF está em conformidade PDF/A._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obter status de conformidade PDF/A do documento PDF
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/portuguese/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obtém se um documento PDF está em conformidade com PDF/UA."
+type: docs
+url: /pt/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Obtém se um documento PDF está em conformidade com PDF/UA._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtenha o status de conformidade PDF/UA do documento PDF
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/optimize/_index.md
+++ b/portuguese/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Otimiza o conteúdo do documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/optimize/
+---
+
+_Otimiza o conteúdo do documento PDF._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Otimizar o conteúdo do documento PDF
+    pdf.optimize()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/optimize_file_size/_index.md
+++ b/portuguese/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Otimiza o tamanho do documento PDF com qualidade de compressão de imagem."
+type: docs
+url: /pt/rust-cpp/organize/optimize_file_size/
+---
+
+_Otimiza o tamanho do documento PDF com qualidade de compressão de imagem._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Otimizar o tamanho do documento PDF com qualidade de compressão de imagem
+    pdf.optimize_file_size(50)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/optimize_resource/_index.md
+++ b/portuguese/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Otimiza recursos do documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/optimize_resource/
+---
+
+_Otimiza recursos do documento PDF._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Otimizar recursos do documento PDF
+    pdf.optimize_resource()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_add_page_num/_index.md
+++ b/portuguese/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona número de página na página."
+type: docs
+url: /pt/rust-cpp/organize/page_add_page_num/
+---
+
+_Adiciona número de página na página._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar número da página na página
+    pdf.page_add_page_num(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_add_text/_index.md
+++ b/portuguese/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona texto a uma página."
+type: docs
+url: /pt/rust-cpp/organize/page_add_text/
+---
+
+_Adiciona texto a uma página._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar texto na página
+    pdf.page_add_text(1, "added text")?;
+
+    // Salvar o PDF-document aberto anteriormente
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/portuguese/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona texto no rodapé da página."
+type: docs
+url: /pt/rust-cpp/organize/page_add_text_footer/
+---
+
+_Adiciona texto no rodapé da página._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar texto no rodapé da página
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_add_text_header/_index.md
+++ b/portuguese/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona texto no cabeçalho da página."
+type: docs
+url: /pt/rust-cpp/organize/page_add_text_header/
+---
+
+_Adiciona texto no cabeçalho da página._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar texto no cabeçalho da página
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_add_watermark/_index.md
+++ b/portuguese/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Adiciona marca d'água na página."
+type: docs
+url: /pt/rust-cpp/organize/page_add_watermark/
+---
+
+_Adiciona marca d'água na página._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Adicionar marca d'água na página
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_crop/_index.md
+++ b/portuguese/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Recorta uma página."
+type: docs
+url: /pt/rust-cpp/organize/page_crop/
+---
+
+_Recorta uma página._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recortar uma página
+    pdf.page_crop(1, 1.0)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_grayscale/_index.md
+++ b/portuguese/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Converte uma página para preto e branco."
+type: docs
+url: /pt/rust-cpp/organize/page_grayscale/
+---
+
+_Converte uma página para preto e branco._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Converter página para preto e branco
+    pdf.page_grayscale(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_layers/_index.md
+++ b/portuguese/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obtém os nomes das camadas na página."
+type: docs
+url: /pt/rust-cpp/organize/page_layers/
+---
+
+_Obtém os nomes das camadas na página._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Obtenha os nomes das camadas na página 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_merge_layers/_index.md
+++ b/portuguese/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Mescla todas as camadas da página em uma única camada com o nome da nova camada especificado."
+type: docs
+url: /pt/rust-cpp/organize/page_merge_layers/
+---
+
+_Mescla todas as camadas da página em uma única camada com o nome da nova camada especificado._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Mesclar todas as camadas da página em uma única camada com o nome da nova camada especificado
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove anotações na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_annotations/
+---
+
+_Remove anotações na página._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover anotações na página
+    pdf.page_remove_annotations(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove texto oculto na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Remove texto oculto na página._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover texto oculto na página
+    pdf.page_remove_hidden_text(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_images/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove imagens na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_images/
+---
+
+_Remove imagens na página._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover imagens na página
+    pdf.page_remove_images(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_tables/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove tabelas na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_tables/
+---
+
+_Remove tabelas na página._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove tabelas na página
+    pdf.page_remove_tables(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove rodapés de texto na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Remove rodapés de texto na página._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover rodapés de texto na página
+    pdf.page_remove_text_footers(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove cabeçalhos de texto na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Remove cabeçalhos de texto na página._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove cabeçalhos de texto na página
+    pdf.page_remove_text_headers(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/portuguese/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove marcas d'água na página."
+type: docs
+url: /pt/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Remove marcas d'água na página._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove marcas d'água na página
+    pdf.page_remove_watermarks(1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_replace_font/_index.md
+++ b/portuguese/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Substitui fonte na página."
+type: docs
+url: /pt/rust-cpp/organize/page_replace_font/
+---
+
+_Substitui fonte na página._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Substituir fonte na página
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_replace_text/_index.md
+++ b/portuguese/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Substitui texto na página."
+type: docs
+url: /pt/rust-cpp/organize/page_replace_text/
+---
+
+_Substitui texto na página._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Substituir texto na página
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_rotate/_index.md
+++ b/portuguese/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Gira uma página no documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/page_rotate/
+---
+
+_Gira uma página no documento PDF._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um PDF-document a partir de um arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Girar página
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/page_set_size/_index.md
+++ b/portuguese/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Define o tamanho de uma página no documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/page_set_size/
+---
+
+_Define o tamanho de uma página no documento PDF._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Definir o tamanho de uma página no documento PDF
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_annotations/_index.md
+++ b/portuguese/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove anotações do PDF-documento."
+type: docs
+url: /pt/rust-cpp/organize/remove_annotations/
+---
+
+_Remove anotações do PDF-documento._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover anotações do documento PDF
+    pdf.remove_annotations()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_attachments/_index.md
+++ b/portuguese/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove anexos de PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_attachments/
+---
+
+_Remove anexos de PDF-document._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover anexos do documento PDF
+    pdf.remove_attachments()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/portuguese/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove páginas em branco do PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_blank_pages/
+---
+
+_Remove páginas em branco do PDF-document._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover páginas em branco do documento PDF
+    pdf.remove_blank_pages()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/portuguese/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove marcadores do PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_bookmarks/
+---
+
+_Remove marcadores do PDF-document._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover marcadores do documento PDF
+    pdf.remove_bookmarks()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/portuguese/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove texto oculto de PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_hidden_text/
+---
+
+_Remove texto oculto de PDF-document._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover texto oculto do documento PDF
+    pdf.remove_hidden_text()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_images/_index.md
+++ b/portuguese/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove imagens de PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_images/
+---
+
+_Remove imagens de PDF-document._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover imagens do documento PDF
+    pdf.remove_images()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_javascripts/_index.md
+++ b/portuguese/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove scripts Java do documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/remove_javascripts/
+---
+
+_Remove scripts Java do documento PDF._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover scripts Java do documento PDF
+    pdf.remove_javascripts()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/portuguese/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove a conformidade PDF/A de um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Remover a conformidade PDF/A de um documento PDF._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover a conformidade PDF/A de um documento PDF
+    pdf.remove_pdfa_compliance()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/portuguese/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remova a conformidade PDF/UA de um documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Remova a conformidade PDF/UA de um documento PDF._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover a conformidade PDF/UA de um documento PDF
+    pdf.remove_pdfua_compliance()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_tables/_index.md
+++ b/portuguese/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove tabelas do PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_tables/
+---
+
+_Remove tabelas do PDF-document._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remover tabelas do PDF-document
+    pdf.remove_tables()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_text_footers/_index.md
+++ b/portuguese/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove rodapés de texto do documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/remove_text_footers/
+---
+
+_Remove rodapés de texto do documento PDF._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove rodapés de texto do documento PDF
+    pdf.remove_text_footers()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_text_headers/_index.md
+++ b/portuguese/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove cabeçalhos de texto de PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_text_headers/
+---
+
+_Remove cabeçalhos de texto de PDF-document._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove cabeçalhos de texto de PDF-document
+    pdf.remove_text_headers()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/remove_watermarks/_index.md
+++ b/portuguese/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remove marcas d'água de PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/remove_watermarks/
+---
+
+_Remove marcas d'água de PDF-document._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Remove marcas d'água de PDF-document
+    pdf.remove_watermarks()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/repair/_index.md
+++ b/portuguese/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Repara o documento PDF."
+type: docs
+url: /pt/rust-cpp/organize/repair/
+---
+
+_Repara o PDF-document._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reparar PDF-document
+    pdf.repair()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/replace_font/_index.md
+++ b/portuguese/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Substitui a fonte em um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/replace_font/
+---
+
+_Substitui a fonte em um PDF-document._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Substituir fonte em um documento PDF.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/replace_text/_index.md
+++ b/portuguese/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Substitui texto."
+type: docs
+url: /pt/rust-cpp/organize/replace_text/
+---
+
+_Substitui texto._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Substituir texto no documento PDF
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/rotate/_index.md
+++ b/portuguese/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Gira o PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/rotate/
+---
+
+_Gira o PDF-document._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Girar PDF-document
+    pdf.rotate(Rotation::On270)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/set_background/_index.md
+++ b/portuguese/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Define a cor de fundo do documento PDF usando valores RGB."
+type: docs
+url: /pt/rust-cpp/organize/set_background/
+---
+
+_Define a cor de fundo do documento PDF usando valores RGB._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Definir a cor de fundo do documento PDF usando valores RGB
+    pdf.set_background(200, 100, 101)?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/unembed_fonts/_index.md
+++ b/portuguese/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Desincorpora fontes de um PDF-document."
+type: docs
+url: /pt/rust-cpp/organize/unembed_fonts/
+---
+
+_Desincorpora fontes de um PDF-document._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Desincorpora fontes de um PDF-document
+    pdf.unembed_fonts()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/organize/validate/_index.md
+++ b/portuguese/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Valida um documento PDF quanto à conformidade com o formato PDF."
+type: docs
+url: /pt/rust-cpp/organize/validate/
+---
+
+_Valida um documento PDF quanto à conformidade com o formato PDF._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Validar um documento PDF quanto à conformidade com o formato PDF
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Imprimir resultado da validação e log completo
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/_index.md
+++ b/portuguese/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funções de segurança"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Funções de segurança."
+type: docs
+url: /pt/rust-cpp/security/
+---
+
+## Security
+
+| Função | Descrição |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Abrir um PDF-document protegido por senha. |
+| [encrypt](./encrypt/) | Criptografar PDF-document. |
+| [decrypt](./decrypt/) | Descriptografar PDF-document. |
+| [set_permissions](./set_permissions/) | Definir permissões para PDF-document. |
+| [get_permissions](./get_permissions/) | Obter permissões atuais do PDF-document. |
+| [is_encrypted](./is_encrypted/) | Obter status de criptografia do PDF-document. |
+| [sign_pkcs7](./sign_pkcs7/) | Assinar um PDF-document usando assinaturas digitais PKCS#7. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Assinar um PDF-document usando assinaturas digitais PKCS#7 Detached. |
+| [is_signed](./is_signed/) | Obter status de assinatura do PDF-document. |
+| [remove_signs](./remove_signs/) | Remover assinaturas do PDF-document. |
+
+
+## Detailed Description
+
+Funções de segurança.
+

--- a/portuguese/rust-cpp/security/decrypt/_index.md
+++ b/portuguese/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "descriptografar"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Descriptografar PDF-document."
+type: docs
+url: /pt/rust-cpp/security/decrypt/
+---
+
+_Descriptografar documento PDF._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF protegido por senha
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Descriptografar documento PDF
+    pdf.decrypt()?;
+
+    // Salvar o documento PDF aberto anteriormente com um novo nome de arquivo
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/encrypt/_index.md
+++ b/portuguese/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "criptografar"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Criptografar PDF-document."
+type: docs
+url: /pt/rust-cpp/security/encrypt/
+---
+
+_Criptografar PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Criptografar PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Salvar o PDF-document criptografado
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/get_permissions/_index.md
+++ b/portuguese/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obter permissões atuais do PDF-document."
+type: docs
+url: /pt/rust-cpp/security/get_permissions/
+---
+
+_Obter permissões atuais do documento PDF._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF protegido por senha
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Obter permissões atuais do documento PDF
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Imprimir permissões
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/is_encrypted/_index.md
+++ b/portuguese/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obter status de criptografia do PDF-document."
+type: docs
+url: /pt/rust-cpp/security/is_encrypted/
+---
+
+_Obter status de criptografia do documento PDF._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF protegido por senha
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Obter status de criptografia do documento PDF
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/is_signed/_index.md
+++ b/portuguese/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Obter status de assinatura do PDF-document."
+type: docs
+url: /pt/rust-cpp/security/is_signed/
+---
+
+_Obter status de assinatura do PDF-document._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF chamado "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Obter status de assinatura do PDF-document
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/open_with_password/_index.md
+++ b/portuguese/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Abrir um PDF-document protegido por senha."
+type: docs
+url: /pt/rust-cpp/security/open_with_password/
+---
+
+_Abrir um documento PDF protegido por senha._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF protegido por senha
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // processando...
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/remove_signs/_index.md
+++ b/portuguese/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Remover assinaturas do PDF-document."
+type: docs
+url: /pt/rust-cpp/security/remove_signs/
+---
+
+_Remover assinaturas do documento PDF._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir um documento PDF chamado "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Remover assinaturas do documento PDF
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/set_permissions/_index.md
+++ b/portuguese/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Definir permissões para PDF-document."
+type: docs
+url: /pt/rust-cpp/security/set_permissions/
+---
+
+_Definir permissões para PDF-document._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crie um novo PDF-document
+    let pdf = Document::new()?;
+
+    // Definir permissões para PDF-document.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Salvar o PDF-document com as permissões atualizadas
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/sign_pkcs7/_index.md
+++ b/portuguese/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Assinar um PDF-document usando assinaturas digitais PKCS#7."
+type: docs
+url: /pt/rust-cpp/security/sign_pkcs7/
+---
+
+_Assinar um PDF-document usando assinaturas digitais PKCS#7._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ler arquivos de certificado e imagem em vetores de bytes
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Assinar um PDF-document usando assinaturas digitais PKCS#7
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/portuguese/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/portuguese/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF para Rust via C++"
+description: "Assinar um PDF-document usando assinaturas digitais PKCS#7 Detached."
+type: docs
+url: /pt/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Assinar um PDF-document usando assinaturas digitais PKCS#7 Detached._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ler arquivos de certificado e imagem em vetores de bytes
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Abrir um documento PDF com nome de arquivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Assinar um PDF-document usando assinaturas digitais PKCS#7 Detached
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Automated translation of the RUST-CPP API Reference to **Portuguese** (`pt`) generated by RDA.

- Pages translated: 122/122
- Errors: 0
- Source: `english/rust-cpp`
- Output: `portuguese/rust-cpp`

🤖 Generated by RDA