### PR TITLE
[auto] Translate RUST-CPP API Reference to Swedish

### DIFF
--- a/swedish/rust-cpp/_index.md
+++ b/swedish/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Aspose.PDF för Rust via C++"
+description: "Aspose.PDF för Rust via C++"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /sv/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Strukturer
+
+## Document
+Dokumentet representerar ett PDF-dokument.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett DocX-dokument. |
+| [save_doc](./convert/save_doc/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Doc-dokument. |
+| [save_xlsx](./convert/save_xlsx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett XlsX-dokument. |
+| [save_txt](./convert/save_txt/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Txt-dokument. |
+| [save_pptx](./convert/save_pptx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett PptX-dokument. |
+| [save_xps](./convert/save_xps/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Xps-dokument. |
+| [save_tex](./convert/save_tex/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett TeX-dokument. |
+| [save_epub](./convert/save_epub/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Epub-dokument. |
+| [save_booklet](./convert/save_booklet/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett häfte PDF-dokument. |
+| [save_n_up](./convert/save_n_up/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett N-Up PDF-dokument. |
+| [save_markdown](./convert/save_markdown/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Markdown-dokument. |
+| [save_tiff](./convert/save_tiff/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Tiff-dokument. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett DocX-dokument med förbättrat igenkänningsläge (fullt redigerbara tabeller och stycken). |
+| [save_svg_zip](./convert/save_svg_zip/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett SVG-arkiv. |
+| [export_fdf](./convert/export_fdf/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett FDF-dokument. |
+| [export_xfdf](./convert/export_xfdf/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett XFDF-dokument. |
+| [export_xml](./convert/export_xml/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett XML-dokument. |
+| [page_to_jpg](./convert/page_to_jpg/) | Konvertera och spara den angivna sidan som en Jpg-bild. |
+| [page_to_png](./convert/page_to_png/) | Konvertera och spara den angivna sidan som en Png-bild. |
+| [page_to_bmp](./convert/page_to_bmp/) | Konvertera och spara den angivna sidan som en Bmp-bild. |
+| [page_to_tiff](./convert/page_to_tiff/) | Konvertera och spara den angivna sidan som Tiff-bild. |
+| [page_to_svg](./convert/page_to_svg/) | Konvertera och spara den angivna sidan som Svg-bild. |
+| [page_to_pdf](./convert/page_to_pdf/) | Konvertera och spara den angivna sidan som PDF-dokument. |
+| [page_to_dicom](./convert/page_to_dicom/) | Konvertera och spara den angivna sidan som DICOM-bild. |
+
+
+## Organize PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | Optimera PDF-dokumentets innehåll. |
+| [optimize_resource](./organize/optimize_resource/) | Optimera resurserna i PDF-dokumentet. |
+| [grayscale](./organize/grayscale/) | Konvertera PDF-dokument till svartvitt. |
+| [rotate](./organize/rotate/) | Rotera PDF-dokument. |
+| [set_background](./organize/set_background/) | Ställ in PDF-dokumentets bakgrundsfärg med RGB-värden. |
+| [repair](./organize/repair/) | Reparera PDF-dokument. |
+| [replace_text](./organize/replace_text/) | Ersätt text i PDF-dokument |
+| [add_page_num](./organize/add_page_num/) | Lägg till sidnummer i ett PDF-dokument |
+| [add_text_header](./organize/add_text_header/) | Lägg till text i rubriken på ett PDF-dokument |
+| [add_text_footer](./organize/add_text_footer/) | Lägg till text i sidfoten på ett PDF-dokument |
+| [flatten](./organize/flatten/) | Platta till PDF-dokument |
+| [remove_annotations](./organize/remove_annotations/) | Ta bort annotationer från PDF-dokument |
+| [remove_attachments](./organize/remove_attachments/) | Ta bort bilagor från PDF-dokument |
+| [remove_blank_pages](./organize/remove_blank_pages/) | Ta bort tomma sidor från PDF-dokument |
+| [remove_bookmarks](./organize/remove_bookmarks/) | Ta bort bokmärken från PDF-dokument |
+| [remove_hidden_text](./organize/remove_hidden_text/) | Ta bort dold text från PDF-dokument |
+| [remove_images](./organize/remove_images/) | Ta bort bilder från PDF-dokument |
+| [remove_javascripts](./organize/remove_javascripts/) | Ta bort JavaScript från PDF-dokument |
+| [remove_tables](./organize/remove_tables/) | Ta bort tabeller från ett PDF-dokument. |
+| [remove_watermarks](./organize/remove_watermarks/) | Ta bort vattenstämplar från PDF-dokument. |
+| [add_watermark](./organize/add_watermark/) | Lägg till vattenstämpel i PDF-dokument. |
+| [embed_fonts](./organize/embed_fonts/) | Bädda in typsnitt i ett PDF-dokument. |
+| [unembed_fonts](./organize/unembed_fonts/) | Ta bort inbäddade typsnitt i ett PDF-dokument. |
+| [optimize_file_size](./organize/optimize_file_size/) | Optimera storleken på PDF-dokumentet med bildkomprimeringskvalitet. |
+| [remove_text_headers](./organize/remove_text_headers/) | Ta bort textrubriker från PDF-dokumentet. |
+| [remove_text_footers](./organize/remove_text_footers/) | Ta bort textsidfötter från PDF-dokumentet. |
+| [crop](./organize/crop/) | Beskär sidor i ett PDF-dokument. |
+| [replace_font](./organize/replace_font/) | Byt ut typsnitt i ett PDF-dokument. |
+| [convert](./organize/convert/) | Konvertera ett PDF-dokument till ett PDF-dokument med det angivna PDF-formatet |
+| [validate](./organize/validate/) | Validera ett PDF-dokument för efterlevnad av PDF-formatet |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Ta bort PDF/A-efterlevnad från ett PDF-dokument |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Ta bort PDF/UA-efterlevnad från ett PDF-dokument |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | Kontrollera om ett PDF-dokument är PDF/A-kompatibelt |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | Kontrollera om ett PDF-dokument är PDF/UA-kompatibelt |
+| [page_rotate](./organize/page_rotate/) | Rotera en sida i PDF-dokumentet. |
+| [page_set_size](./organize/page_set_size/) | Ställ in storleken på en sida i PDF-dokumentet. |
+| [page_grayscale](./organize/page_grayscale/) | Konvertera sidan till svartvitt. |
+| [page_add_text](./organize/page_add_text/) | Lägg till text på sidan. |
+| [page_replace_text](./organize/page_replace_text/) | Byt ut text på sidan |
+| [page_add_page_num](./organize/page_add_page_num/) | Lägg till sidnummer på sidan |
+| [page_add_text_header](./organize/page_add_text_header/) | Lägg till text i sidhuvud |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Lägg till text i sidfot |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Ta bort annotationer på sidan. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Ta bort dold text på sidan. |
+| [page_remove_images](./organize/page_remove_images/) | Ta bort bilder på sidan. |
+| [page_remove_tables](./organize/page_remove_tables/) | Ta bort tabeller på sidan. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Ta bort vattenstämplar på sidan. |
+| [page_add_watermark](./organize/page_add_watermark/) | Lägg till vattenstämpel på sidan. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Ta bort textrubriker på sidan. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Ta bort textfotnoter på sidan. |
+| [page_crop](./organize/page_crop/) | Beskär en sida. |
+| [page_replace_font](./organize/page_replace_font/) | Byt teckensnitt på sidan. |
+| [page_merge_layers](./organize/page_merge_layers/) | Slå samman alla lager på sidan till ett enda lager med det angivna nya lagernamnet. |
+| [page_layers](./organize/page_layers/) | Hämta lagernamnen på sidan. |
+
+
+## Core PDF functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [new](./core/new/) | Skapa ett nytt PDF-dokument. |
+| [open](./core/open/) | Öppna ett PDF-dokument med filnamn. |
+| [save](./core/save/) | Spara det tidigare öppnade PDF-dokumentet. |
+| [save_as](./core/save_as/) | Spara det tidigare öppnade PDF-dokumentet med nytt filnamn. |
+| [set_license](./core/set_license/) | Ange licens med filnamn. |
+| [extract_text](./core/extract_text/) | Returnera PDF-dokumentets innehåll som vanlig text. |
+| [word_count](./core/word_count/) | Returnera antalet ord i PDF-dokumentet. |
+| [character_count](./core/character_count/) | Returnera antalet tecken i PDF-dokumentet. |
+| [append](./core/append/) | Lägg till sidor från ett annat PDF-dokument. |
+| [append_pages](./core/append_pages/) | Lägg till valda sidor från ett annat PDF-dokument. |
+| [merge_documents](./core/merge_documents/) | Skapa ett nytt PDF-dokument genom att slå samman de angivna PDF-dokumenten. |
+| [split_document](./core/split_document/) | Skapa flera nya PDF-dokument genom att extrahera sidor från käll-PDF-dokumentet. |
+| [split](./core/split/) | Skapa flera nya PDF-dokument genom att extrahera sidor från det aktuella PDF-dokumentet. |
+| [split_at_page](./core/split_at_page/) | Dela PDF-dokumentet i två nya PDF-dokument. |
+| [split_at](./core/split_at/) | Dela det aktuella PDF-dokumentet i två nya PDF-dokument. |
+| [bytes](./core/bytes/) | Returnera innehållet i PDF-dokumentet som en bytevektor. |
+| [get_meta_info](./core/get_meta_info/) | Hämta metainformationsvärdet för PDF-dokumentet. |
+| [set_meta_info](./core/set_meta_info/) | Ange metainformationsvärde för PDF-dokument. |
+| [clear_meta_info](./core/clear_meta_info/) | Rensa alla metainformationsvärden för PDF-dokument. |
+| [is_linearized](./core/is_linearized/) | Hämta ett värde som indikerar om dokumentet är lineariserat. |
+| [page_add](./core/page_add/) | Lägg till en ny sida i PDF-dokument. |
+| [page_insert](./core/page_insert/) | Infoga en ny sida på den angivna positionen i PDF-dokument. |
+| [page_delete](./core/page_delete/) | Ta bort angiven sida i PDF-dokument. |
+| [page_count](./core/page_count/) | Returnera antalet sidor i PDF-dokument. |
+| [page_word_count](./core/page_word_count/) | Returnera ordantal på angiven sida i PDF-dokument. |
+| [page_character_count](./core/page_character_count/) | Returnera teckenantal på angiven sida i PDF-dokument. |
+| [page_is_blank](./core/page_is_blank/) | Returnera om sidan är tom i PDF-dokument. |
+
+
+## Security
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Öppna ett lösenordsskyddat PDF-dokument. |
+| [encrypt](./security/encrypt/) | Kryptera PDF-dokument. |
+| [decrypt](./security/decrypt/) | Dekryptera PDF-dokument. |
+| [set_permissions](./security/set_permissions/) | Ange behörigheter för PDF-dokument. |
+| [get_permissions](./security/get_permissions/) | Hämta aktuella behörigheter för PDF-dokument. |
+| [is_encrypted](./security/is_encrypted/) | Hämta krypteringsstatus för PDF-dokument. |
+| [sign_pkcs7](./security/sign_pkcs7/) | Signera ett PDF-dokument med PKCS#7 digitala signaturer. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | Signera ett PDF-dokument med PKCS#7 fristående digitala signaturer. |
+| [is_signed](./security/is_signed/) | Hämta signeringsstatus för PDF-dokument. |
+| [remove_signs](./security/remove_signs/) | Ta bort signaturer från PDF-dokument. |
+
+
+## Miscellaneous
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Returnera metadatainformation om Aspose.PDF för Rust via C++. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// Bitflag-uppsättning som representerar PDF-behörighetsfunktioner.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// A0-storlek.
+    A0 = 0,
+    /// A1-storlek.
+    A1 = 1,
+    /// A2-storlek.
+    A2 = 2,
+    /// A3 storlek.
+    A3 = 3,
+    /// A4 storlek.
+    A4 = 4,
+    /// A5 storlek.
+    A5 = 5,
+    /// A6 storlek.
+    A6 = 6,
+    /// B5 storlek.
+    B5 = 7,
+    /// PageLetter storlek.
+    PageLetter = 8,
+    /// PageLegal storlek.
+    PageLegal = 9,
+    /// PageLedger storlek.
+    PageLedger = 10,
+    /// P11x17 storlek.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Ej roterad.
+    None = 0,
+    /// Roterad 90 grader medurs.
+    On90 = 1,
+    /// Roterad 180 grader.
+    On180 = 2,
+    /// Roterad 270 grader medurs.
+    On270 = 3,
+    /// Roterad 360 grader medurs.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4 med nyckellängd 40.
+    RC4x40 = 0,
+    /// RC4 med nyckellängd 128.
+    RC4x128 = 1,
+    /// AES med nyckellängd 128.
+    AESx128 = 2,
+    /// AES med nyckellängd 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// PDF/A-1a format.
+    PDF_A_1A = 0,
+    /// PDF/A-1b format.
+    PDF_A_1B = 1,
+    /// PDF/A-2a format.
+    PDF_A_2A = 2,
+    /// PDF/A-3a format.
+    PDF_A_3A = 3,
+    /// PDF/A-2b format.
+    PDF_A_2B = 4,
+    /// PDF/A-2u format.
+    PDF_A_2U = 5,
+    /// PDF/A-3b format.
+    PDF_A_3B = 6,
+    /// PDF/A-3u-format.
+    PDF_A_3U = 7,
+    /// Adobe version 1.0.
+    V_1_0 = 8,
+    /// Adobe version 1.1.
+    V_1_1 = 9,
+    /// Adobe version 1.2.
+    V_1_2 = 10,
+    /// Adobe version 1.3.
+    V_1_3 = 11,
+    /// Adobe version 1.4.
+    V_1_4 = 12,
+    /// Adobe version 1.5.
+    V_1_5 = 13,
+    /// Adobe version 1.6.
+    V_1_6 = 14,
+    /// Adobe version 1.7.
+    V_1_7 = 15,
+    /// ISO-standard PDF 2.0.
+    V_2_0 = 16,
+    /// PDF/UA-1-format.
+    PDF_UA_1 = 17,
+    /// PDF/X-1a:2001-format.
+    PDF_X_1A_2001 = 18,
+    /// PDF/X-1a-format.
+    PDF_X_1A = 19,
+    /// PDF/X-3-format.
+    PDF_X_3 = 20,
+    /// ZUGFeRD-format.
+    ZUGFeRD = 21,
+    /// PDF/A-4-format.
+    PDF_A_4 = 22,
+    /// PDF/A-4e-format.
+    PDF_A_4E = 23,
+    /// PDF/A-4f-format.
+    PDF_A_4F = 24,
+    /// PDF/X-4-format.
+    PDF_X_4 = 25,
+    /// PDF/E-1 (PDF 1.6)-format.
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Ta bort icke‑konformerande element.
+    Delete = 0,
+    /// Gör ingenting, behåll icke‑konformerande element.
+    None = 1,
+}
+```
+

--- a/swedish/rust-cpp/convert/_index.md
+++ b/swedish/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Konvertera från PDF-funktioner"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Funktioner för konvertering från PDF-filer."
+type: docs
+url: /sv/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett DocX-dokument. |
+| [save_doc](./save_doc/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Doc-dokument. |
+| [save_xlsx](./save_xlsx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett XlsX-dokument. |
+| [save_txt](./save_txt/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Txt-dokument. |
+| [save_pptx](./save_pptx/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett PptX-dokument. |
+| [save_xps](./save_xps/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Xps-dokument. |
+| [save_tex](./save_tex/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett TeX-dokument. |
+| [save_epub](./save_epub/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Epub-dokument. |
+| [save_booklet](./save_booklet/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett häfte PDF-dokument. |
+| [save_n_up](./save_n_up/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett N-Up PDF-dokument. |
+| [save_markdown](./save_markdown/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Markdown-dokument. |
+| [save_tiff](./save_tiff/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett Tiff-dokument. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett DocX-dokument med förbättrat igenkänningsläge (fullt redigerbara tabeller och stycken). |
+| [save_svg_zip](./save_svg_zip/) | Konvertera och spara det tidigare öppnade PDF-dokumentet som ett SVG-arkiv. |
+| [export_fdf](./export_fdf/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett FDF-dokument. |
+| [export_xfdf](./export_xfdf/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett XFDF-dokument. |
+| [export_xml](./export_xml/) | Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till ett XML-dokument. |
+| [page_to_jpg](./page_to_jpg/) | Konvertera och spara den angivna sidan som en Jpg-bild. |
+| [page_to_png](./page_to_png/) | Konvertera och spara den angivna sidan som en Png-bild. |
+| [page_to_bmp](./page_to_bmp/) | Konvertera och spara den angivna sidan som en Bmp-bild. |
+| [page_to_tiff](./page_to_tiff/) | Konvertera och spara den angivna sidan som Tiff-bild. |
+| [page_to_svg](./page_to_svg/) | Konvertera och spara den angivna sidan som Svg-bild. |
+| [page_to_pdf](./page_to_pdf/) | Konvertera och spara den angivna sidan som PDF-dokument. |
+| [page_to_dicom](./page_to_dicom/) | Konvertera och spara den angivna sidan som DICOM-bild. |
+
+
+## Detailed Description
+
+Funktioner för konvertering från PDF-filer.
+

--- a/swedish/rust-cpp/convert/export_fdf/_index.md
+++ b/swedish/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Exporterar från tidigare öppnat PDF-dokument med AcroForm till FDF-dokument med filnamn."
+type: docs
+url: /sv/rust-cpp/convert/export_fdf/
+---
+
+_Exporterar från tidigare öppnat PDF-dokument med AcroForm till FDF-dokument med filnamn._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till FDF-dokument
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/export_xfdf/_index.md
+++ b/swedish/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Exporterar från tidigare öppnad PDF-dokument med AcroForm till XFDF-dokument med filnamn."
+type: docs
+url: /sv/rust-cpp/convert/export_xfdf/
+---
+
+_Exporterar från tidigare öppnad PDF-dokument med AcroForm till XFDF-dokument med filnamn._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till XFDF-dokument
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/export_xml/_index.md
+++ b/swedish/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Exporterar från tidigare öppnad PDF-dokument med AcroForm till XML-dokument med filnamn."
+type: docs
+url: /sv/rust-cpp/convert/export_xml/
+---
+
+_Exporterar från tidigare öppnad PDF-dokument med AcroForm till XML-dokument med filnamn._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Exportera från det tidigare öppnade PDF-dokumentet med AcroForm till XML-dokument
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_bmp/_index.md
+++ b/swedish/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en BMP-image."
+type: docs
+url: /sv/rust-cpp/convert/page_to_bmp/
+---
+
+_Konverterar och sparar den angivna sidan som en BMP-image._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som Bmp-image
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_dicom/_index.md
+++ b/swedish/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en DICOM-bild."
+type: docs
+url: /sv/rust-cpp/convert/page_to_dicom/
+---
+
+_Konverterar och sparar den angivna sidan som en DICOM-bild._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som DICOM-bild
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_jpg/_index.md
+++ b/swedish/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en JPG-bild."
+type: docs
+url: /sv/rust-cpp/convert/page_to_jpg/
+---
+
+_Konverterar och sparar den angivna sidan som en JPG-bild._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som Jpg-bild
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_pdf/_index.md
+++ b/swedish/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/convert/page_to_pdf/
+---
+
+_Konverterar och sparar den angivna sidan som ett PDF-dokument._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som PDF-dokument
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_png/_index.md
+++ b/swedish/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en PNG-bild."
+type: docs
+url: /sv/rust-cpp/convert/page_to_png/
+---
+
+_Konverterar och sparar den angivna sidan som en PNG-bild._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som Png-bild
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_svg/_index.md
+++ b/swedish/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en SVG-image."
+type: docs
+url: /sv/rust-cpp/convert/page_to_svg/
+---
+
+_Konverterar och sparar den angivna sidan som en SVG-image._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som Svg-image
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/page_to_tiff/_index.md
+++ b/swedish/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar den angivna sidan som en TIFF-bild."
+type: docs
+url: /sv/rust-cpp/convert/page_to_tiff/
+---
+
+_Konverterar och sparar den angivna sidan som en TIFF-bild._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara den angivna sidan som Tiff-bild
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_booklet/_index.md
+++ b/swedish/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett häfte PDF-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_booklet/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett häfte PDF-dokument._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som häfte PDF-dokument
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/swedish/rust-cpp/convert/save_doc/_index.md
+++ b/swedish/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett DOC-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_doc/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett DOC-dokument._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som DOC-dokument
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_docx/_index.md
+++ b/swedish/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett DOCX-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_docx/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett DOCX-dokument._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som DOCX-dokument
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/swedish/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-document som ett DOCX-document med Enhanced Recognition Mode (fullt redigerbara tabeller och stycken)."
+type: docs
+url: /sv/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-document som ett DOCX-document med Enhanced Recognition Mode (fullt redigerbara tabeller och stycken)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-document som DocX-document med Enhanced Recognition Mode (fullt redigerbara tabeller och stycken)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_epub/_index.md
+++ b/swedish/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett EPUB-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_epub/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett EPUB-dokument._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som EPUB-dokument
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_markdown/_index.md
+++ b/swedish/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett Markdown-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_markdown/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett Markdown-dokument._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som Markdown-dokument
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/swedish/rust-cpp/convert/save_n_up/_index.md
+++ b/swedish/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-document som ett N-Up PDF-document."
+type: docs
+url: /sv/rust-cpp/convert/save_n_up/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-document som ett N-Up PDF-document._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-document som N-Up PDF-document
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/swedish/rust-cpp/convert/save_pptx/_index.md
+++ b/swedish/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett PPTX-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_pptx/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett PPTX-dokument._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som PPTX-dokument
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_svg_zip/_index.md
+++ b/swedish/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett SVG-arkiv."
+type: docs
+url: /sv/rust-cpp/convert/save_svg_zip/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett SVG-arkiv._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som SVG-arkiv
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_tex/_index.md
+++ b/swedish/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-document som ett TeX-document."
+type: docs
+url: /sv/rust-cpp/convert/save_tex/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-document som ett TeX-document._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-document som TeX-document
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_tiff/_index.md
+++ b/swedish/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett Tiff-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_tiff/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett Tiff-dokument._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som Tiff-dokument
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/swedish/rust-cpp/convert/save_txt/_index.md
+++ b/swedish/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett TXT-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_txt/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett TXT-dokument._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som Txt-dokument
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_xlsx/_index.md
+++ b/swedish/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett XLSX-dokument."
+type: docs
+url: /sv/rust-cpp/convert/save_xlsx/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-dokumentet som ett XLSX-dokument._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-dokumentet som XlsX-dokument
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/convert/save_xps/_index.md
+++ b/swedish/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar och sparar det tidigare öppnade PDF-document som ett XPS-document."
+type: docs
+url: /sv/rust-cpp/convert/save_xps/
+---
+
+_Konverterar och sparar det tidigare öppnade PDF-document som ett XPS-document._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera och spara det tidigare öppnade PDF-document som Xps-document
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/_index.md
+++ b/swedish/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Kärn PDF-funktioner"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Kärnfunktioner för att arbeta med PDF-filer."
+type: docs
+url: /sv/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [new](./new/) | Skapa ett nytt PDF-dokument. |
+| [open](./open/) | Öppna ett PDF-dokument med filnamn. |
+| [save](./save/) | Spara det tidigare öppnade PDF-dokumentet. |
+| [save_as](./save_as/) | Spara det tidigare öppnade PDF-dokumentet med nytt filnamn. |
+| [set_license](./set_license/) | Ange licens med filnamn. |
+| [extract_text](./extract_text/) | Returnera PDF-dokumentets innehåll som vanlig text. |
+| [word_count](./word_count/) | Returnera antalet ord i PDF-dokumentet. |
+| [character_count](./character_count/) | Returnera antalet tecken i PDF-dokumentet. |
+| [append](./append/) | Lägg till sidor från ett annat PDF-dokument. |
+| [append_pages](./append_pages/) | Lägg till valda sidor från ett annat PDF-dokument. |
+| [merge_documents](./merge_documents/) | Skapa ett nytt PDF-dokument genom att slå samman de angivna PDF-dokumenten. |
+| [split_document](./split_document/) | Skapa flera nya PDF-dokument genom att extrahera sidor från käll-PDF-dokumentet. |
+| [split](./split/) | Skapa flera nya PDF-dokument genom att extrahera sidor från det aktuella PDF-dokumentet. |
+| [split_at_page](./split_at_page/) | Dela PDF-dokumentet i två nya PDF-dokument. |
+| [split_at](./split_at/) | Dela det aktuella PDF-dokumentet i två nya PDF-dokument. |
+| [bytes](./bytes/) | Returnera innehållet i PDF-dokumentet som en bytevektor. |
+| [get_meta_info](./get_meta_info/) | Hämta metainformationsvärdet för PDF-dokumentet. |
+| [set_meta_info](./set_meta_info/) | Ange metainformationsvärde för PDF-dokument. |
+| [clear_meta_info](./clear_meta_info/) | Rensa alla metainformationsvärden för PDF-dokument. |
+| [is_linearized](./is_linearized/) | Hämta ett värde som indikerar om dokumentet är lineariserat. |
+| [page_add](./page_add/) | Lägg till en ny sida i PDF-dokument. |
+| [page_insert](./page_insert/) | Infoga en ny sida på den angivna positionen i PDF-dokument. |
+| [page_delete](./page_delete/) | Ta bort angiven sida i PDF-dokument. |
+| [page_count](./page_count/) | Returnera antalet sidor i PDF-dokument. |
+| [page_word_count](./page_word_count/) | Returnera ordantal på angiven sida i PDF-dokument. |
+| [page_character_count](./page_character_count/) | Returnera teckenantal på angiven sida i PDF-dokument. |
+| [page_is_blank](./page_is_blank/) | Returnera om sidan är tom i PDF-dokument. |
+
+
+## Detailed Description
+
+Kärnfunktioner för att arbeta med PDF-filer.
+

--- a/swedish/rust-cpp/core/append/_index.md
+++ b/swedish/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till sidor från ett annat PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/append/
+---
+
+_Lägger till sidor från ett annat PDF-dokument._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna det primära PDF-dokumentet
+    let pdf = Document::open("sample.pdf")?;
+
+    // Öppna ett annat PDF-document för att lägga till
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Lägg till sidor från ett annat PDF-document
+    pdf.append(&another_pdf)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/append_pages/_index.md
+++ b/swedish/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till valda sidor från ett annat PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/append_pages/
+---
+
+_Lägger till valda sidor från ett annat PDF-dokument._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna det primära PDF-dokumentet
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Öppna ett annat PDF-document för att lägga till
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Lägg till specifika sidor (1 och 3) från ett annat PDF-dokument
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/bytes/_index.md
+++ b/swedish/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "bytes"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar innehållet i PDF-dokumentet som en bytevektor."
+type: docs
+url: /sv/rust-cpp/core/bytes/
+---
+
+_Returnerar innehållet i PDF-dokumentet som en bytevektor._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Returnera innehållet i PDF-dokumentet som en bytevektor
+    let data = pdf.bytes()?;
+
+    // Skriv ut längden på bytevektorn
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/character_count/_index.md
+++ b/swedish/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar teckenantal i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/character_count/
+---
+
+_Returnerar teckenantal i PDF-dokumentet._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Returnera teckenantal i PDF-dokumentet
+    let count = pdf.character_count()?;
+
+    // Skriv ut teckenantalet
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/clear_meta_info/_index.md
+++ b/swedish/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Rensar alla metainformationsvärden för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/clear_meta_info/
+---
+
+_Rensar alla metainformationsvärden för PDF-dokument._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rensa alla metainformationsvärden för PDF-dokument
+    pdf.clear_meta_info()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/extract_text/_index.md
+++ b/swedish/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar PDF-documentets innehåll som vanlig text."
+type: docs
+url: /sv/rust-cpp/core/extract_text/
+---
+
+_Returnerar PDF-documentets innehåll som vanlig text._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Returnera PDF-documentets innehåll som vanlig text
+    let txt = pdf.extract_text()?;
+
+    // Skriv ut extraherad text
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/get_meta_info/_index.md
+++ b/swedish/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämtar metainformationsvärde för PDF-document."
+type: docs
+url: /sv/rust-cpp/core/get_meta_info/
+---
+
+_Hämtar metainformationsvärde för PDF-document._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Hämta metainformationsvärde för PDF-document
+    let author = pdf.get_meta_info("Author")?;
+
+    // Skriv ut resultatet
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/is_linearized/_index.md
+++ b/swedish/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämtar ett värde som indikerar om dokumentet är lineariserat."
+type: docs
+url: /sv/rust-cpp/core/is_linearized/
+---
+
+_Hämtar ett värde som indikerar om dokumentet är lineariserat._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Hämta ett värde som indikerar om dokumentet är lineariserat
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/merge_documents/_index.md
+++ b/swedish/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Skapar ett nytt PDF-dokument genom att slå samman de angivna PDF-dokumenten."
+type: docs
+url: /sv/rust-cpp/core/merge_documents/
+---
+
+_Skapar ett nytt PDF-dokument genom att slå samman de angivna PDF-dokumenten._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf1 = Document::new()?;
+
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Skapa ett nytt PDF-dokument genom att slå samman de angivna PDF-dokumenten
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/new/_index.md
+++ b/swedish/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "new"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Skapar ett nytt PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/new/
+---
+
+_Skapar ett nytt PDF-dokument._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/open/_index.md
+++ b/swedish/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Öppnar ett PDF-document med filnamn."
+type: docs
+url: /sv/rust-cpp/core/open/
+---
+
+_Öppnar ett PDF-document med filnamn._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_add/_index.md
+++ b/swedish/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till en ny sida i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_add/
+---
+
+_Lägger till en ny sida i PDF-dokumentet._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till ny sida i PDF-dokument
+    pdf.page_add()?;
+
+    // Spara det tidigare öppnade PDF-dokumentet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_character_count/_index.md
+++ b/swedish/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar teckenantal på angiven sida i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_character_count/
+---
+
+_Returnerar teckenantal på angiven sida i PDF-dokumentet._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ange sidnumret (1-baserat index)
+    let page_number = 1;
+
+    // Returnera teckenantal på den angivna sidan
+    let count = pdf.page_character_count(page_number)?;
+
+    // Skriv ut teckenantalet
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_count/_index.md
+++ b/swedish/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar antalet sidor i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_count/
+---
+
+_Returnerar antalet sidor i PDF-dokumentet._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Returnera sidantal i PDF-dokument
+    let count = pdf.page_count()?;
+
+    // Skriv ut sidantalet
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_delete/_index.md
+++ b/swedish/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort den angivna sidan från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_delete/
+---
+
+_Tar bort den angivna sidan från PDF-dokumentet._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort angiven sida i PDF-dokumentet
+    pdf.page_delete(1)?;
+
+    // Spara det tidigare öppnade PDF-dokumentet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_insert/_index.md
+++ b/swedish/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Infogar en ny sida på den angivna positionen i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_insert/
+---
+
+_Infogar en ny sida på den angivna positionen i PDF-dokumentet._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Infoga ny sida på den angivna positionen i PDF-dokumentet
+    pdf.page_insert(1)?;
+
+    // Spara det tidigare öppnade PDF-dokumentet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_is_blank/_index.md
+++ b/swedish/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnera om sidan är tom i PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/page_is_blank/
+---
+
+_Sidan är tom i PDF-document._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ange sidnumret (1-baserat index)
+    let page_number = 1;
+
+    // Sidan är tom i PDF-document
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Skriv ut om den angivna sidan är tom
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/page_word_count/_index.md
+++ b/swedish/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar antalet ord på den angivna sidan i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/page_word_count/
+---
+
+_Returnerar antalet ord på den angivna sidan i PDF-dokumentet._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ange sidnumret (1-baserat index)
+    let page_number = 1;
+
+    // Returnera antalet ord på den angivna sidan
+    let count = pdf.page_word_count(page_number)?;
+
+    // Skriv ut antalet ord
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/save/_index.md
+++ b/swedish/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Sparar det tidigare öppnade PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/save/
+---
+
+_Sparar det tidigare öppnade PDF-dokumentet._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf = Document::open("sample.pdf")?;
+
+    // Spara det tidigare öppnade PDF-dokumentet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/save_as/_index.md
+++ b/swedish/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Sparar det tidigare öppnade PDF-dokumentet med ett nytt filnamn."
+type: docs
+url: /sv/rust-cpp/core/save_as/
+---
+
+_Sparar det tidigare öppnade PDF-dokumentet med ett nytt filnamn._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Spara PDF-dokumentet med ett nytt filnamn
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/set_license/_index.md
+++ b/swedish/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ställer in licens med filnamn."
+type: docs
+url: /sv/rust-cpp/core/set_license/
+---
+
+_Ställer in licens med filnamn._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ställ in licens med filnamn
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Nu kan du arbeta med det licensierade PDF-dokumentet
+    // ...
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/set_meta_info/_index.md
+++ b/swedish/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ställer in metainformationsvärde för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/set_meta_info/
+---
+
+_Ställer in metainformationsvärde för PDF-dokument._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ställ in metainformationsvärde för PDF-dokument
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/split/_index.md
+++ b/swedish/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Skapar flera nya PDF-dokument genom att extrahera sidor från det aktuella PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/split/
+---
+
+_Skapar flera nya PDF-dokument genom att extrahera sidor från det aktuella PDF-dokumentet._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Skapa flera nya PDF-dokument genom att extrahera sidor från det aktuella PDF-dokumentet
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Spara varje del som ett separat PDF-dokument
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/split_at/_index.md
+++ b/swedish/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Delar det aktuella PDF-dokumentet i två nya PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/split_at/
+---
+
+_Delar det aktuella PDF-dokumentet i två nya PDF-dokument._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dela det aktuella PDF-dokumentet i två nya PDF-dokument
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Spara varje del som ett separat PDF-dokument
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/split_at_page/_index.md
+++ b/swedish/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Delar PDF-dokumentet i två nya PDF-dokument."
+type: docs
+url: /sv/rust-cpp/core/split_at_page/
+---
+
+_Delar PDF-dokumentet i två nya PDF-dokument._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Dela PDF-dokumentet i två nya PDF-dokument
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Spara varje del som ett separat PDF-dokument
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/split_document/_index.md
+++ b/swedish/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Skapar flera nya PDF-dokument genom att extrahera sidor från käll-PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/split_document/
+---
+
+_Skapar flera nya PDF-dokument genom att extrahera sidor från käll-PDF-dokumentet._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample.pdf"
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Skapar flera nya PDF-dokument genom att extrahera sidor från käll-PDF-dokumentet
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Spara varje del som ett separat PDF-dokument
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/core/word_count/_index.md
+++ b/swedish/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar antalet ord i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/core/word_count/
+---
+
+_Returnerar antalet ord i PDF-dokumentet._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Returnera antalet ord i PDF-dokumentet
+    let count = pdf.word_count()?;
+
+    // Skriv ut antalet ord
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/miscellaneous/_index.md
+++ b/swedish/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Övriga funktioner"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Övriga funktioner för att arbeta."
+type: docs
+url: /sv/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [about](./about/) | Returnera metadatainformation om Aspose.PDF för Rust via C++. |
+
+
+## Detailed Description
+
+Övriga funktioner för att arbeta.
+

--- a/swedish/rust-cpp/miscellaneous/about/_index.md
+++ b/swedish/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "om"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Returnerar metadatainformation om Aspose.PDF för Rust via C++."
+type: docs
+url: /sv/rust-cpp/miscellaneous/about/
+---
+
+_Returnerar metadatainformation om Aspose.PDF för Rust via C++._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Returnera metadatainformation om Aspose.PDF för Go via C++.
+    let info = pdf.about()?;
+
+    // Skriv ut metadatafält
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/_index.md
+++ b/swedish/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Organisera PDF-funktioner"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Funktioner för att organisera PDF-filer."
+type: docs
+url: /sv/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [optimize](./optimize/) | Optimera PDF-dokumentets innehåll. |
+| [optimize_resource](./optimize_resource/) | Optimera resurserna i PDF-dokumentet. |
+| [grayscale](./grayscale/) | Konvertera PDF-dokument till svartvitt. |
+| [rotate](./rotate/) | Rotera PDF-dokument. |
+| [set_background](./set_background/) | Ställ in PDF-dokumentets bakgrundsfärg med RGB-värden. |
+| [repair](./repair/) | Reparera PDF-dokument. |
+| [replace_text](./replace_text/) | Ersätt text i PDF-dokument |
+| [add_page_num](./add_page_num/) | Lägg till sidnummer i ett PDF-dokument |
+| [add_text_header](./add_text_header/) | Lägg till text i rubriken på ett PDF-dokument |
+| [add_text_footer](./add_text_footer/) | Lägg till text i sidfoten på ett PDF-dokument |
+| [flatten](./flatten/) | Platta till PDF-dokument |
+| [remove_annotations](./remove_annotations/) | Ta bort annotationer från PDF-dokument |
+| [remove_attachments](./remove_attachments/) | Ta bort bilagor från PDF-dokument |
+| [remove_blank_pages](./remove_blank_pages/) | Ta bort tomma sidor från PDF-dokument |
+| [remove_bookmarks](./remove_bookmarks/) | Ta bort bokmärken från PDF-dokument |
+| [remove_hidden_text](./remove_hidden_text/) | Ta bort dold text från PDF-dokument |
+| [remove_images](./remove_images/) | Ta bort bilder från PDF-dokument |
+| [remove_javascripts](./remove_javascripts/) | Ta bort JavaScript från PDF-dokument |
+| [remove_tables](./remove_tables/) | Ta bort tabeller från ett PDF-dokument. |
+| [remove_watermarks](./remove_watermarks/) | Ta bort vattenstämplar från PDF-dokument. |
+| [add_watermark](./add_watermark/) | Lägg till vattenstämpel i PDF-dokument. |
+| [embed_fonts](./embed_fonts/) | Bädda in typsnitt i ett PDF-dokument. |
+| [unembed_fonts](./unembed_fonts/) | Ta bort inbäddade typsnitt i ett PDF-dokument. |
+| [optimize_file_size](./optimize_file_size/) | Optimera storleken på PDF-dokumentet med bildkomprimeringskvalitet. |
+| [remove_text_headers](./remove_text_headers/) | Ta bort textrubriker från PDF-dokumentet. |
+| [remove_text_footers](./remove_text_footers/) | Ta bort textsidfötter från PDF-dokumentet. |
+| [crop](./crop/) | Beskär sidor i ett PDF-dokument. |
+| [replace_font](./replace_font/) | Byt ut typsnitt i ett PDF-dokument. |
+| [convert](./convert/) | Konvertera ett PDF-dokument till ett PDF-dokument med det angivna PDF-formatet |
+| [validate](./validate/) | Validera ett PDF-dokument för efterlevnad av PDF-formatet |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Ta bort PDF/A-efterlevnad från ett PDF-dokument |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Ta bort PDF/UA-efterlevnad från ett PDF-dokument |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | Kontrollera om ett PDF-dokument är PDF/A-kompatibelt |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | Kontrollera om ett PDF-dokument är PDF/UA-kompatibelt |
+| [page_rotate](./page_rotate/) | Rotera en sida i PDF-dokumentet. |
+| [page_set_size](./page_set_size/) | Ställ in storleken på en sida i PDF-dokumentet. |
+| [page_grayscale](./page_grayscale/) | Konvertera sidan till svartvitt. |
+| [page_add_text](./page_add_text/) | Lägg till text på sidan. |
+| [page_replace_text](./page_replace_text/) | Byt ut text på sidan |
+| [page_add_page_num](./page_add_page_num/) | Lägg till sidnummer på sidan |
+| [page_add_text_header](./page_add_text_header/) | Lägg till text i sidhuvud |
+| [page_add_text_footer](./page_add_text_footer/) | Lägg till text i sidfot |
+| [page_remove_annotations](./page_remove_annotations/) | Ta bort annotationer på sidan. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Ta bort dold text på sidan. |
+| [page_remove_images](./page_remove_images/) | Ta bort bilder på sidan. |
+| [page_remove_tables](./page_remove_tables/) | Ta bort tabeller på sidan. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Ta bort vattenstämplar på sidan. |
+| [page_add_watermark](./page_add_watermark/) | Lägg till vattenstämpel på sidan. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Ta bort textrubriker på sidan. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Ta bort textfotnoter på sidan. |
+| [page_crop](./page_crop/) | Beskär en sida. |
+| [page_replace_font](./page_replace_font/) | Byt teckensnitt på sidan. |
+| [page_merge_layers](./page_merge_layers/) | Slå samman alla lager på sidan till ett enda lager med det angivna nya lagernamnet. |
+| [page_layers](./page_layers/) | Hämta lagernamnen på sidan. |
+
+
+## Detailed Description
+
+Funktioner för att organisera PDF-filer.

--- a/swedish/rust-cpp/organize/add_page_num/_index.md
+++ b/swedish/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till sidnummer i ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/add_page_num/
+---
+
+_Lägger till sidnummer i ett PDF-dokument._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till sidnummer i ett PDF-dokument
+    pdf.add_page_num()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/add_text_footer/_index.md
+++ b/swedish/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till text i sidfot på ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/add_text_footer/
+---
+
+_Lägger till text i sidfot på ett PDF-dokument._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till text i sidfoten på ett PDF-dokument
+    pdf.add_text_footer("FOOTER")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/add_text_header/_index.md
+++ b/swedish/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till text i rubriken på ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/add_text_header/
+---
+
+_Lägger till text i rubriken på ett PDF-dokument._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till text i rubriken på ett PDF-dokument
+    pdf.add_text_header("HEADER")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/add_watermark/_index.md
+++ b/swedish/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till vattenstämpel i PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/add_watermark/
+---
+
+_Lägger till vattenstämpel i PDF-dokument._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till vattenstämpel i PDF-dokument
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/convert/_index.md
+++ b/swedish/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar ett PDF-dokument till ett PDF-dokument med det angivna PDF-formatet."
+type: docs
+url: /sv/rust-cpp/organize/convert/
+---
+
+_Konverterar ett PDF-dokument till ett PDF-dokument med det angivna PDF-formatet._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera ett PDF-dokument till ett PDF-dokument med det angivna PDF-formatet
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Skriv ut konverteringsresultat och fullständig logg
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/crop/_index.md
+++ b/swedish/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "beskär"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Beskär sidor i ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/crop/
+---
+
+_Beskär sidor i ett PDF-dokument._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Beskär sidor i ett PDF-dokument
+    pdf.crop(10.5)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/embed_fonts/_index.md
+++ b/swedish/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Inbäddar teckensnitt i ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/embed_fonts/
+---
+
+_Inbäddar teckensnitt i ett PDF-dokument._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Inbädda teckensnitt i ett PDF-dokument
+    pdf.embed_fonts()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/flatten/_index.md
+++ b/swedish/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Plattar till PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/flatten/
+---
+
+_Plattar till PDF-dokumentet._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Returnera PDF-documentets innehåll som vanlig text
+    let txt = pdf.extract_text()?;
+
+    // Skriv ut extraherad text
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/grayscale/_index.md
+++ b/swedish/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar PDF-dokumentet till svartvitt."
+type: docs
+url: /sv/rust-cpp/organize/grayscale/
+---
+
+_Konverterar PDF-dokumentet till svartvitt._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera PDF-dokumentet till svartvitt
+    pdf.grayscale()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/swedish/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämtar om ett PDF-dokument är PDF/A-kompatibelt."
+type: docs
+url: /sv/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_Hämtar om ett PDF-dokument är PDF/A-kompatibelt._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Hämta PDF/A-kompatibilitetsstatus för PDF-dokument
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/swedish/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämtar om ett PDF-dokument är PDF/UA-kompatibelt."
+type: docs
+url: /sv/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_Hämtar om ett PDF-dokument är PDF/UA-kompatibelt._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Hämta PDF/UA-kompatibilitetsstatus för PDF-dokument
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/optimize/_index.md
+++ b/swedish/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Optimerar PDF-dokumentets innehåll."
+type: docs
+url: /sv/rust-cpp/organize/optimize/
+---
+
+_Optimerar PDF-dokumentets innehåll._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimera PDF-dokumentets innehåll
+    pdf.optimize()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/optimize_file_size/_index.md
+++ b/swedish/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Optimerar storleken på PDF-dokument med bildkomprimeringskvalitet."
+type: docs
+url: /sv/rust-cpp/organize/optimize_file_size/
+---
+
+_Optimerar storleken på PDF-dokument med bildkomprimeringskvalitet._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimera storleken på PDF-dokument med bildkomprimeringskvalitet
+    pdf.optimize_file_size(50)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/optimize_resource/_index.md
+++ b/swedish/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Optimerar resurser i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/optimize_resource/
+---
+
+_Optimerar resurser i PDF-dokumentet._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Optimera resurser i PDF-dokument
+    pdf.optimize_resource()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_add_page_num/_index.md
+++ b/swedish/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till sidnummer på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_add_page_num/
+---
+
+_Lägger till sidnummer på sidan._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till sidnummer på sidan
+    pdf.page_add_page_num(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_add_text/_index.md
+++ b/swedish/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till text på en sida."
+type: docs
+url: /sv/rust-cpp/organize/page_add_text/
+---
+
+_Lägger till text på en sida._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till text på sidan
+    pdf.page_add_text(1, "added text")?;
+
+    // Spara det tidigare öppnade PDF-dokumentet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/swedish/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till text i sidfoten."
+type: docs
+url: /sv/rust-cpp/organize/page_add_text_footer/
+---
+
+_Lägger till text i sidfoten._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till text i sidfot
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_add_text_header/_index.md
+++ b/swedish/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till text i sidhuvudet."
+type: docs
+url: /sv/rust-cpp/organize/page_add_text_header/
+---
+
+_Lägger till text i sidhuvudet._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till text i sidhuvud
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_add_watermark/_index.md
+++ b/swedish/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Lägger till vattenstämpel på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_add_watermark/
+---
+
+_Lägger till vattenstämpel på sidan._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Lägg till vattenstämpel på sidan
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_crop/_index.md
+++ b/swedish/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Beskär en sida."
+type: docs
+url: /sv/rust-cpp/organize/page_crop/
+---
+
+_Beskär en sida._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Beskär en sida
+    pdf.page_crop(1, 1.0)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_grayscale/_index.md
+++ b/swedish/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Konverterar en sida till svartvitt."
+type: docs
+url: /sv/rust-cpp/organize/page_grayscale/
+---
+
+_Konverterar en sida till svartvitt._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Konvertera sida till svartvitt
+    pdf.page_grayscale(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_layers/_index.md
+++ b/swedish/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämtar lagrens namn på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_layers/
+---
+
+_Hämtar lagrens namn på sidan._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Hämta namnen på lagren på sida 1
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_merge_layers/_index.md
+++ b/swedish/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Slår samman alla lager på sidan till ett enda lager med det angivna nya lagernamnet."
+type: docs
+url: /sv/rust-cpp/organize/page_merge_layers/
+---
+
+_Slår samman alla lager på sidan till ett enda lager med det angivna nya lagernamnet._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Slå samman alla lager på sidan till ett enda lager med det angivna nya lagernamnet
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort annotationer på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_annotations/
+---
+
+_Tar bort annotationer på sidan._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort annotationer på sidan
+    pdf.page_remove_annotations(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort dold text på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Tar bort dold text på sidan._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort dold text på sidan
+    pdf.page_remove_hidden_text(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_images/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort bilder på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_images/
+---
+
+_Tar bort bilder på sidan._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort bilder på sidan
+    pdf.page_remove_images(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_tables/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort tabeller på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_tables/
+---
+
+_Tar bort tabeller på sidan._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort tabeller på sidan
+    pdf.page_remove_tables(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort textfötter på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Tar bort textfötter på sidan._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort textfötter på sidan
+    pdf.page_remove_text_footers(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort textrubriker på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Tar bort textrubriker på sidan._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort textrubriker på sidan
+    pdf.page_remove_text_headers(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/swedish/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort vattenstämplar på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Tar bort vattenstämplar på sidan._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort vattenstämplar på sidan
+    pdf.page_remove_watermarks(1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_replace_font/_index.md
+++ b/swedish/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Byter teckensnitt på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_replace_font/
+---
+
+_Byter teckensnitt på sidan._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Byt teckensnitt på sidan
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_replace_text/_index.md
+++ b/swedish/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ersätter text på sidan."
+type: docs
+url: /sv/rust-cpp/organize/page_replace_text/
+---
+
+_Ersätter text på sidan._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Byt ut text på sidan
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_rotate/_index.md
+++ b/swedish/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Roterar en sida i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/page_rotate/
+---
+
+_Roterar en sida i PDF-dokumentet._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument från fil
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rotera sida
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/page_set_size/_index.md
+++ b/swedish/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ställer in storleken på en sida i PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/page_set_size/
+---
+
+_Ställer in storleken på en sida i PDF-dokumentet._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ställ in storleken på en sida i PDF-dokumentet
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_annotations/_index.md
+++ b/swedish/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort kommentarer från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_annotations/
+---
+
+_Tar bort kommentarer från PDF-dokumentet._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort annotationer från PDF-dokument
+    pdf.remove_annotations()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_attachments/_index.md
+++ b/swedish/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort bilagor från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_attachments/
+---
+
+_Tar bort bilagor från PDF-dokumentet._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort bilagor från PDF-dokument
+    pdf.remove_attachments()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/swedish/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort tomma sidor från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_blank_pages/
+---
+
+_Tar bort tomma sidor från PDF-dokumentet._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort tomma sidor från PDF-dokument
+    pdf.remove_blank_pages()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/swedish/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort bokmärken från PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/remove_bookmarks/
+---
+
+_Tar bort bokmärken från PDF-dokument._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort bokmärken från PDF-dokument
+    pdf.remove_bookmarks()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/swedish/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort dold text från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_hidden_text/
+---
+
+_Tar bort dold text från PDF-dokumentet._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort dold text från PDF-dokument
+    pdf.remove_hidden_text()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_images/_index.md
+++ b/swedish/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort bilder från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_images/
+---
+
+_Tar bort bilder från PDF-dokumentet._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort bilder från PDF-dokument
+    pdf.remove_images()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_javascripts/_index.md
+++ b/swedish/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort Java-skript från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_javascripts/
+---
+
+_Tar bort Java-skript från PDF-dokumentet._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort JavaScript från PDF-dokument
+    pdf.remove_javascripts()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/swedish/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ta bort PDF/A-efterlevnad från ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_Ta bort PDF/A-efterlevnad från ett PDF-dokument._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort PDF/A-efterlevnad från ett PDF-dokument
+    pdf.remove_pdfa_compliance()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/swedish/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ta bort PDF/UA-kompatibilitet från ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_Ta bort PDF/UA-kompatibilitet från ett PDF-dokument._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort PDF/UA-efterlevnad från ett PDF-dokument
+    pdf.remove_pdfua_compliance()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_tables/_index.md
+++ b/swedish/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort tabeller från PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/remove_tables/
+---
+
+_Tar bort tabeller från PDF-dokument._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort tabeller från PDF-dokument
+    pdf.remove_tables()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_text_footers/_index.md
+++ b/swedish/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort textfotnoter från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_text_footers/
+---
+
+_Tar bort textfotnoter från PDF-dokumentet._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort textfotnoter från PDF-dokumentet
+    pdf.remove_text_footers()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_text_headers/_index.md
+++ b/swedish/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort textrubriker från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_text_headers/
+---
+
+_Tar bort textrubriker från PDF-dokumentet._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort textrubriker från PDF-dokumentet
+    pdf.remove_text_headers()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/remove_watermarks/_index.md
+++ b/swedish/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Tar bort vattenstämplar från PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/remove_watermarks/
+---
+
+_Tar bort vattenstämplar från PDF-dokumentet._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ta bort vattenstämplar från PDF-dokumentet
+    pdf.remove_watermarks()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/repair/_index.md
+++ b/swedish/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Reparerar PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/repair/
+---
+
+_Reparerar PDF-dokumentet._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Reparera PDF-dokument
+    pdf.repair()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/replace_font/_index.md
+++ b/swedish/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ersätter teckensnitt i ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/replace_font/
+---
+
+_Ersätter teckensnitt i ett PDF-dokument._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Byt ut typsnitt i ett PDF-dokument.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/replace_text/_index.md
+++ b/swedish/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ersätter text."
+type: docs
+url: /sv/rust-cpp/organize/replace_text/
+---
+
+_Ersätter text._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ersätt text i PDF-dokument
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/rotate/_index.md
+++ b/swedish/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Roterar PDF-dokumentet."
+type: docs
+url: /sv/rust-cpp/organize/rotate/
+---
+
+_Roterar PDF-dokumentet._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Rotera PDF-dokument
+    pdf.rotate(Rotation::On270)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/set_background/_index.md
+++ b/swedish/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ställer in bakgrundsfärgen för PDF-dokument med RGB-värden."
+type: docs
+url: /sv/rust-cpp/organize/set_background/
+---
+
+_Ställer in bakgrundsfärgen för PDF-dokument med RGB-värden._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Ställ in bakgrundsfärgen för PDF-dokument med RGB-värden
+    pdf.set_background(200, 100, 101)?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/unembed_fonts/_index.md
+++ b/swedish/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Avbäddar typsnitt i ett PDF-dokument."
+type: docs
+url: /sv/rust-cpp/organize/unembed_fonts/
+---
+
+_Avbäddar typsnitt i ett PDF-dokument._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Avbädda typsnitt i ett PDF-dokument
+    pdf.unembed_fonts()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/organize/validate/_index.md
+++ b/swedish/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Validerar ett PDF-dokument för överensstämmelse med PDF-formatet."
+type: docs
+url: /sv/rust-cpp/organize/validate/
+---
+
+_Validerar ett PDF-dokument för överensstämmelse med PDF-formatet._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Validera ett PDF-dokument för efterlevnad av PDF-formatet
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Skriv ut valideringsresultat och fullständig logg
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/_index.md
+++ b/swedish/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Säkerhetsfunktioner"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Säkerhetsfunktioner."
+type: docs
+url: /sv/rust-cpp/security/
+---
+
+## Security
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Öppna ett lösenordsskyddat PDF-dokument. |
+| [encrypt](./encrypt/) | Kryptera PDF-dokument. |
+| [decrypt](./decrypt/) | Dekryptera PDF-dokument. |
+| [set_permissions](./set_permissions/) | Ange behörigheter för PDF-dokument. |
+| [get_permissions](./get_permissions/) | Hämta aktuella behörigheter för PDF-dokument. |
+| [is_encrypted](./is_encrypted/) | Hämta krypteringsstatus för PDF-dokument. |
+| [sign_pkcs7](./sign_pkcs7/) | Signera ett PDF-dokument med PKCS#7 digitala signaturer. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | Signera ett PDF-dokument med PKCS#7 fristående digitala signaturer. |
+| [is_signed](./is_signed/) | Hämta signeringsstatus för PDF-dokument. |
+| [remove_signs](./remove_signs/) | Ta bort signaturer från PDF-dokument. |
+
+
+## Detailed Description
+
+Säkerhetsfunktioner.
+

--- a/swedish/rust-cpp/security/decrypt/_index.md
+++ b/swedish/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "dekryptera"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Dekryptera PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/decrypt/
+---
+
+_Dekryptera PDF-dokument._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett lösenordsskyddat PDF-dokument
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Dekryptera PDF-dokument
+    pdf.decrypt()?;
+
+    // Spara det tidigare öppnade PDF-document med nytt filnamn
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/encrypt/_index.md
+++ b/swedish/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "kryptera"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Kryptera PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/encrypt/
+---
+
+_Kryptera PDF-dokument._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Kryptera PDF-dokument
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Spara det krypterade PDF-dokumentet
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/get_permissions/_index.md
+++ b/swedish/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämta aktuella behörigheter för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/get_permissions/
+---
+
+_Hämta aktuella behörigheter för PDF-dokumentet._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett lösenordsskyddat PDF-dokument
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // Hämta aktuella behörigheter för PDF-dokumentet
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // Skriv ut behörigheter
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/is_encrypted/_index.md
+++ b/swedish/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämta krypteringsstatus för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/is_encrypted/
+---
+
+_Hämta krypteringsstatus för PDF-dokumentet._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett lösenordsskyddat PDF-dokument
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // Hämta krypteringsstatus för PDF-dokumentet
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/is_signed/_index.md
+++ b/swedish/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Hämta signeringsstatus för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/is_signed/
+---
+
+_Hämta signeringsstatus för PDF-dokument._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Hämta signeringsstatus för PDF-dokument
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/open_with_password/_index.md
+++ b/swedish/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Öppna ett lösenordsskyddat PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/open_with_password/
+---
+
+_Öppna ett lösenordsskyddat PDF-dokument._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett lösenordsskyddat PDF-dokument
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // arbetar...
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/remove_signs/_index.md
+++ b/swedish/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ta bort signaturer från PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/remove_signs/
+---
+
+_Ta bort signaturer från PDF-dokumentet._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Öppna ett PDF-dokument med namnet "sample_with_sign.pdf"
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // Ta bort signaturer från PDF-dokumentet
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/set_permissions/_index.md
+++ b/swedish/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Ange behörigheter för PDF-dokument."
+type: docs
+url: /sv/rust-cpp/security/set_permissions/
+---
+
+_Ställ in behörigheter för PDF-dokument._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Skapa ett nytt PDF-dokument
+    let pdf = Document::new()?;
+
+    // Ange behörigheter för PDF-dokument.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Spara PDF-dokumentet med de uppdaterade behörigheterna
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/sign_pkcs7/_index.md
+++ b/swedish/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Signera ett PDF-dokument med PKCS#7 digitala signaturer."
+type: docs
+url: /sv/rust-cpp/security/sign_pkcs7/
+---
+
+_Signera ett PDF-dokument med PKCS#7 digitala signaturer._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Läs certifikat- och bildfiler till bytevektorer
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signera ett PDF-dokument med PKCS#7 digitala signaturer
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/swedish/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/swedish/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Aspose.PDF för Rust via C++"
+description: "Signera ett PDF-dokument med PKCS#7 fristående digitala signaturer."
+type: docs
+url: /sv/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_Signera ett PDF-dokument med PKCS#7 fristående digitala signaturer._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Läs certifikat- och bildfiler till bytevektorer
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Öppna ett PDF-dokument med filnamn
+    let pdf = Document::open("sample.pdf")?;
+
+    // Signera ett PDF-dokument med PKCS#7 fristående digitala signaturer
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Automated translation of the RUST-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 122/122
- Errors: 0
- Source: `english/rust-cpp`
- Output: `swedish/rust-cpp`

🤖 Generated by RDA