### PR TITLE
[auto] Translate RUST-CPP API Reference to Spanish

### DIFF
--- a/spanish/rust-cpp/_index.md
+++ b/spanish/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF para Rust vía C++"
+description: "Aspose.PDF para Rust vía C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /es/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Estructuras
+
+## Document
+Document representa un documento PDF.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Convertir y guardar el PDF-documento previamente abierto como documento DocX-document. |
+| [save_doc](./convert/save_doc/) | Convertir y guardar el PDF-documento previamente abierto como documento Doc-document. |
+| [save_xlsx](./convert/save_xlsx/) | Convertir y guardar el PDF-documento previamente abierto como documento XlsX-document. |
+| [save_txt](./convert/save_txt/) | Convertir y guardar el PDF-documento previamente abierto como documento Txt-document. |
+| [save_pptx](./convert/save_pptx/) | Convertir y guardar el PDF-documento previamente abierto como documento PptX-document. |
+| [save_xps](./convert/save_xps/) | Convertir y guardar el PDF-documento previamente abierto como documento Xps-document. |
+| [save_tex](./convert/save_tex/) | Convertir y guardar el PDF-documento previamente abierto como documento TeX-document. |
+| [save_epub](./convert/save_epub/) | Convertir y guardar el PDF-documento previamente abierto como documento Epub-document. |
+| [save_booklet](./convert/save_booklet/) | Convertir y guardar el PDF-documento previamente abierto como documento PDF de folleto. |
+| [save_n_up](./convert/save_n_up/) | Convertir y guardar el PDF-documento previamente abierto como documento PDF N-Up. |
+| [save_markdown](./convert/save_markdown/) | Convertir y guardar el PDF-documento previamente abierto como documento Markdown-document. |
+| [save_tiff](./convert/save_tiff/) | Convertir y guardar el PDF-documento previamente abierto como documento Tiff-document. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Convertir y guardar el PDF-documento previamente abierto como documento DocX-document con Modo de Reconocimiento Mejorado (tablas y párrafos totalmente editables). |
+| [save_svg_zip](./convert/save_svg_zip/) | Convertir y guardar el PDF-documento previamente abierto como archivo SVG-archive. |
+| [export_fdf](./convert/export_fdf/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento FDF-document. |
+| [export_xfdf](./convert/export_xfdf/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento XFDF-document. |
+| [export_xml](./convert/export_xml/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento XML-document. |
+| [page_to_jpg](./convert/page_to_jpg/) | Convertir y guardar la página especificada como imagen Jpg-image. |
+| [page_to_png](./convert/page_to_png/) | Convertir y guardar la página especificada como imagen Png-image. |
+| [page_to_bmp](./convert/page_to_bmp/) | Convertir y guardar la página especificada como imagen Bmp-image. |
+| [page_to_tiff](./convert/page_to_tiff/) | Convertir y guardar la página especificada como imagen Tiff. |
+| [page_to_svg](./convert/page_to_svg/) | Convertir y guardar la página especificada como imagen Svg. |
+| [page_to_pdf](./convert/page_to_pdf/) | Convertir y guardar la página especificada como documento PDF. |
+| [page_to_dicom](./convert/page_to_dicom/) | Convertir y guardar la página especificada como imagen DICOM. |
+
+
+## Organize PDF functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Optimizar el contenido del documento PDF. |
+| [optimize_resource](./organize/optimize_resource/) | Optimizar los recursos del documento PDF. |
+| [grayscale](./organize/grayscale/) | Convertir el documento PDF a blanco y negro. |
+| [rotate](./organize/rotate/) | Rotar el documento PDF. |
+| [set_background](./organize/set_background/) | Establecer el color de fondo del documento PDF usando valores RGB. |
+| [repair](./organize/repair/) | Reparar el documento PDF. |
+| [replace_text](./organize/replace_text/) | Reemplazar texto en el documento PDF |
+| [add_page_num](./organize/add_page_num/) | Agregar número de página a un documento PDF |
+| [add_text_header](./organize/add_text_header/) | Agregar texto en el encabezado de un documento PDF |
+| [add_text_footer](./organize/add_text_footer/) | Agregar texto en el pie de página de un documento PDF |
+| [flatten](./organize/flatten/) | Aplanar el documento PDF |
+| [remove_annotations](./organize/remove_annotations/) | Eliminar anotaciones del documento PDF |
+| [remove_attachments](./organize/remove_attachments/) | Eliminar adjuntos del documento PDF |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Eliminar páginas en blanco del documento PDF |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Eliminar marcadores del documento PDF |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Eliminar texto oculto del documento PDF |
+| [remove_images](./organize/remove_images/) | Eliminar imágenes del documento PDF |
+| [remove_javascripts](./organize/remove_javascripts/) | Eliminar scripts Java del documento PDF |
+| [remove_tables](./organize/remove_tables/) | Eliminar tablas de un documento PDF. |
+| [remove_watermarks](./organize/remove_watermarks/) | Eliminar marcas de agua del documento PDF. |
+| [add_watermark](./organize/add_watermark/) | Agregar marca de agua al documento PDF. |
+| [embed_fonts](./organize/embed_fonts/) | Incrustar fuentes en un documento PDF. |
+| [unembed_fonts](./organize/unembed_fonts/) | Desincrustar fuentes de un documento PDF. |
+| [optimize_file_size](./organize/optimize_file_size/) | Optimizar el tamaño de un documento PDF con calidad de compresión de imagen. |
+| [remove_text_headers](./organize/remove_text_headers/) | Eliminar encabezados de texto de un documento PDF. |
+| [remove_text_footers](./organize/remove_text_footers/) | Eliminar pies de página de texto de un documento PDF. |
+| [crop](./organize/crop/) | Recortar páginas de un documento PDF. |
+| [replace_font](./organize/replace_font/) | Reemplazar la fuente en un documento PDF. |
+| [convert](./organize/convert/) | Convertir un documento PDF en un documento PDF con el formato PDF especificado |
+| [validate](./organize/validate/) | Validar un documento PDF para el cumplimiento del formato PDF |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Eliminar el cumplimiento PDF/A de un documento PDF |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Eliminar el cumplimiento PDF/UA de un documento PDF |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Obtener si un documento PDF cumple con PDF/A |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Obtener si un documento PDF cumple con PDF/UA |
+| [page_rotate](./organize/page_rotate/) | Rotar una página en el documento PDF. |
+| [page_set_size](./organize/page_set_size/) | Establecer el tamaño de una página en el documento PDF. |
+| [page_grayscale](./organize/page_grayscale/) | Convertir la página a blanco y negro. |
+| [page_add_text](./organize/page_add_text/) | Agregar texto en la página. |
+| [page_replace_text](./organize/page_replace_text/) | Reemplazar texto en la página |
+| [page_add_page_num](./organize/page_add_page_num/) | Agregar número de página en la página |
+| [page_add_text_header](./organize/page_add_text_header/) | Agregar texto en el encabezado de la página |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Agregar texto en el pie de página de la página |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Eliminar anotaciones en la página. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Eliminar texto oculto en la página. |
+| [page_remove_images](./organize/page_remove_images/) | Eliminar imágenes en la página. |
+| [page_remove_tables](./organize/page_remove_tables/) | Eliminar tablas en la página. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Eliminar marcas de agua en la página. |
+| [page_add_watermark](./organize/page_add_watermark/) | Agregar marca de agua en la página. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Eliminar encabezados de texto en la página. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Eliminar pies de página de texto en la página. |
+| [page_crop](./organize/page_crop/) | Recortar una página. |
+| [page_replace_font](./organize/page_replace_font/) | Reemplazar la fuente en la página. |
+| [page_merge_layers](./organize/page_merge_layers/) | Combinar todas las capas en la página en una sola capa con el nombre de capa nuevo especificado. |
+| [page_layers](./organize/page_layers/) | Obtener los nombres de las capas en la página. |
+
+
+## Core PDF functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [new](./core/new/) | Crear un nuevo documento PDF. |
+| [open](./core/open/) | Abrir un documento PDF con el nombre de archivo. |
+| [save](./core/save/) | Guardar el documento PDF abierto previamente. |
+| [save_as](./core/save_as/) | Guardar el documento PDF abierto previamente con un nuevo nombre de archivo. |
+| [set_license](./core/set_license/) | Establecer la licencia con el nombre de archivo. |
+| [extract_text](./core/extract_text/) | Devolver el contenido del documento PDF como texto plano. |
+| [word_count](./core/word_count/) | Devolver el recuento de palabras en el documento PDF. |
+| [character_count](./core/character_count/) | Devolver el recuento de caracteres en el documento PDF. |
+| [append](./core/append/) | Agregar páginas de otro documento PDF. |
+| [append_pages](./core/append_pages/) | Agregar páginas seleccionadas de otro documento PDF. |
+| [merge_documents](./core/merge_documents/) | Crear un nuevo documento PDF combinando los documentos PDF proporcionados. |
+| [split_document](./core/split_document/) | Crear varios documentos PDF nuevos extrayendo páginas del documento PDF fuente. |
+| [split](./core/split/) | Crear varios documentos PDF nuevos extrayendo páginas del documento PDF actual. |
+| [split_at_page](./core/split_at_page/) | Dividir el documento PDF en dos documentos PDF nuevos. |
+| [split_at](./core/split_at/) | Dividir el documento PDF actual en dos documentos PDF nuevos. |
+| [bytes](./core/bytes/) | Devolver el contenido del documento PDF como un vector de bytes. |
+| [get_meta_info](./core/get_meta_info/) | Obtener el valor de la información meta del documento PDF. |
+| [set_meta_info](./core/set_meta_info/) | Establecer el valor de la información meta del PDF-document. |
+| [clear_meta_info](./core/clear_meta_info/) | Borrar todos los valores de información meta del PDF-document. |
+| [is_linearized](./core/is_linearized/) | Obtener un valor que indique si el documento está linealizado. |
+| [page_add](./core/page_add/) | Agregar una nueva página en el PDF-document. |
+| [page_insert](./core/page_insert/) | Insertar una nueva página en la posición especificada del PDF-document. |
+| [page_delete](./core/page_delete/) | Eliminar la página especificada del PDF-document. |
+| [page_count](./core/page_count/) | Devolver el número de páginas del PDF-document. |
+| [page_word_count](./core/page_word_count/) | Devolver el recuento de palabras en la página especificada del PDF-document. |
+| [page_character_count](./core/page_character_count/) | Devolver el recuento de caracteres en la página especificada del PDF-document. |
+| [page_is_blank](./core/page_is_blank/) | Devolver si la página está en blanco en el PDF-document. |
+
+
+## Security
+| Función | Descripción |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Abrir un PDF-document protegido con contraseña. |
+| [encrypt](./security/encrypt/) | Cifrar el PDF-document. |
+| [decrypt](./security/decrypt/) | Descifrar el PDF-document. |
+| [set_permissions](./security/set_permissions/) | Establecer permisos para el PDF-document. |
+| [get_permissions](./security/get_permissions/) | Obtener los permisos actuales del PDF-document. |
+| [is_encrypted](./security/is_encrypted/) | Obtener el estado cifrado del PDF-document. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Firmar un PDF-document usando firmas digitales PKCS#7. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Firmar un PDF-document usando firmas digitales PKCS#7 desacopladas. |
+| [is_signed](./security/is_signed/) | Obtener el estado de firma del PDF-document. |
+| [remove_signs](./security/remove_signs/) | Eliminar firmas del PDF-document. |
+
+
+## Miscellaneous
+
+| Función | Descripción |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Devolver información de metadatos sobre Aspose.PDF para Rust vía C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Conjunto de banderas que representa las capacidades de permisos PDF.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// Tamaño A0.
+    A0 = 0,
+    /// Tamaño A1.
+    A1 = 1,
+    /// Tamaño A2.
+    A2 = 2,
+    /// tamaño A3.
+    A3 = 3,
+    /// tamaño A4.
+    A4 = 4,
+    /// tamaño A5.
+    A5 = 5,
+    /// tamaño A6.
+    A6 = 6,
+    /// tamaño B5.
+    B5 = 7,
+    /// tamaño PageLetter.
+    PageLetter = 8,
+    /// tamaño PageLegal.
+    PageLegal = 9,
+    /// tamaño PageLedger.
+    PageLedger = 10,
+    /// tamaño P11x17.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// No rotado.
+    None = 0,
+    /// Rotado 90 grados en sentido horario.
+    On90 = 1,
+    /// Rotado 180 grados.
+    On180 = 2,
+    /// Rotado 270 grados en sentido horario.
+    On270 = 3,
+    /// Rotado 360 grados en sentido horario.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 con longitud de clave 40.
+    RC4x40 = 0,
+    /// RC4 con longitud de clave 128.
+    RC4x128 = 1,
+    /// AES con longitud de clave 128.
+    AESx128 = 2,
+    /// AES con longitud de clave 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// formato PDF/A-1a.
+    PDF_A_1A = 0,
+    /// formato PDF/A-1b.
+    PDF_A_1B = 1,
+    /// formato PDF/A-2a.
+    PDF_A_2A = 2,
+    /// formato PDF/A-3a.
+    PDF_A_3A = 3,
+    /// formato PDF/A-2b.
+    PDF_A_2B = 4,
+    /// formato PDF/A-2u.
+    PDF_A_2U = 5,
+    /// formato PDF/A-3b.
+    PDF_A_3B = 6,
+    /// formato PDF/A-3u.
+    PDF_A_3U = 7,
+    /// versión Adobe 1.0.
+    V_1_0 = 8,
+    /// versión Adobe 1.1.
+    V_1_1 = 9,
+    /// versión Adobe 1.2.
+    V_1_2 = 10,
+    /// versión Adobe 1.3.
+    V_1_3 = 11,
+    /// versión Adobe 1.4.
+    V_1_4 = 12,
+    /// versión Adobe 1.5.
+    V_1_5 = 13,
+    /// versión Adobe 1.6.
+    V_1_6 = 14,
+    /// versión Adobe 1.7.
+    V_1_7 = 15,
+    /// Estándar ISO PDF 2.0.
+    V_2_0 = 16,
+    /// formato PDF/UA-1.
+    PDF_UA_1 = 17,
+    /// formato PDF/X-1a:2001.
+    PDF_X_1A_2001 = 18,
+    /// formato PDF/X-1a.
+    PDF_X_1A = 19,
+    /// formato PDF/X-3.
+    PDF_X_3 = 20,
+    /// formato ZUGFeRD.
+    ZUGFeRD = 21,
+    /// formato PDF/A-4.
+    PDF_A_4 = 22,
+    /// formato PDF/A-4e.
+    PDF_A_4E = 23,
+    /// formato PDF/A-4f.
+    PDF_A_4F = 24,
+    /// formato PDF/X-4.
+    PDF_X_4 = 25,
+    /// formato PDF/E-1 (PDF 1.6).
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Eliminar elementos no conformes.
+    Delete = 0,
+    /// No hacer nada, mantener elementos no conformes.
+    None = 1,
+}
+```
+

--- a/spanish/rust-cpp/convert/_index.md
+++ b/spanish/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Convertir desde funciones PDF"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Funciones para convertir desde archivos PDF."
+type: docs
+url: /es/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Convertir y guardar el PDF-documento previamente abierto como documento DocX-document. |
+| [save_doc](./save_doc/) | Convertir y guardar el PDF-documento previamente abierto como documento Doc-document. |
+| [save_xlsx](./save_xlsx/) | Convertir y guardar el PDF-documento previamente abierto como documento XlsX-document. |
+| [save_txt](./save_txt/) | Convertir y guardar el PDF-documento previamente abierto como documento Txt-document. |
+| [save_pptx](./save_pptx/) | Convertir y guardar el PDF-documento previamente abierto como documento PptX-document. |
+| [save_xps](./save_xps/) | Convertir y guardar el PDF-documento previamente abierto como documento Xps-document. |
+| [save_tex](./save_tex/) | Convertir y guardar el PDF-documento previamente abierto como documento TeX-document. |
+| [save_epub](./save_epub/) | Convertir y guardar el PDF-documento previamente abierto como documento Epub-document. |
+| [save_booklet](./save_booklet/) | Convertir y guardar el PDF-documento previamente abierto como documento PDF de folleto. |
+| [save_n_up](./save_n_up/) | Convertir y guardar el PDF-documento previamente abierto como documento PDF N-Up. |
+| [save_markdown](./save_markdown/) | Convertir y guardar el PDF-documento previamente abierto como documento Markdown-document. |
+| [save_tiff](./save_tiff/) | Convertir y guardar el PDF-documento previamente abierto como documento Tiff-document. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Convertir y guardar el PDF-documento previamente abierto como documento DocX-document con Modo de Reconocimiento Mejorado (tablas y párrafos totalmente editables). |
+| [save_svg_zip](./save_svg_zip/) | Convertir y guardar el PDF-documento previamente abierto como archivo SVG-archive. |
+| [export_fdf](./export_fdf/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento FDF-document. |
+| [export_xfdf](./export_xfdf/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento XFDF-document. |
+| [export_xml](./export_xml/) | Exportar desde el PDF-documento previamente abierto con AcroForm a documento XML-document. |
+| [page_to_jpg](./page_to_jpg/) | Convertir y guardar la página especificada como imagen Jpg-image. |
+| [page_to_png](./page_to_png/) | Convertir y guardar la página especificada como imagen Png-image. |
+| [page_to_bmp](./page_to_bmp/) | Convertir y guardar la página especificada como imagen Bmp-image. |
+| [page_to_tiff](./page_to_tiff/) | Convertir y guardar la página especificada como imagen Tiff. |
+| [page_to_svg](./page_to_svg/) | Convertir y guardar la página especificada como imagen Svg. |
+| [page_to_pdf](./page_to_pdf/) | Convertir y guardar la página especificada como documento PDF. |
+| [page_to_dicom](./page_to_dicom/) | Convertir y guardar la página especificada como imagen DICOM. |
+
+
+## Detailed Description
+
+Funciones para convertir desde archivos PDF.
+

--- a/spanish/rust-cpp/convert/export_fdf/_index.md
+++ b/spanish/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Exporta del documento PDF previamente abierto con AcroForm a un documento FDF con nombre de archivo."
+type: docs
+url: /es/rust-cpp/convert/export_fdf/
+---
+
+_Exporta del documento PDF previamente abierto con AcroForm a un documento FDF con nombre de archivo._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar del documento PDF previamente abierto con AcroForm a documento FDF
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/export_xfdf/_index.md
+++ b/spanish/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Exportaciones del PDF-document previamente abierto con AcroForm a XFDF-document con nombre de archivo."
+type: docs
+url: /es/rust-cpp/convert/export_xfdf/
+---
+
+_Exportaciones del PDF-document previamente abierto con AcroForm a XFDF-document con nombre de archivo._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar del PDF-document previamente abierto con AcroForm a XFDF-document
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/export_xml/_index.md
+++ b/spanish/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Exportaciones del PDF-document previamente abierto con AcroForm a XML-document con nombre de archivo."
+type: docs
+url: /es/rust-cpp/convert/export_xml/
+---
+
+_Exportaciones del PDF-document previamente abierto con AcroForm a XML-document con nombre de archivo._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportar del PDF-document previamente abierto con AcroForm a XML-document
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_bmp/_index.md
+++ b/spanish/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una imagen BMP."
+type: docs
+url: /es/rust-cpp/convert/page_to_bmp/
+---
+
+_Convierte y guarda la página especificada como una imagen BMP._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como imagen Bmp
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_dicom/_index.md
+++ b/spanish/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una DICOM-image."
+type: docs
+url: /es/rust-cpp/convert/page_to_dicom/
+---
+
+_Convierte y guarda la página especificada como una DICOM-image._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como DICOM-image
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_jpg/_index.md
+++ b/spanish/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una imagen JPG."
+type: docs
+url: /es/rust-cpp/convert/page_to_jpg/
+---
+
+_Convierte y guarda la página especificada como una imagen JPG._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como imagen Jpg
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_pdf/_index.md
+++ b/spanish/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como un PDF-document."
+type: docs
+url: /es/rust-cpp/convert/page_to_pdf/
+---
+
+_Convierte y guarda la página especificada como un PDF-document._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como PDF-document
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_png/_index.md
+++ b/spanish/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una imagen PNG."
+type: docs
+url: /es/rust-cpp/convert/page_to_png/
+---
+
+_Convierte y guarda la página especificada como una imagen PNG._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como imagen Png
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_svg/_index.md
+++ b/spanish/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una imagen SVG."
+type: docs
+url: /es/rust-cpp/convert/page_to_svg/
+---
+
+_Convierte y guarda la página especificada como una imagen SVG._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como imagen Svg
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/page_to_tiff/_index.md
+++ b/spanish/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda la página especificada como una imagen TIFF."
+type: docs
+url: /es/rust-cpp/convert/page_to_tiff/
+---
+
+_Convierte y guarda la página especificada como una imagen TIFF._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar la página especificada como imagen Tiff
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_booklet/_index.md
+++ b/spanish/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento PDF de folleto."
+type: docs
+url: /es/rust-cpp/convert/save_booklet/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento PDF de folleto._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento PDF de folleto
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/spanish/rust-cpp/convert/save_doc/_index.md
+++ b/spanish/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento DOC."
+type: docs
+url: /es/rust-cpp/convert/save_doc/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento DOC._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento Doc
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_docx/_index.md
+++ b/spanish/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento DOCX."
+type: docs
+url: /es/rust-cpp/convert/save_docx/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento DOCX._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento DocX
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/spanish/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-documento previamente abierto como un documento DOCX con Modo de Reconocimiento Mejorado (tablas y párrafos totalmente editables)."
+type: docs
+url: /es/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Convierte y guarda el PDF-documento previamente abierto como un documento DOCX con Modo de Reconocimiento Mejorado (tablas y párrafos totalmente editables)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-documento previamente abierto como documento DocX con Modo de Reconocimiento Mejorado (tablas y párrafos totalmente editables)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_epub/_index.md
+++ b/spanish/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-document previamente abierto como un EPUB-document."
+type: docs
+url: /es/rust-cpp/convert/save_epub/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento EPUB._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento EPUB
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_markdown/_index.md
+++ b/spanish/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento Markdown."
+type: docs
+url: /es/rust-cpp/convert/save_markdown/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento Markdown._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento Markdown
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/spanish/rust-cpp/convert/save_n_up/_index.md
+++ b/spanish/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-documento previamente abierto como un documento PDF N-Up."
+type: docs
+url: /es/rust-cpp/convert/save_n_up/
+---
+
+_Convierte y guarda el PDF-documento previamente abierto como un documento PDF N-Up._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-documento previamente abierto como documento PDF N-Up
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/spanish/rust-cpp/convert/save_pptx/_index.md
+++ b/spanish/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento PPTX."
+type: docs
+url: /es/rust-cpp/convert/save_pptx/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento PPTX._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento PptX
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_svg_zip/_index.md
+++ b/spanish/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-document previamente abierto como un SVG-archive."
+type: docs
+url: /es/rust-cpp/convert/save_svg_zip/
+---
+
+_Convierte y guarda el PDF-document previamente abierto como un SVG-archive._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-document previamente abierto como SVG-archive
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_tex/_index.md
+++ b/spanish/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-documento previamente abierto como un documento TeX."
+type: docs
+url: /es/rust-cpp/convert/save_tex/
+---
+
+_Convierte y guarda el PDF-documento previamente abierto como un documento TeX._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-documento previamente abierto como documento TeX
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_tiff/_index.md
+++ b/spanish/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el documento PDF previamente abierto como un documento Tiff."
+type: docs
+url: /es/rust-cpp/convert/save_tiff/
+---
+
+_Convierte y guarda el documento PDF previamente abierto como un documento Tiff._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el documento PDF previamente abierto como documento Tiff
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/spanish/rust-cpp/convert/save_txt/_index.md
+++ b/spanish/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-document previamente abierto como un TXT-document."
+type: docs
+url: /es/rust-cpp/convert/save_txt/
+---
+
+_Convierte y guarda el PDF-document previamente abierto como un TXT-document._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-document previamente abierto como Txt-document
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_xlsx/_index.md
+++ b/spanish/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-documento previamente abierto como un documento XLSX."
+type: docs
+url: /es/rust-cpp/convert/save_xlsx/
+---
+
+_Convierte y guarda el PDF-documento previamente abierto como un documento XLSX._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-documento previamente abierto como documento XlsX
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/convert/save_xps/_index.md
+++ b/spanish/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte y guarda el PDF-documento previamente abierto como un documento XPS."
+type: docs
+url: /es/rust-cpp/convert/save_xps/
+---
+
+_Convierte y guarda el PDF-documento previamente abierto como un documento XPS._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir y guardar el PDF-documento previamente abierto como documento Xps
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/_index.md
+++ b/spanish/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Funciones principales de PDF"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Funciones principales para trabajar con archivos PDF."
+type: docs
+url: /es/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [new](./new/) | Crear un nuevo documento PDF. |
+| [open](./open/) | Abrir un documento PDF con el nombre de archivo. |
+| [save](./save/) | Guardar el documento PDF abierto previamente. |
+| [save_as](./save_as/) | Guardar el documento PDF abierto previamente con un nuevo nombre de archivo. |
+| [set_license](./set_license/) | Establecer la licencia con el nombre de archivo. |
+| [extract_text](./extract_text/) | Devolver el contenido del documento PDF como texto plano. |
+| [word_count](./word_count/) | Devolver el recuento de palabras en el documento PDF. |
+| [character_count](./character_count/) | Devolver el recuento de caracteres en el documento PDF. |
+| [append](./append/) | Agregar páginas de otro documento PDF. |
+| [append_pages](./append_pages/) | Agregar páginas seleccionadas de otro documento PDF. |
+| [merge_documents](./merge_documents/) | Crear un nuevo documento PDF combinando los documentos PDF proporcionados. |
+| [split_document](./split_document/) | Crear varios documentos PDF nuevos extrayendo páginas del documento PDF fuente. |
+| [split](./split/) | Crear varios documentos PDF nuevos extrayendo páginas del documento PDF actual. |
+| [split_at_page](./split_at_page/) | Dividir el documento PDF en dos documentos PDF nuevos. |
+| [split_at](./split_at/) | Dividir el documento PDF actual en dos documentos PDF nuevos. |
+| [bytes](./bytes/) | Devolver el contenido del documento PDF como un vector de bytes. |
+| [get_meta_info](./get_meta_info/) | Obtener el valor de la información meta del documento PDF. |
+| [set_meta_info](./set_meta_info/) | Establecer el valor de la información meta del PDF-document. |
+| [clear_meta_info](./clear_meta_info/) | Borrar todos los valores de información meta del PDF-document. |
+| [is_linearized](./is_linearized/) | Obtener un valor que indique si el documento está linealizado. |
+| [page_add](./page_add/) | Agregar una nueva página en el PDF-document. |
+| [page_insert](./page_insert/) | Insertar una nueva página en la posición especificada del PDF-document. |
+| [page_delete](./page_delete/) | Eliminar la página especificada del PDF-document. |
+| [page_count](./page_count/) | Devolver el número de páginas del PDF-document. |
+| [page_word_count](./page_word_count/) | Devolver el recuento de palabras en la página especificada del PDF-document. |
+| [page_character_count](./page_character_count/) | Devolver el recuento de caracteres en la página especificada del PDF-document. |
+| [page_is_blank](./page_is_blank/) | Devolver si la página está en blanco en el PDF-document. |
+
+
+## Detailed Description
+
+Funciones principales para trabajar con archivos PDF.
+

--- a/spanish/rust-cpp/core/append/_index.md
+++ b/spanish/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Añade páginas de otro PDF-documento."
+type: docs
+url: /es/rust-cpp/core/append/
+---
+
+_Añade páginas de otro PDF-documento._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir el PDF-documento principal
+    let pdf = Document::open("sample.pdf")?;
+
+    // Abrir otro PDF-documento para añadir
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Añadir páginas de otro PDF-documento
+    pdf.append(&another_pdf)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/append_pages/_index.md
+++ b/spanish/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Añade páginas seleccionadas de otro PDF-document."
+type: docs
+url: /es/rust-cpp/core/append_pages/
+---
+
+_Añade páginas seleccionadas de otro PDF-document._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir el PDF-documento principal
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Abrir otro PDF-documento para añadir
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Añade páginas específicas (1 y 3) de otro PDF-document
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/bytes/_index.md
+++ b/spanish/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "bytes"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el contenido del documento PDF como un vector de bytes."
+type: docs
+url: /es/rust-cpp/core/bytes/
+---
+
+_Devuelve el contenido del documento PDF como un vector de bytes._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Devolver el contenido del documento PDF como un vector de bytes
+    let data = pdf.bytes()?;
+
+    // Imprimir la longitud del vector de bytes
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/character_count/_index.md
+++ b/spanish/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el recuento de caracteres en el documento PDF."
+type: docs
+url: /es/rust-cpp/core/character_count/
+---
+
+_Devuelve el recuento de caracteres en el documento PDF._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Devolver el recuento de caracteres en el documento PDF
+    let count = pdf.character_count()?;
+
+    // Imprimir el recuento de caracteres
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/clear_meta_info/_index.md
+++ b/spanish/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina todos los valores de información meta del PDF-document."
+type: docs
+url: /es/rust-cpp/core/clear_meta_info/
+---
+
+_Elimina todos los valores de información meta del PDF-document._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar toda la información meta del PDF-document
+    pdf.clear_meta_info()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/extract_text/_index.md
+++ b/spanish/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el contenido del PDF-documento como texto plano."
+type: docs
+url: /es/rust-cpp/core/extract_text/
+---
+
+_Devuelve el contenido del PDF-documento como texto plano._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Devolver el contenido del PDF-documento como texto plano
+    let txt = pdf.extract_text()?;
+
+    // Imprimir texto extraído
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/get_meta_info/_index.md
+++ b/spanish/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtiene el valor de la información meta del PDF-documento."
+type: docs
+url: /es/rust-cpp/core/get_meta_info/
+---
+
+_Obtiene el valor de la información meta del PDF-documento._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtener el valor de la información meta del PDF-documento
+    let author = pdf.get_meta_info("Author")?;
+
+    // Imprimir el resultado
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/is_linearized/_index.md
+++ b/spanish/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtiene un valor que indica si el documento está linealizado."
+type: docs
+url: /es/rust-cpp/core/is_linearized/
+---
+
+_Obtiene un valor que indica si el documento está linealizado._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtener un valor que indica si el documento está linealizado
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/merge_documents/_index.md
+++ b/spanish/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Crea un PDF-document nuevo fusionando los PDF-documents proporcionados."
+type: docs
+url: /es/rust-cpp/core/merge_documents/
+---
+
+_Crea un PDF-document nuevo fusionando los PDF-documents proporcionados._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf1 = Document::new()?;
+
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Crear un PDF-document nuevo fusionando los PDF-documents proporcionados
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/new/_index.md
+++ b/spanish/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "new"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Crea un nuevo documento PDF."
+type: docs
+url: /es/rust-cpp/core/new/
+---
+
+_Crea un nuevo documento PDF._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/open/_index.md
+++ b/spanish/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Abre un PDF-documento con nombre de archivo."
+type: docs
+url: /es/rust-cpp/core/open/
+---
+
+_Abre un PDF-documento con nombre de archivo._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_add/_index.md
+++ b/spanish/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega una nueva página al documento PDF."
+type: docs
+url: /es/rust-cpp/core/page_add/
+---
+
+_Agrega una nueva página al documento PDF._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar nueva página en el documento PDF
+    pdf.page_add()?;
+
+    // Guardar el PDF-documento previamente abierto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_character_count/_index.md
+++ b/spanish/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el recuento de caracteres en la página especificada del documento PDF."
+type: docs
+url: /es/rust-cpp/core/page_character_count/
+---
+
+_Devuelve el recuento de caracteres en la página especificada del documento PDF._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifica el número de página (índice basado en 1)
+    let page_number = 1;
+
+    // Devolver el recuento de caracteres en la página especificada
+    let count = pdf.page_character_count(page_number)?;
+
+    // Imprimir el recuento de caracteres
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_count/_index.md
+++ b/spanish/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el número de páginas del PDF-document."
+type: docs
+url: /es/rust-cpp/core/page_count/
+---
+
+_Devuelve el número de páginas del PDF-document._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Devolver el recuento de páginas en PDF-document
+    let count = pdf.page_count()?;
+
+    // Imprimir el recuento de páginas
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_delete/_index.md
+++ b/spanish/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina la página especificada del PDF-documento."
+type: docs
+url: /es/rust-cpp/core/page_delete/
+---
+
+_Elimina la página especificada del PDF-documento._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar página especificada en el PDF-documento
+    pdf.page_delete(1)?;
+
+    // Guardar el PDF-documento previamente abierto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_insert/_index.md
+++ b/spanish/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Inserta una nueva página en la posición especificada del PDF-documento."
+type: docs
+url: /es/rust-cpp/core/page_insert/
+---
+
+_Inserta una nueva página en la posición especificada del PDF-documento._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Insertar nueva página en la posición especificada del PDF-documento
+    pdf.page_insert(1)?;
+
+    // Guardar el PDF-documento previamente abierto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_is_blank/_index.md
+++ b/spanish/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devolver si la página está en blanco en el PDF-document."
+type: docs
+url: /es/rust-cpp/core/page_is_blank/
+---
+
+_La página devuelta está en blanco en el PDF-documento._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifica el número de página (índice basado en 1)
+    let page_number = 1;
+
+    // La página devuelta está en blanco en el PDF-documento
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Imprimir si la página especificada está en blanco
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/page_word_count/_index.md
+++ b/spanish/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el recuento de palabras en la página especificada del PDF-documento."
+type: docs
+url: /es/rust-cpp/core/page_word_count/
+---
+
+_Devuelve el recuento de palabras en la página especificada del PDF-documento._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Especifica el número de página (índice basado en 1)
+    let page_number = 1;
+
+    // Devolver el recuento de palabras en la página especificada
+    let count = pdf.page_word_count(page_number)?;
+
+    // Imprimir el recuento de palabras
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/save/_index.md
+++ b/spanish/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Guarda el PDF-documento previamente abierto."
+type: docs
+url: /es/rust-cpp/core/save/
+---
+
+_Guarda el PDF-documento previamente abierto._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Guardar el PDF-documento previamente abierto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/save_as/_index.md
+++ b/spanish/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Guarda el PDF-documento previamente abierto con un nuevo nombre de archivo."
+type: docs
+url: /es/rust-cpp/core/save_as/
+---
+
+_Guarda el PDF-documento previamente abierto con un nuevo nombre de archivo._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Guardar el PDF-documento con un nuevo nombre de archivo
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/set_license/_index.md
+++ b/spanish/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Establece la licencia usando el nombre de archivo."
+type: docs
+url: /es/rust-cpp/core/set_license/
+---
+
+_Establece la licencia usando el nombre de archivo._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Establecer licencia con nombre de archivo
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Ahora puedes trabajar con el documento PDF con licencia
+    // ...
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/set_meta_info/_index.md
+++ b/spanish/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Establece el valor de la información meta del PDF-document."
+type: docs
+url: /es/rust-cpp/core/set_meta_info/
+---
+
+_Establece el valor de la información meta del PDF-document._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Establecer el valor de la información meta del PDF-document
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/split/_index.md
+++ b/spanish/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Crea varios PDF-documents nuevos extrayendo páginas del PDF-document actual."
+type: docs
+url: /es/rust-cpp/core/split/
+---
+
+_Crea varios PDF-documents nuevos extrayendo páginas del PDF-document actual._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Crear varios PDF-documents nuevos extrayendo páginas del PDF-document actual
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Guardar cada parte dividida como un PDF-documento separado
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/split_at/_index.md
+++ b/spanish/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Divide el PDF-documento actual en dos nuevos PDF-documentos."
+type: docs
+url: /es/rust-cpp/core/split_at/
+---
+
+_Divide el PDF-documento actual en dos nuevos PDF-documentos._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dividir el PDF-documento actual en dos nuevos PDF-documentos
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Guardar cada parte dividida como un PDF-documento separado
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/split_at_page/_index.md
+++ b/spanish/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Divide el PDF-documento en dos nuevos PDF-documentos."
+type: docs
+url: /es/rust-cpp/core/split_at_page/
+---
+
+_Divide el PDF-documento en dos nuevos PDF-documentos._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dividir el PDF-documento en dos nuevos PDF-documentos
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Guardar cada parte dividida como un PDF-documento separado
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/split_document/_index.md
+++ b/spanish/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Crea varios PDF-documentos nuevos extrayendo páginas del PDF-documento fuente."
+type: docs
+url: /es/rust-cpp/core/split_document/
+---
+
+_Crea varios PDF-documentos nuevos extrayendo páginas del PDF-documento fuente._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento llamado "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Crea varios PDF-documentos nuevos extrayendo páginas del PDF-documento fuente
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Guardar cada parte dividida como un PDF-documento separado
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/core/word_count/_index.md
+++ b/spanish/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve el recuento de palabras en el PDF-documento."
+type: docs
+url: /es/rust-cpp/core/word_count/
+---
+
+_Devuelve el recuento de palabras en el PDF-documento._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Devolver el recuento de palabras en el PDF-documento
+    let count = pdf.word_count()?;
+
+    // Imprimir el recuento de palabras
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/miscellaneous/_index.md
+++ b/spanish/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funciones misceláneas"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Funciones misceláneas para trabajar."
+type: docs
+url: /es/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Función | Descripción |
+| -------- | ----------- |
+| [about](./about/) | Devolver información de metadatos sobre Aspose.PDF para Rust vía C++. |
+
+
+## Detailed Description
+
+Funciones misceláneas para trabajar.
+

--- a/spanish/rust-cpp/miscellaneous/about/_index.md
+++ b/spanish/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "acerca de"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Devuelve información de metadatos sobre Aspose.PDF para Rust a través de C++."
+type: docs
+url: /es/rust-cpp/miscellaneous/about/
+---
+
+_Devuelve información de metadatos sobre Aspose.PDF para Rust a través de C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Devuelve información de metadatos sobre Aspose.PDF para Go a través de C++.
+    let info = pdf.about()?;
+
+    // Imprimir campos de metadatos
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/_index.md
+++ b/spanish/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Funciones para organizar PDF"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Funciones para organizar archivos PDF."
+type: docs
+url: /es/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Optimizar el contenido del documento PDF. |
+| [optimize_resource](./optimize_resource/) | Optimizar los recursos del documento PDF. |
+| [grayscale](./grayscale/) | Convertir el documento PDF a blanco y negro. |
+| [rotate](./rotate/) | Rotar el documento PDF. |
+| [set_background](./set_background/) | Establecer el color de fondo del documento PDF usando valores RGB. |
+| [repair](./repair/) | Reparar el documento PDF. |
+| [replace_text](./replace_text/) | Reemplazar texto en el documento PDF |
+| [add_page_num](./add_page_num/) | Agregar número de página a un documento PDF |
+| [add_text_header](./add_text_header/) | Agregar texto en el encabezado de un documento PDF |
+| [add_text_footer](./add_text_footer/) | Agregar texto en el pie de página de un documento PDF |
+| [flatten](./flatten/) | Aplanar el documento PDF |
+| [remove_annotations](./remove_annotations/) | Eliminar anotaciones del documento PDF |
+| [remove_attachments](./remove_attachments/) | Eliminar adjuntos del documento PDF |
+| [remove_blank_pages](./remove_blank_pages/) | Eliminar páginas en blanco del documento PDF |
+| [remove_bookmarks](./remove_bookmarks/) | Eliminar marcadores del documento PDF |
+| [remove_hidden_text](./remove_hidden_text/) | Eliminar texto oculto del documento PDF |
+| [remove_images](./remove_images/) | Eliminar imágenes del documento PDF |
+| [remove_javascripts](./remove_javascripts/) | Eliminar scripts Java del documento PDF |
+| [remove_tables](./remove_tables/) | Eliminar tablas de un documento PDF. |
+| [remove_watermarks](./remove_watermarks/) | Eliminar marcas de agua del documento PDF. |
+| [add_watermark](./add_watermark/) | Agregar marca de agua al documento PDF. |
+| [embed_fonts](./embed_fonts/) | Incrustar fuentes en un documento PDF. |
+| [unembed_fonts](./unembed_fonts/) | Desincrustar fuentes de un documento PDF. |
+| [optimize_file_size](./optimize_file_size/) | Optimizar el tamaño de un documento PDF con calidad de compresión de imagen. |
+| [remove_text_headers](./remove_text_headers/) | Eliminar encabezados de texto de un documento PDF. |
+| [remove_text_footers](./remove_text_footers/) | Eliminar pies de página de texto de un documento PDF. |
+| [crop](./crop/) | Recortar páginas de un documento PDF. |
+| [replace_font](./replace_font/) | Reemplazar la fuente en un documento PDF. |
+| [convert](./convert/) | Convertir un documento PDF en un documento PDF con el formato PDF especificado |
+| [validate](./validate/) | Validar un documento PDF para el cumplimiento del formato PDF |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Eliminar el cumplimiento PDF/A de un documento PDF |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Eliminar el cumplimiento PDF/UA de un documento PDF |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Obtener si un documento PDF cumple con PDF/A |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Obtener si un documento PDF cumple con PDF/UA |
+| [page_rotate](./page_rotate/) | Rotar una página en el documento PDF. |
+| [page_set_size](./page_set_size/) | Establecer el tamaño de una página en el documento PDF. |
+| [page_grayscale](./page_grayscale/) | Convertir la página a blanco y negro. |
+| [page_add_text](./page_add_text/) | Agregar texto en la página. |
+| [page_replace_text](./page_replace_text/) | Reemplazar texto en la página |
+| [page_add_page_num](./page_add_page_num/) | Agregar número de página en la página |
+| [page_add_text_header](./page_add_text_header/) | Agregar texto en el encabezado de la página |
+| [page_add_text_footer](./page_add_text_footer/) | Agregar texto en el pie de página de la página |
+| [page_remove_annotations](./page_remove_annotations/) | Eliminar anotaciones en la página. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Eliminar texto oculto en la página. |
+| [page_remove_images](./page_remove_images/) | Eliminar imágenes en la página. |
+| [page_remove_tables](./page_remove_tables/) | Eliminar tablas en la página. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Eliminar marcas de agua en la página. |
+| [page_add_watermark](./page_add_watermark/) | Agregar marca de agua en la página. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Eliminar encabezados de texto en la página. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Eliminar pies de página de texto en la página. |
+| [page_crop](./page_crop/) | Recortar una página. |
+| [page_replace_font](./page_replace_font/) | Reemplazar la fuente en la página. |
+| [page_merge_layers](./page_merge_layers/) | Combinar todas las capas en la página en una sola capa con el nombre de capa nuevo especificado. |
+| [page_layers](./page_layers/) | Obtener los nombres de las capas en la página. |
+
+
+## Detailed Description
+
+Funciones para organizar archivos PDF.

--- a/spanish/rust-cpp/organize/add_page_num/_index.md
+++ b/spanish/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega número de página a un PDF-document."
+type: docs
+url: /es/rust-cpp/organize/add_page_num/
+---
+
+_Agrega número de página a un PDF-document._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar número de página a un documento PDF
+    pdf.add_page_num()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/add_text_footer/_index.md
+++ b/spanish/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega texto en el pie de página de un PDF-document."
+type: docs
+url: /es/rust-cpp/organize/add_text_footer/
+---
+
+_Agrega texto en el pie de página de un PDF-document._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar texto en el pie de página de un documento PDF
+    pdf.add_text_footer("FOOTER")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/add_text_header/_index.md
+++ b/spanish/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega texto en el encabezado de un PDF-document."
+type: docs
+url: /es/rust-cpp/organize/add_text_header/
+---
+
+_Agrega texto en el encabezado de un PDF-document._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar texto en el encabezado de un documento PDF
+    pdf.add_text_header("HEADER")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/add_watermark/_index.md
+++ b/spanish/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega marca de agua a un PDF-document."
+type: docs
+url: /es/rust-cpp/organize/add_watermark/
+---
+
+_Agrega marca de agua a un PDF-document._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar marca de agua a un PDF-document
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/convert/_index.md
+++ b/spanish/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte un PDF-document en un PDF-document con el formato PDF especificado."
+type: docs
+url: /es/rust-cpp/organize/convert/
+---
+
+_Convierte un PDF-document en un PDF-document con el formato PDF especificado._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir un documento PDF en un documento PDF con el formato PDF especificado
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Imprime el resultado de la conversión y el registro completo
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/crop/_index.md
+++ b/spanish/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "recortar"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Recorta páginas de un documento PDF."
+type: docs
+url: /es/rust-cpp/organize/crop/
+---
+
+_Recorta páginas de un documento PDF._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recortar páginas de un documento PDF
+    pdf.crop(10.5)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/embed_fonts/_index.md
+++ b/spanish/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Incrusta fuentes en un documento PDF."
+type: docs
+url: /es/rust-cpp/organize/embed_fonts/
+---
+
+_Incrusta fuentes en un documento PDF._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Incrustar fuentes en un documento PDF
+    pdf.embed_fonts()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/flatten/_index.md
+++ b/spanish/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Aplana el documento PDF."
+type: docs
+url: /es/rust-cpp/organize/flatten/
+---
+
+_Aplana el documento PDF._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Devolver el contenido del PDF-documento como texto plano
+    let txt = pdf.extract_text()?;
+
+    // Imprimir texto extraído
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/grayscale/_index.md
+++ b/spanish/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte el documento PDF a blanco y negro."
+type: docs
+url: /es/rust-cpp/organize/grayscale/
+---
+
+_Convierte el documento PDF a blanco y negro._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir documento PDF a blanco y negro
+    pdf.grayscale()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/spanish/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtiene si un documento PDF es compatible con PDF/A."
+type: docs
+url: /es/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Obtiene si un documento PDF es compatible con PDF/A._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtener el estado de compatibilidad PDF/A del documento PDF
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/spanish/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtiene si un documento PDF es compatible con PDF/UA."
+type: docs
+url: /es/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Obtiene si un documento PDF es compatible con PDF/UA._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Obtén el estado de compatibilidad PDF/UA del documento PDF
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/optimize/_index.md
+++ b/spanish/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Optimiza el contenido del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/optimize/
+---
+
+_Optimiza el contenido del documento PDF._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimizar el contenido del documento PDF
+    pdf.optimize()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/optimize_file_size/_index.md
+++ b/spanish/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Optimiza el tamaño de un PDF-document con calidad de compresión de imagen."
+type: docs
+url: /es/rust-cpp/organize/optimize_file_size/
+---
+
+_Optimiza el tamaño de un PDF-document con calidad de compresión de imagen._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimizar el tamaño de un PDF-document con calidad de compresión de imagen
+    pdf.optimize_file_size(50)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/optimize_resource/_index.md
+++ b/spanish/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Optimiza los recursos del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/optimize_resource/
+---
+
+_Optimiza los recursos del documento PDF._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimizar recursos del documento PDF
+    pdf.optimize_resource()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_add_page_num/_index.md
+++ b/spanish/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega número de página en la página."
+type: docs
+url: /es/rust-cpp/organize/page_add_page_num/
+---
+
+_Agrega número de página en la página._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar número de página en la página
+    pdf.page_add_page_num(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_add_text/_index.md
+++ b/spanish/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega texto a una página."
+type: docs
+url: /es/rust-cpp/organize/page_add_text/
+---
+
+_Agrega texto a una página._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar texto en la página
+    pdf.page_add_text(1, "added text")?;
+
+    // Guardar el PDF-documento previamente abierto
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/spanish/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Agrega texto en el pie de página."
+type: docs
+url: /es/rust-cpp/organize/page_add_text_footer/
+---
+
+_Agrega texto en el pie de página._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar texto en el pie de página de la página
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_add_text_header/_index.md
+++ b/spanish/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Añade texto en el encabezado de la página."
+type: docs
+url: /es/rust-cpp/organize/page_add_text_header/
+---
+
+_Añade texto en el encabezado de la página._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Agregar texto en el encabezado de la página
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_add_watermark/_index.md
+++ b/spanish/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Añade una marca de agua en la página."
+type: docs
+url: /es/rust-cpp/organize/page_add_watermark/
+---
+
+_Añade una marca de agua en la página._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Añadir marca de agua en la página
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_crop/_index.md
+++ b/spanish/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Recorta una página."
+type: docs
+url: /es/rust-cpp/organize/page_crop/
+---
+
+_Recorta una página._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Recortar una página
+    pdf.page_crop(1, 1.0)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_grayscale/_index.md
+++ b/spanish/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Convierte una página a blanco y negro."
+type: docs
+url: /es/rust-cpp/organize/page_grayscale/
+---
+
+_Convierte una página a blanco y negro._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Convertir página a blanco y negro
+    pdf.page_grayscale(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_layers/_index.md
+++ b/spanish/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtiene los nombres de las capas en la página."
+type: docs
+url: /es/rust-cpp/organize/page_layers/
+---
+
+_Obtiene los nombres de las capas en la página._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Obtén los nombres de las capas en la página 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_merge_layers/_index.md
+++ b/spanish/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Fusiona todas las capas de la página en una sola capa con el nombre de capa nuevo especificado."
+type: docs
+url: /es/rust-cpp/organize/page_merge_layers/
+---
+
+_Fusiona todas las capas de la página en una sola capa con el nombre de capa nuevo especificado._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Fusionar todas las capas de la página en una sola capa con el nombre de capa nuevo especificado
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina anotaciones en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_annotations/
+---
+
+_Elimina anotaciones en la página._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar anotaciones en la página
+    pdf.page_remove_annotations(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina texto oculto en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Elimina texto oculto en la página._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar texto oculto en la página
+    pdf.page_remove_hidden_text(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_images/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina imágenes en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_images/
+---
+
+_Elimina imágenes en la página._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar imágenes en la página
+    pdf.page_remove_images(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_tables/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina tablas en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_tables/
+---
+
+_Elimina tablas en la página._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar tablas en la página
+    pdf.page_remove_tables(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina los pies de página de texto en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Elimina los pies de página de texto en la página._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar pies de página de texto en la página
+    pdf.page_remove_text_footers(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina encabezados de texto en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Elimina encabezados de texto en la página._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar encabezados de texto en la página
+    pdf.page_remove_text_headers(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/spanish/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina marcas de agua en la página."
+type: docs
+url: /es/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Elimina marcas de agua en la página._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar marcas de agua en la página
+    pdf.page_remove_watermarks(1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_replace_font/_index.md
+++ b/spanish/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Reemplaza la fuente en la página."
+type: docs
+url: /es/rust-cpp/organize/page_replace_font/
+---
+
+_Reemplaza la fuente en la página._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reemplazar fuente en la página
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_replace_text/_index.md
+++ b/spanish/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Reemplaza texto en la página."
+type: docs
+url: /es/rust-cpp/organize/page_replace_text/
+---
+
+_Reemplaza texto en la página._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reemplazar texto en la página
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_rotate/_index.md
+++ b/spanish/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Rota una página en el documento PDF."
+type: docs
+url: /es/rust-cpp/organize/page_rotate/
+---
+
+_Rota una página en el documento PDF._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-documento desde un archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rotar página
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/page_set_size/_index.md
+++ b/spanish/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Establece el tamaño de una página en el documento PDF."
+type: docs
+url: /es/rust-cpp/organize/page_set_size/
+---
+
+_Establece el tamaño de una página en el documento PDF._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Establecer el tamaño de una página en el documento PDF
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_annotations/_index.md
+++ b/spanish/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina anotaciones del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_annotations/
+---
+
+_Elimina anotaciones del documento PDF._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar anotaciones del documento PDF
+    pdf.remove_annotations()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_attachments/_index.md
+++ b/spanish/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina archivos adjuntos del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_attachments/
+---
+
+_Elimina archivos adjuntos del documento PDF._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar adjuntos del documento PDF
+    pdf.remove_attachments()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/spanish/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina páginas en blanco del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_blank_pages/
+---
+
+_Elimina páginas en blanco del documento PDF._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar páginas en blanco del documento PDF
+    pdf.remove_blank_pages()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/spanish/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina marcadores del PDF-document."
+type: docs
+url: /es/rust-cpp/organize/remove_bookmarks/
+---
+
+_Elimina marcadores del PDF-document._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar marcadores del documento PDF
+    pdf.remove_bookmarks()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/spanish/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina texto oculto del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_hidden_text/
+---
+
+_Elimina texto oculto del documento PDF._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar texto oculto del documento PDF
+    pdf.remove_hidden_text()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_images/_index.md
+++ b/spanish/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina imágenes del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_images/
+---
+
+_Elimina imágenes del documento PDF._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar imágenes del documento PDF
+    pdf.remove_images()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_javascripts/_index.md
+++ b/spanish/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina scripts Java del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_javascripts/
+---
+
+_Elimina scripts Java del documento PDF._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar scripts Java del documento PDF
+    pdf.remove_javascripts()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/spanish/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Eliminar el cumplimiento PDF/A de un documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Eliminar el cumplimiento PDF/A de un documento PDF._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar el cumplimiento PDF/A de un documento PDF
+    pdf.remove_pdfa_compliance()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/spanish/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina la compatibilidad PDF/UA de un documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Elimina la compatibilidad PDF/UA de un documento PDF._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar el cumplimiento PDF/UA de un documento PDF
+    pdf.remove_pdfua_compliance()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_tables/_index.md
+++ b/spanish/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina tablas del PDF-document."
+type: docs
+url: /es/rust-cpp/organize/remove_tables/
+---
+
+_Elimina tablas del PDF-document._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar tablas del PDF-document
+    pdf.remove_tables()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_text_footers/_index.md
+++ b/spanish/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina pies de página de texto del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_text_footers/
+---
+
+_Elimina pies de página de texto del documento PDF._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar pies de página de texto del documento PDF
+    pdf.remove_text_footers()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_text_headers/_index.md
+++ b/spanish/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina encabezados de texto del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_text_headers/
+---
+
+_Elimina encabezados de texto del documento PDF._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar encabezados de texto del documento PDF
+    pdf.remove_text_headers()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/remove_watermarks/_index.md
+++ b/spanish/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Elimina marcas de agua del documento PDF."
+type: docs
+url: /es/rust-cpp/organize/remove_watermarks/
+---
+
+_Elimina marcas de agua del documento PDF._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Eliminar marcas de agua del documento PDF
+    pdf.remove_watermarks()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/repair/_index.md
+++ b/spanish/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Repara el documento PDF."
+type: docs
+url: /es/rust-cpp/organize/repair/
+---
+
+_Repara el documento PDF._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reparar documento PDF
+    pdf.repair()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/replace_font/_index.md
+++ b/spanish/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Reemplaza la fuente en un documento PDF."
+type: docs
+url: /es/rust-cpp/organize/replace_font/
+---
+
+_Reemplaza la fuente en un documento PDF._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reemplazar la fuente en un documento PDF.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/replace_text/_index.md
+++ b/spanish/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Reemplaza texto."
+type: docs
+url: /es/rust-cpp/organize/replace_text/
+---
+
+_Reemplaza texto._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reemplazar texto en el documento PDF
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/rotate/_index.md
+++ b/spanish/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Gira el documento PDF."
+type: docs
+url: /es/rust-cpp/organize/rotate/
+---
+
+_Gira el documento PDF._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Girar documento PDF
+    pdf.rotate(Rotation::On270)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/set_background/_index.md
+++ b/spanish/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Establece el color de fondo del PDF-document usando valores RGB."
+type: docs
+url: /es/rust-cpp/organize/set_background/
+---
+
+_Establece el color de fondo del PDF-document usando valores RGB._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Establecer el color de fondo del PDF-document usando valores RGB
+    pdf.set_background(200, 100, 101)?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/unembed_fonts/_index.md
+++ b/spanish/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Desincorpora fuentes de un PDF-document."
+type: docs
+url: /es/rust-cpp/organize/unembed_fonts/
+---
+
+_Desincorpora fuentes de un PDF-document._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Desincorporar fuentes de un PDF-document
+    pdf.unembed_fonts()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/organize/validate/_index.md
+++ b/spanish/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Valida un PDF-document para cumplir con el formato PDF."
+type: docs
+url: /es/rust-cpp/organize/validate/
+---
+
+_Valida un PDF-document para cumplir con el formato PDF._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Validar un documento PDF para el cumplimiento del formato PDF
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Imprimir resultado de validación y registro completo
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/_index.md
+++ b/spanish/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funciones de seguridad"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Funciones de seguridad."
+type: docs
+url: /es/rust-cpp/security/
+---
+
+## Security
+
+| Función | Descripción |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Abrir un PDF-document protegido con contraseña. |
+| [encrypt](./encrypt/) | Cifrar el PDF-document. |
+| [decrypt](./decrypt/) | Descifrar el PDF-document. |
+| [set_permissions](./set_permissions/) | Establecer permisos para el PDF-document. |
+| [get_permissions](./get_permissions/) | Obtener los permisos actuales del PDF-document. |
+| [is_encrypted](./is_encrypted/) | Obtener el estado cifrado del PDF-document. |
+| [sign_pkcs7](./sign_pkcs7/) | Firmar un PDF-document usando firmas digitales PKCS#7. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Firmar un PDF-document usando firmas digitales PKCS#7 desacopladas. |
+| [is_signed](./is_signed/) | Obtener el estado de firma del PDF-document. |
+| [remove_signs](./remove_signs/) | Eliminar firmas del PDF-document. |
+
+
+## Detailed Description
+
+Funciones de seguridad.
+

--- a/spanish/rust-cpp/security/decrypt/_index.md
+++ b/spanish/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "descifrar"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Descifrar el PDF-document."
+type: docs
+url: /es/rust-cpp/security/decrypt/
+---
+
+_Descifrar PDF-document._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document protegido con contraseña
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Descifrar PDF-document
+    pdf.decrypt()?;
+
+    // Guardar el PDF-documento previamente abierto con un nuevo nombre de archivo
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/encrypt/_index.md
+++ b/spanish/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "cifrar"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Cifrar el PDF-document."
+type: docs
+url: /es/rust-cpp/security/encrypt/
+---
+
+_Cifrar PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Cifrar PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Guardar el PDF-document cifrado
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/get_permissions/_index.md
+++ b/spanish/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtener los permisos actuales del PDF-document."
+type: docs
+url: /es/rust-cpp/security/get_permissions/
+---
+
+_Obtener permisos actuales del PDF-document._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document protegido con contraseña
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Obtener permisos actuales del PDF-document
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Imprimir permisos
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/is_encrypted/_index.md
+++ b/spanish/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtener el estado cifrado del PDF-document."
+type: docs
+url: /es/rust-cpp/security/is_encrypted/
+---
+
+_Obtener estado cifrado del PDF-document._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document protegido con contraseña
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Obtener estado cifrado del PDF-document
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/is_signed/_index.md
+++ b/spanish/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Obtener el estado de firma del PDF-document."
+type: docs
+url: /es/rust-cpp/security/is_signed/
+---
+
+_Obtener el estado firmado del PDF-document._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document llamado "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Obtener el estado firmado del PDF-document
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/open_with_password/_index.md
+++ b/spanish/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Abrir un PDF-document protegido con contraseña."
+type: docs
+url: /es/rust-cpp/security/open_with_password/
+---
+
+_Abrir un PDF-document protegido con contraseña._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document protegido con contraseña
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // trabajando...
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/remove_signs/_index.md
+++ b/spanish/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Eliminar firmas del PDF-document."
+type: docs
+url: /es/rust-cpp/security/remove_signs/
+---
+
+_Eliminar firmas del PDF-document._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Abrir un PDF-document llamado "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Eliminar firmas del PDF-document
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/set_permissions/_index.md
+++ b/spanish/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Establecer permisos para el PDF-document."
+type: docs
+url: /es/rust-cpp/security/set_permissions/
+---
+
+_Establecer permisos para PDF-document._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Crear un nuevo PDF-documento
+    let pdf = Document::new()?;
+
+    // Establecer permisos para el PDF-document.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Guardar el PDF-document con los permisos actualizados
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/sign_pkcs7/_index.md
+++ b/spanish/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Firmar un PDF-document usando firmas digitales PKCS#7."
+type: docs
+url: /es/rust-cpp/security/sign_pkcs7/
+---
+
+_Firmar un PDF-document usando firmas digitales PKCS#7._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Leer certificados y archivos de imagen en vectores de bytes
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Firmar un PDF-document usando firmas digitales PKCS#7
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/spanish/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/spanish/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF para Rust vía C++"
+description: "Firmar un PDF-document usando firmas digitales PKCS#7 desacopladas."
+type: docs
+url: /es/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Firmar un PDF-document usando firmas digitales PKCS#7 Detached._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Leer certificados y archivos de imagen en vectores de bytes
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Abrir un documento PDF con nombre de archivo
+    let pdf = Document::open("sample.pdf")?;
+
+    // Firmar un PDF-document usando firmas digitales PKCS#7 Detached
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Automated translation of the RUST-CPP API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 122/122
- Errors: 0
- Source: `english/rust-cpp`
- Output: `spanish/rust-cpp`

🤖 Generated by RDA