### PR TITLE
[auto] Translate RUST-CPP API Reference to Turkish

### DIFF
--- a/turkish/rust-cpp/_index.md
+++ b/turkish/rust-cpp/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Rust için C++ aracılığıyla Aspose.PDF"
+keywords:  "Rust, PDF, PDF toolkit, pdf, convert, processing"
+tags: ['pdf-to-jpg', 'pdf-to-png', 'pdf-convert', 'pdf-tools']
+weight: 40
+url: /tr/rust-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.PDF for Rust via C++ allows developers manipulate them PDF files directly in the Rust.
+
+# Yapılar
+
+## Document
+Document bir PDF belgesini temsil eder.
+
+```rust
+pub struct Document { /* private fields */ }
+```
+
+# Implementations
+
+## Convert from PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [save_docx](./convert/save_docx/) | Önceden açılmış PDF belgesini DocX belgesi olarak dönüştür ve kaydet. |
+| [save_doc](./convert/save_doc/) | Önceden açılmış PDF belgesini Doc belgesi olarak dönüştür ve kaydet. |
+| [save_xlsx](./convert/save_xlsx/) | Önceden açılmış PDF belgesini XlsX belgesi olarak dönüştür ve kaydet. |
+| [save_txt](./convert/save_txt/) | Önceden açılmış PDF belgesini Txt belgesi olarak dönüştür ve kaydet. |
+| [save_pptx](./convert/save_pptx/) | Önceden açılmış PDF belgesini PptX belgesi olarak dönüştür ve kaydet. |
+| [save_xps](./convert/save_xps/) | Önceden açılmış PDF belgesini Xps belgesi olarak dönüştür ve kaydet. |
+| [save_tex](./convert/save_tex/) | Önceden açılmış PDF belgesini TeX belgesi olarak dönüştür ve kaydet. |
+| [save_epub](./convert/save_epub/) | Önceden açılmış PDF belgesini Epub belgesi olarak dönüştür ve kaydet. |
+| [save_booklet](./convert/save_booklet/) | Önceden açılmış PDF belgesini kitapçık PDF belgesi olarak dönüştür ve kaydet. |
+| [save_n_up](./convert/save_n_up/) | Önceden açılmış PDF belgesini N-Up PDF belgesi olarak dönüştür ve kaydet. |
+| [save_markdown](./convert/save_markdown/) | Önceden açılmış PDF belgesini Markdown belgesi olarak dönüştür ve kaydet. |
+| [save_tiff](./convert/save_tiff/) | Önceden açılmış PDF belgesini Tiff belgesi olarak dönüştür ve kaydet. |
+| [save_docx_enhanced](./convert/save_docx_enhanced/) | Önceden açılmış PDF belgesini Gelişmiş Tanıma Modu ile DocX belgesi olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar). |
+| [save_svg_zip](./convert/save_svg_zip/) | Önceden açılmış PDF belgesini SVG arşivi olarak dönüştür ve kaydet. |
+| [export_fdf](./convert/export_fdf/) | AcroForm içeren önceden açılmış PDF belgesini FDF belgesine dışa aktar. |
+| [export_xfdf](./convert/export_xfdf/) | AcroForm içeren önceden açılmış PDF belgesini XFDF belgesine dışa aktar. |
+| [export_xml](./convert/export_xml/) | AcroForm içeren önceden açılmış PDF belgesini XML belgesine dışa aktar. |
+| [page_to_jpg](./convert/page_to_jpg/) | Belirtilen sayfayı Jpg görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_png](./convert/page_to_png/) | Belirtilen sayfayı Png görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_bmp](./convert/page_to_bmp/) | Belirtilen sayfayı Bmp görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_tiff](./convert/page_to_tiff/) | Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_svg](./convert/page_to_svg/) | Belirtilen sayfayı Svg-görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_pdf](./convert/page_to_pdf/) | Belirtilen sayfayı PDF-dokümanı olarak dönüştür ve kaydet. |
+| [page_to_dicom](./convert/page_to_dicom/) | Belirtilen sayfayı DICOM-görüntüsü olarak dönüştür ve kaydet. |
+
+
+## Organize PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [optimize](./organize/optimize/) | PDF-dokümanının içeriğini optimize et. |
+| [optimize_resource](./organize/optimize_resource/) | PDF-dokümanının kaynaklarını optimize et. |
+| [grayscale](./organize/grayscale/) | PDF-dokümanını siyah beyaza dönüştür. |
+| [rotate](./organize/rotate/) | PDF-dokümanını döndür. |
+| [set_background](./organize/set_background/) | RGB değerlerini kullanarak PDF-dokümanının arka plan rengini ayarla. |
+| [repair](./organize/repair/) | PDF-dokümanını onar. |
+| [replace_text](./organize/replace_text/) | PDF-dokümanındaki metni değiştir |
+| [add_page_num](./organize/add_page_num/) | PDF-dokümanına sayfa numarası ekle |
+| [add_text_header](./organize/add_text_header/) | PDF-dokümanının başlığına metin ekle |
+| [add_text_footer](./organize/add_text_footer/) | PDF-dokümanının altbilgisine metin ekle |
+| [flatten](./organize/flatten/) | PDF-dokümanını düzleştir |
+| [remove_annotations](./organize/remove_annotations/) | PDF-dokümanından ek açıklamaları kaldır |
+| [remove_attachments](./organize/remove_attachments/) | PDF-dokümanından ekleri kaldır |
+| [remove_blank_pages](./organize/remove_blank_pages/) | PDF-dokümanından boş sayfaları kaldır |
+| [remove_bookmarks](./organize/remove_bookmarks/) | PDF-dokümanından yer imlerini kaldır |
+| [remove_hidden_text](./organize/remove_hidden_text/) | PDF-dokümanından gizli metni kaldır |
+| [remove_images](./organize/remove_images/) | PDF-dokümanından görüntüleri kaldır |
+| [remove_javascripts](./organize/remove_javascripts/) | PDF-dokümanından java script'leri kaldır |
+| [remove_tables](./organize/remove_tables/) | PDF-dokümanından tabloları kaldır. |
+| [remove_watermarks](./organize/remove_watermarks/) | PDF-dokümanından filigranları kaldır. |
+| [add_watermark](./organize/add_watermark/) | PDF-dokümanına filigran ekle. |
+| [embed_fonts](./organize/embed_fonts/) | Bir PDF-document içine yazı tiplerini göm. |
+| [unembed_fonts](./organize/unembed_fonts/) | Bir PDF-document'tan yazı tiplerini çıkar. |
+| [optimize_file_size](./organize/optimize_file_size/) | PDF-document'in boyutunu görüntü sıkıştırma kalitesiyle optimize et. |
+| [remove_text_headers](./organize/remove_text_headers/) | PDF-document'ten metin başlıklarını kaldır. |
+| [remove_text_footers](./organize/remove_text_footers/) | PDF-document'ten metin altbilgilerini kaldır. |
+| [crop](./organize/crop/) | Bir PDF-document'in sayfalarını kırp. |
+| [replace_font](./organize/replace_font/) | Bir PDF-document'teki yazı tipini değiştir. |
+| [convert](./organize/convert/) | Bir PDF-document'i belirtilen PDF formatıyla bir PDF-document'e dönüştür |
+| [validate](./organize/validate/) | Bir PDF-document'in PDF formatına uyumluluğunu doğrula |
+| [remove_pdfa_compliance](./organize/remove_pdfa_compliance/) | Bir PDF-document'ten PDF/A uyumluluğunu kaldır |
+| [remove_pdfua_compliance](./organize/remove_pdfua_compliance/) | Bir PDF-document'ten PDF/UA uyumluluğunu kaldır |
+| [is_pdfa_compliant](./organize/is_pdfa_compliant/) | PDF-document'in PDF/A uyumlu olup olmadığını al |
+| [is_pdfua_compliant](./organize/is_pdfua_compliant/) | PDF-document'in PDF/UA uyumlu olup olmadığını al |
+| [page_rotate](./organize/page_rotate/) | PDF-document'teki bir sayfayı döndür. |
+| [page_set_size](./organize/page_set_size/) | PDF-document'teki bir sayfanın boyutunu ayarla. |
+| [page_grayscale](./organize/page_grayscale/) | Sayfayı siyah beyaza dönüştür. |
+| [page_add_text](./organize/page_add_text/) | Sayfaya metin ekle. |
+| [page_replace_text](./organize/page_replace_text/) | Sayfadaki metni değiştir |
+| [page_add_page_num](./organize/page_add_page_num/) | Sayfaya sayfa numarası ekle |
+| [page_add_text_header](./organize/page_add_text_header/) | Sayfa başlığına metin ekle |
+| [page_add_text_footer](./organize/page_add_text_footer/) | Sayfa altbilgisine metin ekle |
+| [page_remove_annotations](./organize/page_remove_annotations/) | Sayfadaki ek açıklamaları kaldır. |
+| [page_remove_hidden_text](./organize/page_remove_hidden_text/) | Sayfadaki gizli metni kaldır. |
+| [page_remove_images](./organize/page_remove_images/) | Sayfadaki görüntüleri kaldır. |
+| [page_remove_tables](./organize/page_remove_tables/) | Sayfadaki tabloları kaldır. |
+| [page_remove_watermarks](./organize/page_remove_watermarks/) | Sayfadaki filigranları kaldır. |
+| [page_add_watermark](./organize/page_add_watermark/) | Sayfaya filigran ekle. |
+| [page_remove_text_headers](./organize/page_remove_text_headers/) | Sayfadaki metin başlıklarını kaldır. |
+| [page_remove_text_footers](./organize/page_remove_text_footers/) | Sayfadaki metin altbilgilerini kaldır. |
+| [page_crop](./organize/page_crop/) | Bir sayfayı kırp. |
+| [page_replace_font](./organize/page_replace_font/) | Sayfadaki yazı tipini değiştir. |
+| [page_merge_layers](./organize/page_merge_layers/) | Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmanda birleştir. |
+| [page_layers](./organize/page_layers/) | Sayfadaki katman adlarını al. |
+
+
+## Core PDF functions
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [new](./core/new/) | Yeni bir PDF belgesi oluştur. |
+| [open](./core/open/) | Dosya adıyla bir PDF belgesi aç. |
+| [save](./core/save/) | Daha önce açılan PDF belgesini kaydet. |
+| [save_as](./core/save_as/) | Daha önce açılan PDF belgesini yeni dosya adıyla kaydet. |
+| [set_license](./core/set_license/) | Dosya adıyla lisansı ayarla. |
+| [extract_text](./core/extract_text/) | PDF belgesinin içeriğini düz metin olarak döndür. |
+| [word_count](./core/word_count/) | PDF belgesindeki kelime sayısını döndür. |
+| [character_count](./core/character_count/) | PDF belgesindeki karakter sayısını döndür. |
+| [append](./core/append/) | Başka bir PDF belgesinden sayfaları ekle. |
+| [append_pages](./core/append_pages/) | Başka bir PDF belgesinden seçilen sayfaları ekle. |
+| [merge_documents](./core/merge_documents/) | Sağlanan PDF belgelerini birleştirerek yeni bir PDF belgesi oluştur. |
+| [split_document](./core/split_document/) | Kaynak PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluştur. |
+| [split](./core/split/) | Mevcut PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluştur. |
+| [split_at_page](./core/split_at_page/) | PDF belgesini iki yeni PDF belgesine böl. |
+| [split_at](./core/split_at/) | Mevcut PDF belgesini iki yeni PDF belgesine böl. |
+| [bytes](./core/bytes/) | PDF belgesinin içeriğini bayt vektörü olarak döndür. |
+| [get_meta_info](./core/get_meta_info/) | PDF belgesinin meta bilgi değerini al. |
+| [set_meta_info](./core/set_meta_info/) | PDF-dökümanının meta bilgi değerini ayarla. |
+| [clear_meta_info](./core/clear_meta_info/) | PDF-dökümanının tüm meta bilgi değerlerini temizle. |
+| [is_linearized](./core/is_linearized/) | Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al. |
+| [page_add](./core/page_add/) | PDF-dökümanına yeni bir sayfa ekle. |
+| [page_insert](./core/page_insert/) | PDF-dökümanında belirtilen konuma yeni bir sayfa ekle. |
+| [page_delete](./core/page_delete/) | PDF-dökümanında belirtilen sayfayı sil. |
+| [page_count](./core/page_count/) | PDF-dökümanındaki sayfa sayısını döndür. |
+| [page_word_count](./core/page_word_count/) | PDF-dökümanındaki belirtilen sayfadaki kelime sayısını döndür. |
+| [page_character_count](./core/page_character_count/) | PDF-dökümanındaki belirtilen sayfadaki karakter sayısını döndür. |
+| [page_is_blank](./core/page_is_blank/) | PDF-dökümanındaki sayfanın boş olup olmadığını döndür. |
+
+
+## Security
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [open_with_password](./security/open_with_password/) | Şifre korumalı bir PDF-dökümanını aç. |
+| [encrypt](./security/encrypt/) | PDF-dökümanını şifrele. |
+| [decrypt](./security/decrypt/) | PDF-dökümanının şifresini çöz. |
+| [set_permissions](./security/set_permissions/) | PDF-dökümanı için izinleri ayarla. |
+| [get_permissions](./security/get_permissions/) | PDF-dökümanının mevcut izinlerini al. |
+| [is_encrypted](./security/is_encrypted/) | PDF-dökümanının şifrelenme durumunu al. |
+| [sign_pkcs7](./security/sign_pkcs7/) | PDF-dökümanını PKCS#7 dijital imzalarıyla imzala. |
+| [sign_pkcs7_detached](./security/sign_pkcs7_detached/) | PDF-dökümanını PKCS#7 Ayrık dijital imzalarıyla imzala. |
+| [is_signed](./security/is_signed/) | PDF-dökümanının imzalı durumunu al. |
+| [remove_signs](./security/remove_signs/) | PDF-dökümanından imzaları kaldır. |
+
+
+## Miscellaneous
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [about](./miscellaneous/about/) | Aspose.PDF for Rust via C++ hakkında meta veri bilgilerini döndür. |
+
+
+
+# Structs secondary
+
+## ProductInfo contains metadata about the Aspose.PDF for Rust via C++.
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+## Bitflag set representing PDF permission capabilities.
+```rust
+bitflags! {
+    /// PDF izin yeteneklerini temsil eden bitbayrak kümesi.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct Permissions: i32 {
+        const PRINT_DOCUMENT                    = 1 << 2;  // 4
+        const MODIFY_CONTENT                    = 1 << 3;  // 8
+        const EXTRACT_CONTENT                   = 1 << 4;  // 16
+        const MODIFY_TEXT_ANNOTATIONS           = 1 << 5;  // 32
+        const FILL_FORM                         = 1 << 8;  // 256
+        const EXTRACT_CONTENT_WITH_DISABILITIES = 1 << 9;  // 512
+        const ASSEMBLE_DOCUMENT                 = 1 << 10; // 1024
+        const PRINTING_QUALITY                  = 1 << 11; // 2048
+    }
+}
+```
+
+# Enums
+
+## Enumeration of possible page size values.
+```rust
+pub enum PageSize {
+    /// A0 boyutu.
+    A0 = 0,
+    /// A1 boyutu.
+    A1 = 1,
+    /// A2 boyutu.
+    A2 = 2,
+    /// A3 boyutu.
+    A3 = 3,
+    /// A4 boyutu.
+    A4 = 4,
+    /// A5 boyutu.
+    A5 = 5,
+    /// A6 boyutu.
+    A6 = 6,
+    /// B5 boyutu.
+    B5 = 7,
+    /// PageLetter boyutu.
+    PageLetter = 8,
+    /// PageLegal boyutu.
+    PageLegal = 9,
+    /// PageLedger boyutu.
+    PageLedger = 10,
+    /// P11x17 boyutu.
+    P11x17 = 11,
+}
+```
+
+## Enumeration of possible rotation values.
+```rust
+pub enum Rotation {
+    /// Döndürülmemiş.
+    None = 0,
+    /// 90 derece saat yönünde döndürülmüş.
+    On90 = 1,
+    /// 180 derece döndürülmüş.
+    On180 = 2,
+    /// 270 derece saat yönünde döndürülmüş.
+    On270 = 3,
+    /// 360 derece saat yönünde döndürülmüş.
+    On360 = 4,
+}
+```
+
+## An enumeration of possible crypto algorithms.
+```rust
+pub enum CryptoAlgorithm {
+    /// RC4, anahtar uzunluğu 40.
+    RC4x40 = 0,
+    /// RC4, anahtar uzunluğu 128.
+    RC4x128 = 1,
+    /// AES, anahtar uzunluğu 128.
+    AESx128 = 2,
+    /// AES, anahtar uzunluğu 256.
+    AESx256 = 3,
+}
+```
+
+## An enumeration of possible PDF format standards.
+```rust
+pub enum PdfFormat {
+    /// PDF/A-1a formatı.
+    PDF_A_1A = 0,
+    /// PDF/A-1b formatı.
+    PDF_A_1B = 1,
+    /// PDF/A-2a formatı.
+    PDF_A_2A = 2,
+    /// PDF/A-3a formatı.
+    PDF_A_3A = 3,
+    /// PDF/A-2b formatı.
+    PDF_A_2B = 4,
+    /// PDF/A-2u formatı.
+    PDF_A_2U = 5,
+    /// PDF/A-3b formatı.
+    PDF_A_3B = 6,
+    /// PDF/A-3u formatı.
+    PDF_A_3U = 7,
+    /// Adobe sürüm 1.0.
+    V_1_0 = 8,
+    /// Adobe sürüm 1.1.
+    V_1_1 = 9,
+    /// Adobe sürüm 1.2.
+    V_1_2 = 10,
+    /// Adobe sürüm 1.3.
+    V_1_3 = 11,
+    /// Adobe sürüm 1.4.
+    V_1_4 = 12,
+    /// Adobe sürüm 1.5.
+    V_1_5 = 13,
+    /// Adobe sürüm 1.6.
+    V_1_6 = 14,
+    /// Adobe sürüm 1.7.
+    V_1_7 = 15,
+    /// ISO Standardı PDF 2.0.
+    V_2_0 = 16,
+    /// PDF/UA-1 formatı.
+    PDF_UA_1 = 17,
+    /// PDF/X-1a:2001 formatı.
+    PDF_X_1A_2001 = 18,
+    /// PDF/X-1a formatı.
+    PDF_X_1A = 19,
+    /// PDF/X-3 formatı.
+    PDF_X_3 = 20,
+    /// ZUGFeRD formatı.
+    ZUGFeRD = 21,
+    /// PDF/A-4 formatı.
+    PDF_A_4 = 22,
+    /// PDF/A-4e formatı.
+    PDF_A_4E = 23,
+    /// PDF/A-4f formatı.
+    PDF_A_4F = 24,
+    /// PDF/X-4 formatı.
+    PDF_X_4 = 25,
+    /// PDF/E-1 (PDF 1.6) formatı.
+    PDF_E_1 = 26,
+}
+```
+
+## An enumeration of actions to take when a conversion error occurs.
+```rust
+pub enum ConvertErrorAction {
+    /// Uygun olmayan öğeleri sil.
+    Delete = 0,
+    /// Hiçbir şey yapma, uygun olmayan öğeleri tut.
+    None = 1,
+}
+```
+

--- a/turkish/rust-cpp/convert/_index.md
+++ b/turkish/rust-cpp/convert/_index.md
@@ -1,0 +1,42 @@
+---
+title: "PDF işlevlerinden dönüştür"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF dosyalarından dönüştürme işlevleri."
+type: docs
+url: /tr/rust-cpp/convert/
+---
+
+## Convert from PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [save_docx](./save_docx/) | Önceden açılmış PDF belgesini DocX belgesi olarak dönüştür ve kaydet. |
+| [save_doc](./save_doc/) | Önceden açılmış PDF belgesini Doc belgesi olarak dönüştür ve kaydet. |
+| [save_xlsx](./save_xlsx/) | Önceden açılmış PDF belgesini XlsX belgesi olarak dönüştür ve kaydet. |
+| [save_txt](./save_txt/) | Önceden açılmış PDF belgesini Txt belgesi olarak dönüştür ve kaydet. |
+| [save_pptx](./save_pptx/) | Önceden açılmış PDF belgesini PptX belgesi olarak dönüştür ve kaydet. |
+| [save_xps](./save_xps/) | Önceden açılmış PDF belgesini Xps belgesi olarak dönüştür ve kaydet. |
+| [save_tex](./save_tex/) | Önceden açılmış PDF belgesini TeX belgesi olarak dönüştür ve kaydet. |
+| [save_epub](./save_epub/) | Önceden açılmış PDF belgesini Epub belgesi olarak dönüştür ve kaydet. |
+| [save_booklet](./save_booklet/) | Önceden açılmış PDF belgesini kitapçık PDF belgesi olarak dönüştür ve kaydet. |
+| [save_n_up](./save_n_up/) | Önceden açılmış PDF belgesini N-Up PDF belgesi olarak dönüştür ve kaydet. |
+| [save_markdown](./save_markdown/) | Önceden açılmış PDF belgesini Markdown belgesi olarak dönüştür ve kaydet. |
+| [save_tiff](./save_tiff/) | Önceden açılmış PDF belgesini Tiff belgesi olarak dönüştür ve kaydet. |
+| [save_docx_enhanced](./save_docx_enhanced/) | Önceden açılmış PDF belgesini Gelişmiş Tanıma Modu ile DocX belgesi olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar). |
+| [save_svg_zip](./save_svg_zip/) | Önceden açılmış PDF belgesini SVG arşivi olarak dönüştür ve kaydet. |
+| [export_fdf](./export_fdf/) | AcroForm içeren önceden açılmış PDF belgesini FDF belgesine dışa aktar. |
+| [export_xfdf](./export_xfdf/) | AcroForm içeren önceden açılmış PDF belgesini XFDF belgesine dışa aktar. |
+| [export_xml](./export_xml/) | AcroForm içeren önceden açılmış PDF belgesini XML belgesine dışa aktar. |
+| [page_to_jpg](./page_to_jpg/) | Belirtilen sayfayı Jpg görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_png](./page_to_png/) | Belirtilen sayfayı Png görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_bmp](./page_to_bmp/) | Belirtilen sayfayı Bmp görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_tiff](./page_to_tiff/) | Belirtilen sayfayı Tiff-görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_svg](./page_to_svg/) | Belirtilen sayfayı Svg-görüntüsü olarak dönüştür ve kaydet. |
+| [page_to_pdf](./page_to_pdf/) | Belirtilen sayfayı PDF-dokümanı olarak dönüştür ve kaydet. |
+| [page_to_dicom](./page_to_dicom/) | Belirtilen sayfayı DICOM-görüntüsü olarak dönüştür ve kaydet. |
+
+
+## Detailed Description
+
+PDF dosyalarından dönüştürme işlevleri.
+

--- a/turkish/rust-cpp/convert/export_fdf/_index.md
+++ b/turkish/rust-cpp/convert/export_fdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_fdf"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "AcroForm içeren daha önce açılmış PDF-belgesinden dosya adıyla FDF-belgesine dışa aktarır."
+type: docs
+url: /tr/rust-cpp/convert/export_fdf/
+---
+
+_AcroForm içeren daha önce açılmış PDF-belgesinden dosya adıyla FDF-belgesine dışa aktarır._
+
+```rust
+pub fn export_fdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // AcroForm içeren daha önce açılmış PDF-belgesinden FDF-belgesine dışa aktar
+    pdf.export_fdf("sample.fdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/export_xfdf/_index.md
+++ b/turkish/rust-cpp/convert/export_xfdf/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xfdf"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-belgesinden AcroForm ile XFDF-belgesine dosya adıyla dışa aktarır."
+type: docs
+url: /tr/rust-cpp/convert/export_xfdf/
+---
+
+_Önceden açılmış PDF-belgesinden AcroForm ile XFDF-belgesine dosya adıyla dışa aktarır._
+
+```rust
+pub fn export_xfdf(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-belgesinden AcroForm ile XFDF-belgesine dışa aktar.
+    pdf.export_xfdf("sample.xfdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/export_xml/_index.md
+++ b/turkish/rust-cpp/convert/export_xml/_index.md
@@ -1,0 +1,37 @@
+---
+title: "export_xml"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-belgesinden AcroForm ile XML-belgesine dosya adıyla dışa aktarır."
+type: docs
+url: /tr/rust-cpp/convert/export_xml/
+---
+
+_Önceden açılmış PDF-belgesinden AcroForm ile XML-belgesine dosya adıyla dışa aktarır._
+
+```rust
+pub fn export_xml(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-belgesinden AcroForm ile XML-belgesine dışa aktar.
+    pdf.export_xml("sample.xml")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_bmp/_index.md
+++ b/turkish/rust-cpp/convert/page_to_bmp/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_bmp"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı BMP-görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_bmp/
+---
+
+_Belirtilen sayfayı BMP-görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_bmp(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı BMP-görüntüsü olarak dönüştür ve kaydet
+    pdf.page_to_bmp(1, 100, "sample_page1.bmp")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_dicom/_index.md
+++ b/turkish/rust-cpp/convert/page_to_dicom/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_dicom"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı DICOM görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_dicom/
+---
+
+_Belirtilen sayfayı DICOM görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_dicom(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı DICOM görüntüsü olarak dönüştür ve kaydet
+    pdf.page_to_dicom(1, 100, "sample_page1.dcm")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_jpg/_index.md
+++ b/turkish/rust-cpp/convert/page_to_jpg/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_jpg"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı bir JPG-görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_jpg/
+---
+
+_Belirtilen sayfayı bir JPG-görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_jpg(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı Jpg-image olarak dönüştür ve kaydet
+    pdf.page_to_jpg(1, 100, "sample_page1.jpg")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_pdf/_index.md
+++ b/turkish/rust-cpp/convert/page_to_pdf/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_pdf"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı PDF belgesi olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_pdf/
+---
+
+_Belirtilen sayfayı PDF belgesi olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_pdf(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı PDF belgesi olarak dönüştür ve kaydet
+    pdf.page_to_pdf(1, "sample_page1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_png/_index.md
+++ b/turkish/rust-cpp/convert/page_to_png/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_png"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı PNG görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_png/
+---
+
+_Belirtilen sayfayı PNG görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_png(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı Png görüntüsü olarak dönüştür ve kaydet
+    pdf.page_to_png(1, 100, "sample_page1.png")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_svg/_index.md
+++ b/turkish/rust-cpp/convert/page_to_svg/_index.md
@@ -1,0 +1,38 @@
+---
+title: "page_to_svg"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı SVG-görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_svg/
+---
+
+_Belirtilen sayfayı SVG-görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_svg(&self, num: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı SVG-görüntüsü olarak dönüştür ve kaydet
+    pdf.page_to_svg(1, "sample_page1.svg")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/page_to_tiff/_index.md
+++ b/turkish/rust-cpp/convert/page_to_tiff/_index.md
@@ -1,0 +1,39 @@
+---
+title: "page_to_tiff"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı TIFF görüntüsü olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/page_to_tiff/
+---
+
+_Belirtilen sayfayı TIFF görüntüsü olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn page_to_tiff(&self, num: i32, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belirtilen sayfayı Tiff görüntüsü olarak dönüştür ve kaydet
+    pdf.page_to_tiff(1, 100, "sample_page1.tiff")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_booklet/_index.md
+++ b/turkish/rust-cpp/convert/save_booklet/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_booklet"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açılmış PDF-dökümanını bir booklet PDF-dökümanına dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_booklet/
+---
+
+_Açılmış PDF-dökümanını bir booklet PDF-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_booklet(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını booklet PDF-dökümanına dönüştür ve kaydet
+    pdf.save_booklet("sample_booklet.pdf")?;
+
+    Ok(())
+}
+```

--- a/turkish/rust-cpp/convert/save_doc/_index.md
+++ b/turkish/rust-cpp/convert/save_doc/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_doc"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açılmış PDF-dökümanını bir DOC-dökümanına dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_doc/
+---
+
+_Açılmış PDF-dökümanını bir DOC-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_doc(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını Doc-dökümanına dönüştür ve kaydet
+    pdf.save_doc("sample.doc")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_docx/_index.md
+++ b/turkish/rust-cpp/convert/save_docx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açılmış PDF-dökümanını bir DOCX-dökümanına dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_docx/
+---
+
+_Açılmış PDF-dökümanını bir DOCX-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_docx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını DocX-dökümanına dönüştür ve kaydet
+    pdf.save_docx("sample.docx")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_docx_enhanced/_index.md
+++ b/turkish/rust-cpp/convert/save_docx_enhanced/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_docx_enhanced"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Daha önce açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DOCX-dokümanı olarak dönüştürür ve kaydeder (tamamen düzenlenebilir tablolar ve paragraflar)."
+type: docs
+url: /tr/rust-cpp/convert/save_docx_enhanced/
+---
+
+_Daha önce açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DOCX-dokümanı olarak dönüştürür ve kaydeder (tamamen düzenlenebilir tablolar ve paragraflar)._
+
+```rust
+pub fn save_docx_enhanced(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF-dokümanını Gelişmiş Tanıma Modu ile DOCX-dokümanı olarak dönüştür ve kaydet (tamamen düzenlenebilir tablolar ve paragraflar)
+    pdf.save_docx_enhanced("sample_enhanced.docx")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_epub/_index.md
+++ b/turkish/rust-cpp/convert/save_epub/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_epub"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-belgesini EPUB belgesi olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_epub/
+---
+
+_Açılmış PDF-dökümanını bir EPUB-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_epub(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını Epub-dökümanına dönüştür ve kaydet
+    pdf.save_epub("sample.epub")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_markdown/_index.md
+++ b/turkish/rust-cpp/convert/save_markdown/_index.md
@@ -1,0 +1,36 @@
+---
+title: "save_markdown"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Daha önce açılmış PDF-belgesini Markdown belgesi olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_markdown/
+---
+
+_Daha önce açılmış PDF-belgesini Markdown belgesi olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_markdown(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF-belgesini Markdown belgesi olarak dönüştür ve kaydet
+    pdf.save_markdown("sample.md")?;
+
+    Ok(())
+}
+```

--- a/turkish/rust-cpp/convert/save_n_up/_index.md
+++ b/turkish/rust-cpp/convert/save_n_up/_index.md
@@ -1,0 +1,38 @@
+---
+title: "save_n_up"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Daha önce açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_n_up/
+---
+
+_Daha önce açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_n_up(&self, filename: &str, columns: i32, rows: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+  * **columns** - the number of columns
+  * **rows** - the number of rows
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF-dokümanını N-Up PDF-dokümanı olarak dönüştür ve kaydet
+    pdf.save_n_up("sample_n_up.pdf", 2, 2)?;
+
+    Ok(())
+}
+```

--- a/turkish/rust-cpp/convert/save_pptx/_index.md
+++ b/turkish/rust-cpp/convert/save_pptx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_pptx"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açılmış PDF-dökümanını bir PPTX-dökümanına dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_pptx/
+---
+
+_Açılmış PDF-dökümanını bir PPTX-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_pptx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını PptX-dökümanına dönüştür ve kaydet
+    pdf.save_pptx("sample.pptx")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_svg_zip/_index.md
+++ b/turkish/rust-cpp/convert/save_svg_zip/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_svg_zip"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-belgesini SVG arşivi olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_svg_zip/
+---
+
+_Önceden açılmış PDF-belgesini SVG arşivi olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_svg_zip(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-belgesini SVG arşivi olarak dönüştür ve kaydet
+    pdf.save_svg_zip("sample_svg.zip")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_tex/_index.md
+++ b/turkish/rust-cpp/convert/save_tex/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tex"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Daha önce açılmış PDF-dokümanını TeX-dokümanı olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_tex/
+---
+
+_Daha önce açılmış PDF-dokümanını TeX-dokümanı olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_tex(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF-dokümanını TeX-dokümanı olarak dönüştür ve kaydet
+    pdf.save_tex("sample.tex")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_tiff/_index.md
+++ b/turkish/rust-cpp/convert/save_tiff/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_tiff"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açılmış PDF-dökümanını bir Tiff-dökümanına dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_tiff/
+---
+
+_Açılmış PDF-dökümanını bir Tiff-dökümanına dönüştürür ve kaydeder._
+
+```rust
+pub fn save_tiff(&self, resolution_dpi: i32, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **resolution_dpi** - the resolution in DPI
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Açılmış PDF-dökümanını Tiff-dökümanına dönüştür ve kaydet
+    pdf.save_tiff(100, "sample.tiff")?;
+
+    Ok(())
+}
+```

--- a/turkish/rust-cpp/convert/save_txt/_index.md
+++ b/turkish/rust-cpp/convert/save_txt/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_txt"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-belgesini TXT belgesi olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_txt/
+---
+
+_Önceden açılmış PDF-belgesini TXT belgesi olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_txt(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-belgesini Txt belgesi olarak dönüştür ve kaydet
+    pdf.save_txt("sample.txt")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_xlsx/_index.md
+++ b/turkish/rust-cpp/convert/save_xlsx/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xlsx"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Önceden açılmış PDF-document'i bir XLSX-document olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_xlsx/
+---
+
+_Önceden açılmış PDF-document'i bir XLSX-document olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_xlsx(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-document'i XlsX-document olarak dönüştür ve kaydet
+    pdf.save_xlsx("sample.xlsx")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/convert/save_xps/_index.md
+++ b/turkish/rust-cpp/convert/save_xps/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_xps"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Daha önce açılmış PDF-dokümanını XPS-dokümanı olarak dönüştürür ve kaydeder."
+type: docs
+url: /tr/rust-cpp/convert/save_xps/
+---
+
+_Daha önce açılmış PDF-dokümanını XPS-dokümanı olarak dönüştürür ve kaydeder._
+
+```rust
+pub fn save_xps(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF-dokümanını XPS-dokümanı olarak dönüştür ve kaydet
+    pdf.save_xps("sample.xps")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/_index.md
+++ b/turkish/rust-cpp/core/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Temel PDF işlevleri"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF dosyalarıyla çalışmak için temel işlevler."
+type: docs
+url: /tr/rust-cpp/core/
+---
+
+## Core PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [new](./new/) | Yeni bir PDF belgesi oluştur. |
+| [open](./open/) | Dosya adıyla bir PDF belgesi aç. |
+| [save](./save/) | Daha önce açılan PDF belgesini kaydet. |
+| [save_as](./save_as/) | Daha önce açılan PDF belgesini yeni dosya adıyla kaydet. |
+| [set_license](./set_license/) | Dosya adıyla lisansı ayarla. |
+| [extract_text](./extract_text/) | PDF belgesinin içeriğini düz metin olarak döndür. |
+| [word_count](./word_count/) | PDF belgesindeki kelime sayısını döndür. |
+| [character_count](./character_count/) | PDF belgesindeki karakter sayısını döndür. |
+| [append](./append/) | Başka bir PDF belgesinden sayfaları ekle. |
+| [append_pages](./append_pages/) | Başka bir PDF belgesinden seçilen sayfaları ekle. |
+| [merge_documents](./merge_documents/) | Sağlanan PDF belgelerini birleştirerek yeni bir PDF belgesi oluştur. |
+| [split_document](./split_document/) | Kaynak PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluştur. |
+| [split](./split/) | Mevcut PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluştur. |
+| [split_at_page](./split_at_page/) | PDF belgesini iki yeni PDF belgesine böl. |
+| [split_at](./split_at/) | Mevcut PDF belgesini iki yeni PDF belgesine böl. |
+| [bytes](./bytes/) | PDF belgesinin içeriğini bayt vektörü olarak döndür. |
+| [get_meta_info](./get_meta_info/) | PDF belgesinin meta bilgi değerini al. |
+| [set_meta_info](./set_meta_info/) | PDF-dökümanının meta bilgi değerini ayarla. |
+| [clear_meta_info](./clear_meta_info/) | PDF-dökümanının tüm meta bilgi değerlerini temizle. |
+| [is_linearized](./is_linearized/) | Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al. |
+| [page_add](./page_add/) | PDF-dökümanına yeni bir sayfa ekle. |
+| [page_insert](./page_insert/) | PDF-dökümanında belirtilen konuma yeni bir sayfa ekle. |
+| [page_delete](./page_delete/) | PDF-dökümanında belirtilen sayfayı sil. |
+| [page_count](./page_count/) | PDF-dökümanındaki sayfa sayısını döndür. |
+| [page_word_count](./page_word_count/) | PDF-dökümanındaki belirtilen sayfadaki kelime sayısını döndür. |
+| [page_character_count](./page_character_count/) | PDF-dökümanındaki belirtilen sayfadaki karakter sayısını döndür. |
+| [page_is_blank](./page_is_blank/) | PDF-dökümanındaki sayfanın boş olup olmadığını döndür. |
+
+
+## Detailed Description
+
+PDF dosyalarıyla çalışmak için temel işlevler.
+

--- a/turkish/rust-cpp/core/append/_index.md
+++ b/turkish/rust-cpp/core/append/_index.md
@@ -1,0 +1,43 @@
+---
+title: "append"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Başka bir PDF-document'ten sayfaları ekler."
+type: docs
+url: /tr/rust-cpp/core/append/
+---
+
+_Başka bir PDF-document'ten sayfaları ekler._
+
+```rust
+pub fn append(&self, other: &Document) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ana PDF-document'i aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Başka bir PDF belgesini eklemek için aç
+    let another_pdf = Document::open("sample1page.pdf")?;
+
+    // Başka bir PDF belgesinden sayfaları ekle
+    pdf.append(&another_pdf)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_append.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/append_pages/_index.md
+++ b/turkish/rust-cpp/core/append_pages/_index.md
@@ -1,0 +1,44 @@
+---
+title: "append_pages"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Başka bir PDF belgesinden seçilen sayfaları ekler."
+type: docs
+url: /tr/rust-cpp/core/append_pages/
+---
+
+_Başka bir PDF belgesinden seçilen sayfaları ekler._
+
+```rust
+pub fn append_pages(&self, other: &Document, page_range: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **other** - a reference to another PDF-document to append pages from
+  * **page_range** - a string defining the page ranges to append (e.g. "-2,4,6-8,10-")
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ana PDF-document'i aç
+    let pdf = Document::open("sample1page.pdf")?;
+
+    // Başka bir PDF belgesini eklemek için aç
+    let another_pdf = Document::open("sample.pdf")?;
+
+    // Başka bir PDF belgesinden belirli sayfaları (1 ve 3) ekle
+    pdf.append_pages(&another_pdf, "1,3")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_append_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/bytes/_index.md
+++ b/turkish/rust-cpp/core/bytes/_index.md
@@ -1,0 +1,40 @@
+---
+title: "bayt"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının içeriğini bayt vektörü olarak döndürür."
+type: docs
+url: /tr/rust-cpp/core/bytes/
+---
+
+_PDF-dökümanının içeriğini bayt vektörü olarak döndürür._
+
+```rust
+pub fn bytes(&self) -> Result<Vec<u8>, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Vec\<u8\>)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // PDF-dökümanının içeriğini bayt vektörü olarak döndür
+    let data = pdf.bytes()?;
+
+    // Bayt vektörünün uzunluğunu yazdır
+    println!("Length: {}", data.len());
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/character_count/_index.md
+++ b/turkish/rust-cpp/core/character_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "character_count"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanındaki karakter sayısını döndürür."
+type: docs
+url: /tr/rust-cpp/core/character_count/
+---
+
+_PDF-dökümanındaki karakter sayısını döndürür._
+
+```rust
+pub fn character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanındaki karakter sayısını döndür
+    let count = pdf.character_count()?;
+
+    // Karakter sayısını yazdır
+    println!("Character count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/clear_meta_info/_index.md
+++ b/turkish/rust-cpp/core/clear_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "clear_meta_info"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF belgesinin tüm meta bilgi değerlerini temizler."
+type: docs
+url: /tr/rust-cpp/core/clear_meta_info/
+---
+
+_PDF belgesinin tüm meta bilgi değerlerini temizler._
+
+```rust
+pub fn clear_meta_info(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesinin tüm meta bilgi değerlerini temizle
+    pdf.clear_meta_info()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_clear_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/extract_text/_index.md
+++ b/turkish/rust-cpp/core/extract_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "extract_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF belgesinin içeriğini düz metin olarak döndürür."
+type: docs
+url: /tr/rust-cpp/core/extract_text/
+---
+
+_PDF belgesinin içeriğini düz metin olarak döndürür._
+
+```rust
+pub fn extract_text(&self) -> Result<String, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesinin içeriğini düz metin olarak döndür
+    let txt = pdf.extract_text()?;
+
+    // Çıkarılan metni yazdır
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/get_meta_info/_index.md
+++ b/turkish/rust-cpp/core/get_meta_info/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_meta_info"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF belgesinin meta bilgi değerini alır."
+type: docs
+url: /tr/rust-cpp/core/get_meta_info/
+---
+
+_PDF belgesinin meta bilgi değerini alır._
+
+```rust
+pub fn get_meta_info(&self, key: &str) -> Result<String, PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to get
+
+**Returns**
+  * **Ok(String)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesinin meta bilgi değerini al
+    let author = pdf.get_meta_info("Author")?;
+
+    // Sonucu yazdır
+    println!("Author: {}", author);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/is_linearized/_index.md
+++ b/turkish/rust-cpp/core/is_linearized/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_linearized"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer alır."
+type: docs
+url: /tr/rust-cpp/core/is_linearized/
+---
+
+_Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer alır._
+
+```rust
+pub fn is_linearized(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Belgenin lineerleştirilip lineerleştirilmediğini gösteren bir değer al
+    if pdf.is_linearized()? {
+        println!("The PDF-document is linearized.");
+    } else {
+        println!("The PDF-document is non-linearized.");
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/merge_documents/_index.md
+++ b/turkish/rust-cpp/core/merge_documents/_index.md
@@ -1,0 +1,43 @@
+---
+title: "merge_documents"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sağlanan PDF belgelerini birleştirerek yeni bir PDF belgesi oluşturur."
+type: docs
+url: /tr/rust-cpp/core/merge_documents/
+---
+
+_Sağlanan PDF belgelerini birleştirerek yeni bir PDF belgesi oluşturur._
+
+```rust
+pub fn merge_documents(documents: &[&Document]) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **documents** - a slice of references to PDF-documents to merge
+
+**Returns**
+  * **Ok((Self))** - with a new PDF-document instance, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf1 = Document::new()?;
+
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf2 = Document::open("sample.pdf")?;
+
+    // Sağlanan PDF belgelerini birleştirerek yeni bir PDF belgesi oluştur
+    let pdf_merged = Document::merge_documents(&[&pdf1, &pdf2])?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf_merged.save_as("sample_merge_documents.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/new/_index.md
+++ b/turkish/rust-cpp/core/new/_index.md
@@ -1,0 +1,37 @@
+---
+title: "yeni"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Yeni bir PDF-döküman oluşturur."
+type: docs
+url: /tr/rust-cpp/core/new/
+---
+
+_Yeni bir PDF-döküman oluşturur._
+
+```rust
+pub fn new() -> Result<Self, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_new.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/open/_index.md
+++ b/turkish/rust-cpp/core/open/_index.md
@@ -1,0 +1,37 @@
+---
+title: "aç"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Dosya adıyla bir PDF belgesi açar."
+type: docs
+url: /tr/rust-cpp/core/open/
+---
+
+_Dosya adıyla bir PDF belgesi açar._
+
+```rust
+pub fn open(filename: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_open.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_add/_index.md
+++ b/turkish/rust-cpp/core/page_add/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanına yeni bir sayfa ekler."
+type: docs
+url: /tr/rust-cpp/core/page_add/
+---
+
+_PDF-dökümanına yeni bir sayfa ekler._
+
+```rust
+pub fn page_add(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanına yeni sayfa ekle
+    pdf.page_add()?;
+
+    // Önceden açılmış PDF-document'i kaydet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_character_count/_index.md
+++ b/turkish/rust-cpp/core/page_character_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_character_count"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanındaki belirtilen sayfadaki karakter sayısını döndürür."
+type: docs
+url: /tr/rust-cpp/core/page_character_count/
+---
+
+_PDF-dökümanındaki belirtilen sayfadaki karakter sayısını döndürür._
+
+```rust
+pub fn page_character_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfa numarasını belirtin (1 tabanlı indeks)
+    let page_number = 1;
+
+    // Belirtilen sayfadaki karakter sayısını döndür
+    let count = pdf.page_character_count(page_number)?;
+
+    // Karakter sayısını yazdır
+    println!("Character count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_count/_index.md
+++ b/turkish/rust-cpp/core/page_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_count"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF belgesindeki sayfa sayısını döndürür."
+type: docs
+url: /tr/rust-cpp/core/page_count/
+---
+
+_PDF belgesindeki sayfa sayısını döndürür._
+
+```rust
+pub fn page_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesindeki sayfa sayısını döndür
+    let count = pdf.page_count()?;
+
+    // Sayfa sayısını yazdır
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_delete/_index.md
+++ b/turkish/rust-cpp/core/page_delete/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_delete"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen sayfayı PDF-document'ten siler."
+type: docs
+url: /tr/rust-cpp/core/page_delete/
+---
+
+_Belirtilen sayfayı PDF-document'ten siler._
+
+```rust
+pub fn page_delete(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document'te belirtilen sayfayı sil
+    pdf.page_delete(1)?;
+
+    // Önceden açılmış PDF-document'i kaydet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_insert/_index.md
+++ b/turkish/rust-cpp/core/page_insert/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_insert"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document içinde belirtilen konuma yeni bir sayfa ekler."
+type: docs
+url: /tr/rust-cpp/core/page_insert/
+---
+
+_PDF-document içinde belirtilen konuma yeni bir sayfa ekler._
+
+```rust
+pub fn page_insert(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document içinde belirtilen konuma yeni sayfa ekle
+    pdf.page_insert(1)?;
+
+    // Önceden açılmış PDF-document'i kaydet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_is_blank/_index.md
+++ b/turkish/rust-cpp/core/page_is_blank/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_is_blank"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanındaki sayfanın boş olup olmadığını döndür."
+type: docs
+url: /tr/rust-cpp/core/page_is_blank/
+---
+
+_PDF belgesinde sayfa boştur._
+
+```rust
+pub fn page_is_blank(&self, num: i32) -> Result<bool, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfa numarasını belirtin (1 tabanlı indeks)
+    let page_number = 1;
+
+    // PDF belgesinde sayfa boştur
+    let is_blank = pdf.page_is_blank(page_number)?;
+
+    // Belirtilen sayfa boşsa yazdır
+    println!("Is page {} blank? {}", page_number, is_blank);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/page_word_count/_index.md
+++ b/turkish/rust-cpp/core/page_word_count/_index.md
@@ -1,0 +1,44 @@
+---
+title: "page_word_count"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'teki belirtilen sayfadaki kelime sayısını döndürür."
+type: docs
+url: /tr/rust-cpp/core/page_word_count/
+---
+
+_PDF-document'teki belirtilen sayfadaki kelime sayısını döndürür._
+
+```rust
+pub fn page_word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfa numarasını belirtin (1 tabanlı indeks)
+    let page_number = 1;
+
+    // Belirtilen sayfadaki kelime sayısını döndür
+    let count = pdf.page_word_count(page_number)?;
+
+    // Kelime sayısını yazdır
+    println!("Word count on page {}: {}", page_number, count);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/save/_index.md
+++ b/turkish/rust-cpp/core/save/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açık olan PDF-document'i kaydeder."
+type: docs
+url: /tr/rust-cpp/core/save/
+---
+
+_Açık olan PDF-document'i kaydeder._
+
+```rust
+pub fn save(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Önceden açılmış PDF-document'i kaydet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/save_as/_index.md
+++ b/turkish/rust-cpp/core/save_as/_index.md
@@ -1,0 +1,37 @@
+---
+title: "save_as"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Açık olan PDF-document'i yeni bir dosya adıyla kaydeder."
+type: docs
+url: /tr/rust-cpp/core/save_as/
+---
+
+_Açık olan PDF-document'i yeni bir dosya adıyla kaydeder._
+
+```rust
+pub fn save_as(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the output file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // PDF-document'i yeni bir dosya adıyla kaydet
+    pdf.save_as("sample_save_as.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/set_license/_index.md
+++ b/turkish/rust-cpp/core/set_license/_index.md
@@ -1,0 +1,40 @@
+---
+title: "set_license"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Lisansı dosya adıyla ayarlar."
+type: docs
+url: /tr/rust-cpp/core/set_license/
+---
+
+_Lisansı dosya adıyla ayarlar._
+
+```rust
+pub fn set_license(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the license-file
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Dosya adıyla lisansı ayarla
+    pdf.set_license("Aspose.PDF.RustViaCPP.lic")?;
+
+    // Artık lisanslı PDF belgesiyle çalışabilirsiniz
+    // ...
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/set_meta_info/_index.md
+++ b/turkish/rust-cpp/core/set_meta_info/_index.md
@@ -1,0 +1,41 @@
+---
+title: "set_meta_info"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF belgesinin meta bilgi değerini ayarlar."
+type: docs
+url: /tr/rust-cpp/core/set_meta_info/
+---
+
+_PDF belgesinin meta bilgi değerini ayarlar._
+
+```rust
+pub fn set_meta_info(&self, key: &str, value: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **key** - the key whose value to set
+  * **value** - the value to be set
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesinin meta bilgi değerini ayarla
+    pdf.set_meta_info("Author", "Aspose")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_set_meta_info.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/split/_index.md
+++ b/turkish/rust-cpp/core/split/_index.md
@@ -1,0 +1,43 @@
+---
+title: "split"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Mevcut PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluşturur."
+type: docs
+url: /tr/rust-cpp/core/split/
+---
+
+_Mevcut PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluşturur._
+
+```rust
+pub fn split(&self, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Mevcut PDF belgesinden sayfaları çıkararak birden fazla yeni PDF belgesi oluştur
+    let pdf_parts = pdf_split.split("1-2;3-")?;
+
+    // Her bölünmüş parçayı ayrı bir PDF-document olarak kaydet
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/split_at/_index.md
+++ b/turkish/rust-cpp/core/split_at/_index.md
@@ -1,0 +1,41 @@
+---
+title: "split_at"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Mevcut PDF-document'i iki yeni PDF-document'e böler."
+type: docs
+url: /tr/rust-cpp/core/split_at/
+---
+
+_Mevcut PDF-document'i iki yeni PDF-document'e böler._
+
+```rust
+pub fn split_at(&self, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Mevcut PDF-document'i iki yeni PDF-document'e böl
+    let (left, right) = pdf_split.split_at(2)?;
+
+    // Her bölünmüş parçayı ayrı bir PDF-document olarak kaydet
+    left.save_as("sample_split_at_left.pdf")?;
+    right.save_as("sample_split_at_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/split_at_page/_index.md
+++ b/turkish/rust-cpp/core/split_at_page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "split_at_page"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'i iki yeni PDF-document'e böler."
+type: docs
+url: /tr/rust-cpp/core/split_at_page/
+---
+
+_PDF-document'i iki yeni PDF-document'e böler._
+
+```rust
+pub fn split_at_page(document: &Document, page: i32) -> Result<(Self, Self), PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page** - a page number at which to split (1-based, exclusive for the second part)
+
+**Returns**
+  * **Ok((Self, Self))** - with the two split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // PDF-document'i iki yeni PDF-document'e böl
+    let (left, right) = Document::split_at_page(&pdf_split, 2)?;
+
+    // Her bölünmüş parçayı ayrı bir PDF-document olarak kaydet
+    left.save_as("sample_split_at_page_left.pdf")?;
+    right.save_as("sample_split_at_page_right.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/split_document/_index.md
+++ b/turkish/rust-cpp/core/split_document/_index.md
@@ -1,0 +1,44 @@
+---
+title: "split_document"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Kaynak PDF-document'ten sayfalar çıkararak birden fazla yeni PDF-document oluşturur."
+type: docs
+url: /tr/rust-cpp/core/split_document/
+---
+
+_Kaynak PDF-document'ten sayfalar çıkararak birden fazla yeni PDF-document oluşturur._
+
+```rust
+pub fn split_document(document: &Document, page_range: &str) -> Result<Vec<Self>, PdfError>
+```
+
+**Arguments**
+  * **document** - a reference to the source PDF-document to split
+  * **page_range** - a string specifying page ranges, e.g. `"1-2;3;4-"`
+
+**Returns**
+  * **Ok(Vec\<Self\>)** - containing the resulting split documents, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample.pdf" adlı bir PDF-document aç
+    let pdf_split = Document::open("sample.pdf")?;
+
+    // Kaynak PDF-document'ten sayfalar çıkararak birden fazla yeni PDF-document oluşturur
+    let pdf_parts = Document::split_document(&pdf_split, "1;2-")?;
+
+    // Her bölünmüş parçayı ayrı bir PDF-document olarak kaydet
+    for (i, pdf_part) in pdf_parts.iter().enumerate() {
+        let pdf_filename = format!("sample_split_document_part{}.pdf", i + 1);
+        pdf_part.save_as(&pdf_filename)?;
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/core/word_count/_index.md
+++ b/turkish/rust-cpp/core/word_count/_index.md
@@ -1,0 +1,40 @@
+---
+title: "word_count"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'teki kelime sayısını döndürür."
+type: docs
+url: /tr/rust-cpp/core/word_count/
+---
+
+_PDF-document'teki kelime sayısını döndürür._
+
+```rust
+pub fn word_count(&self) -> Result<i32, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(i32)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document'teki kelime sayısını döndür
+    let count = pdf.word_count()?;
+
+    // Kelime sayısını yazdır
+    println!("Word count: {}", count);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/miscellaneous/_index.md
+++ b/turkish/rust-cpp/miscellaneous/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Çeşitli işlevler"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Çalışmak için çeşitli işlevler."
+type: docs
+url: /tr/rust-cpp/miscellaneous/
+---
+
+## Miscellaneous
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [about](./about/) | Aspose.PDF for Rust via C++ hakkında meta veri bilgilerini döndür. |
+
+
+## Detailed Description
+
+Çalışmak için çeşitli işlevler.
+

--- a/turkish/rust-cpp/miscellaneous/about/_index.md
+++ b/turkish/rust-cpp/miscellaneous/about/_index.md
@@ -1,0 +1,69 @@
+---
+title: "hakkında"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Aspose.PDF for Rust via C++ hakkında üst veri bilgilerini döndürür."
+type: docs
+url: /tr/rust-cpp/miscellaneous/about/
+---
+
+_Aspose.PDF for Rust via C++ hakkında üst veri bilgilerini döndürür._
+
+```rust
+pub fn about(&self) -> Result<ProductInfo, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(ProductInfo)** - if the operation succeeds
+```rust
+#[derive(Debug, Deserialize)]
+pub struct ProductInfo {
+    #[serde(rename = "product")]
+    pub product: String,
+
+    #[serde(rename = "family")]
+    pub family: String,
+
+    #[serde(rename = "version")]
+    pub version: String,
+
+    #[serde(rename = "releasedate")]
+    pub release_date: String,
+
+    #[serde(rename = "producer")]
+    pub producer: String,
+
+    #[serde(rename = "islicensed")]
+    pub is_licensed: bool,
+}
+```
+
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // Aspose.PDF for Go via C++ hakkında üst veri bilgilerini döndürür.
+    let info = pdf.about()?;
+
+    // Üst veri alanlarını yazdır
+    println!("Product Info:");
+    println!("  Product:      {}", info.product);
+    println!("  Family:       {}", info.family);
+    println!("  Version:      {}", info.version);
+    println!("  ReleaseDate:  {}", info.release_date);
+    println!("  Producer:     {}", info.producer);
+    println!("  IsLicensed:   {}", info.is_licensed);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/_index.md
+++ b/turkish/rust-cpp/organize/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PDF işlevlerini düzenleme"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF dosyalarını düzenlemek için işlevler."
+type: docs
+url: /tr/rust-cpp/organize/
+---
+
+## Organize PDF functions
+
+| Ad | Açıklama |
+| -------------- | -------------- |
+| [optimize](./optimize/) | PDF-dokümanının içeriğini optimize et. |
+| [optimize_resource](./optimize_resource/) | PDF-dokümanının kaynaklarını optimize et. |
+| [grayscale](./grayscale/) | PDF-dokümanını siyah beyaza dönüştür. |
+| [rotate](./rotate/) | PDF-dokümanını döndür. |
+| [set_background](./set_background/) | RGB değerlerini kullanarak PDF-dokümanının arka plan rengini ayarla. |
+| [repair](./repair/) | PDF-dokümanını onar. |
+| [replace_text](./replace_text/) | PDF-dokümanındaki metni değiştir |
+| [add_page_num](./add_page_num/) | PDF-dokümanına sayfa numarası ekle |
+| [add_text_header](./add_text_header/) | PDF-dokümanının başlığına metin ekle |
+| [add_text_footer](./add_text_footer/) | PDF-dokümanının altbilgisine metin ekle |
+| [flatten](./flatten/) | PDF-dokümanını düzleştir |
+| [remove_annotations](./remove_annotations/) | PDF-dokümanından ek açıklamaları kaldır |
+| [remove_attachments](./remove_attachments/) | PDF-dokümanından ekleri kaldır |
+| [remove_blank_pages](./remove_blank_pages/) | PDF-dokümanından boş sayfaları kaldır |
+| [remove_bookmarks](./remove_bookmarks/) | PDF-dokümanından yer imlerini kaldır |
+| [remove_hidden_text](./remove_hidden_text/) | PDF-dokümanından gizli metni kaldır |
+| [remove_images](./remove_images/) | PDF-dokümanından görüntüleri kaldır |
+| [remove_javascripts](./remove_javascripts/) | PDF-dokümanından java script'leri kaldır |
+| [remove_tables](./remove_tables/) | PDF-dokümanından tabloları kaldır. |
+| [remove_watermarks](./remove_watermarks/) | PDF-dokümanından filigranları kaldır. |
+| [add_watermark](./add_watermark/) | PDF-dokümanına filigran ekle. |
+| [embed_fonts](./embed_fonts/) | Bir PDF-document içine yazı tiplerini göm. |
+| [unembed_fonts](./unembed_fonts/) | Bir PDF-document'tan yazı tiplerini çıkar. |
+| [optimize_file_size](./optimize_file_size/) | PDF-document'in boyutunu görüntü sıkıştırma kalitesiyle optimize et. |
+| [remove_text_headers](./remove_text_headers/) | PDF-document'ten metin başlıklarını kaldır. |
+| [remove_text_footers](./remove_text_footers/) | PDF-document'ten metin altbilgilerini kaldır. |
+| [crop](./crop/) | Bir PDF-document'in sayfalarını kırp. |
+| [replace_font](./replace_font/) | Bir PDF-document'teki yazı tipini değiştir. |
+| [convert](./convert/) | Bir PDF-document'i belirtilen PDF formatıyla bir PDF-document'e dönüştür |
+| [validate](./validate/) | Bir PDF-document'in PDF formatına uyumluluğunu doğrula |
+| [remove_pdfa_compliance](./remove_pdfa_compliance/) | Bir PDF-document'ten PDF/A uyumluluğunu kaldır |
+| [remove_pdfua_compliance](./remove_pdfua_compliance/) | Bir PDF-document'ten PDF/UA uyumluluğunu kaldır |
+| [is_pdfa_compliant](./is_pdfa_compliant/) | PDF-document'in PDF/A uyumlu olup olmadığını al |
+| [is_pdfua_compliant](./is_pdfua_compliant/) | PDF-document'in PDF/UA uyumlu olup olmadığını al |
+| [page_rotate](./page_rotate/) | PDF-document'teki bir sayfayı döndür. |
+| [page_set_size](./page_set_size/) | PDF-document'teki bir sayfanın boyutunu ayarla. |
+| [page_grayscale](./page_grayscale/) | Sayfayı siyah beyaza dönüştür. |
+| [page_add_text](./page_add_text/) | Sayfaya metin ekle. |
+| [page_replace_text](./page_replace_text/) | Sayfadaki metni değiştir |
+| [page_add_page_num](./page_add_page_num/) | Sayfaya sayfa numarası ekle |
+| [page_add_text_header](./page_add_text_header/) | Sayfa başlığına metin ekle |
+| [page_add_text_footer](./page_add_text_footer/) | Sayfa altbilgisine metin ekle |
+| [page_remove_annotations](./page_remove_annotations/) | Sayfadaki ek açıklamaları kaldır. |
+| [page_remove_hidden_text](./page_remove_hidden_text/) | Sayfadaki gizli metni kaldır. |
+| [page_remove_images](./page_remove_images/) | Sayfadaki görüntüleri kaldır. |
+| [page_remove_tables](./page_remove_tables/) | Sayfadaki tabloları kaldır. |
+| [page_remove_watermarks](./page_remove_watermarks/) | Sayfadaki filigranları kaldır. |
+| [page_add_watermark](./page_add_watermark/) | Sayfaya filigran ekle. |
+| [page_remove_text_headers](./page_remove_text_headers/) | Sayfadaki metin başlıklarını kaldır. |
+| [page_remove_text_footers](./page_remove_text_footers/) | Sayfadaki metin altbilgilerini kaldır. |
+| [page_crop](./page_crop/) | Bir sayfayı kırp. |
+| [page_replace_font](./page_replace_font/) | Sayfadaki yazı tipini değiştir. |
+| [page_merge_layers](./page_merge_layers/) | Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmanda birleştir. |
+| [page_layers](./page_layers/) | Sayfadaki katman adlarını al. |
+
+
+## Detailed Description
+
+PDF dosyalarını düzenlemek için işlevler.

--- a/turkish/rust-cpp/organize/add_page_num/_index.md
+++ b/turkish/rust-cpp/organize/add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_page_num"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'e sayfa numarası ekler."
+type: docs
+url: /tr/rust-cpp/organize/add_page_num/
+---
+
+_PDF-document'e sayfa numarası ekler._
+
+```rust
+pub fn add_page_num(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanına sayfa numarası ekle
+    pdf.add_page_num()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/add_text_footer/_index.md
+++ b/turkish/rust-cpp/organize/add_text_footer/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_footer"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'in Altbilgi kısmına metin ekler."
+type: docs
+url: /tr/rust-cpp/organize/add_text_footer/
+---
+
+_PDF-document'in Altbilgi kısmına metin ekler._
+
+```rust
+pub fn add_text_footer(&self, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanının altbilgisine metin ekle
+    pdf.add_text_footer("FOOTER")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/add_text_header/_index.md
+++ b/turkish/rust-cpp/organize/add_text_header/_index.md
@@ -1,0 +1,40 @@
+---
+title: "add_text_header"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının Başlığında metin ekler."
+type: docs
+url: /tr/rust-cpp/organize/add_text_header/
+---
+
+_PDF-dökümanının Başlığında metin ekler._
+
+```rust
+pub fn add_text_header(&self, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanının başlığına metin ekle
+    pdf.add_text_header("HEADER")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/add_watermark/_index.md
+++ b/turkish/rust-cpp/organize/add_watermark/_index.md
@@ -1,0 +1,69 @@
+---
+title: "add_watermark"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'e filigran ekler."
+type: docs
+url: /tr/rust-cpp/organize/add_watermark/
+---
+
+_PDF-document'e filigran ekler._
+
+```rust
+pub fn add_watermark(
+    &self,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document'e filigran ekle
+    pdf.add_watermark(
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/convert/_index.md
+++ b/turkish/rust-cpp/organize/convert/_index.md
@@ -1,0 +1,49 @@
+---
+title: "convert"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Belirtilen PDF formatı ile bir PDF-document'i başka bir PDF-document'e dönüştürür."
+type: docs
+url: /tr/rust-cpp/organize/convert/
+---
+
+_Belirtilen PDF formatı ile bir PDF-document'i başka bir PDF-document'e dönüştürür._
+
+```rust
+    pub fn convert(
+        &self,
+        pdf_format: PdfFormat,
+        action: ConvertErrorAction,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+  * **action** - the action to take on conversion errors (enum [ConvertErrorAction](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the conversion log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{ConvertErrorAction, Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir PDF-document'i belirtilen PDF formatıyla bir PDF-document'e dönüştür
+    let (ok, log) = pdf.convert(PdfFormat::PDF_A_2A, ConvertErrorAction::Delete)?;
+
+    // Dönüştürme sonucunu ve tam günlüğü yazdır
+    println!("Convert PDF/A result: {}", ok);
+    println!("Convert PDF/A log:\n{}", log);
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_convert.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/crop/_index.md
+++ b/turkish/rust-cpp/organize/crop/_index.md
@@ -1,0 +1,40 @@
+---
+title: "kırp"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Bir PDF-dökümanın sayfalarını kırpar."
+type: docs
+url: /tr/rust-cpp/organize/crop/
+---
+
+_Bir PDF-dökümanın sayfalarını kırpar._
+
+```rust
+pub fn crop(&self, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **margin** - pages margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanın sayfalarını kırp
+    pdf.crop(10.5)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/embed_fonts/_index.md
+++ b/turkish/rust-cpp/organize/embed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "embed_fonts"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dosyaya yazı tiplerini gömer."
+type: docs
+url: /tr/rust-cpp/organize/embed_fonts/
+---
+
+_PDF-dosyaya yazı tiplerini gömer._
+
+```rust
+pub fn embed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dosyaya yazı tiplerini gömer
+    pdf.embed_fonts()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_embed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/flatten/_index.md
+++ b/turkish/rust-cpp/organize/flatten/_index.md
@@ -1,0 +1,40 @@
+---
+title: "flatten"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-belgesini düzleştirir."
+type: docs
+url: /tr/rust-cpp/organize/flatten/
+---
+
+_PDF-belgesini düzleştirir._
+
+```rust
+pub fn flatten(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF belgesinin içeriğini düz metin olarak döndür
+    let txt = pdf.extract_text()?;
+
+    // Çıkarılan metni yazdır
+    println!("Extracted text:\n{}", txt);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/grayscale/_index.md
+++ b/turkish/rust-cpp/organize/grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "grayscale"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-belgesini siyah beyaza dönüştürür."
+type: docs
+url: /tr/rust-cpp/organize/grayscale/
+---
+
+_PDF-belgesini siyah beyaza dönüştürür._
+
+```rust
+pub fn grayscale(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-belgesini siyah beyaza dönüştür
+    pdf.grayscale()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/is_pdfa_compliant/_index.md
+++ b/turkish/rust-cpp/organize/is_pdfa_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfa_compliant"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanın PDF/A uyumlu olup olmadığını alır."
+type: docs
+url: /tr/rust-cpp/organize/is_pdfa_compliant/
+---
+
+_PDF-dökümanın PDF/A uyumlu olup olmadığını alır._
+
+```rust
+pub fn is_pdfa_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanın PDF/A uyumluluk durumunu al
+    if pdf.is_pdfa_compliant()? {
+        println!("The document is PDF/A compliant.");
+    } else {
+        println!("The document is not PDF/A compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/is_pdfua_compliant/_index.md
+++ b/turkish/rust-cpp/organize/is_pdfua_compliant/_index.md
@@ -1,0 +1,41 @@
+---
+title: "is_pdfua_compliant"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanın PDF/UA uyumlu olduğunu alır."
+type: docs
+url: /tr/rust-cpp/organize/is_pdfua_compliant/
+---
+
+_PDF-dökümanın PDF/UA uyumlu olduğunu alır._
+
+```rust
+pub fn is_pdfua_compliant(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanın PDF/UA uyum durumunu al
+    if pdf.is_pdfua_compliant()? {
+        println!("The document is PDF/UA compliant.");
+    } else {
+        println!("The document is not PDF/UA compliant.");
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/optimize/_index.md
+++ b/turkish/rust-cpp/organize/optimize/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-döküman içeriğini optimize eder."
+type: docs
+url: /tr/rust-cpp/organize/optimize/
+---
+
+_PDF-döküman içeriğini optimize eder._
+
+```rust
+pub fn optimize(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-döküman içeriğini optimize et
+    pdf.optimize()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_optimize.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/optimize_file_size/_index.md
+++ b/turkish/rust-cpp/organize/optimize_file_size/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_file_size"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının boyutunu görüntü sıkıştırma kalitesiyle optimize eder."
+type: docs
+url: /tr/rust-cpp/organize/optimize_file_size/
+---
+
+_PDF-dökümanının boyutunu görüntü sıkıştırma kalitesiyle optimize eder._
+
+```rust
+pub fn optimize_file_size(&self, image_quality: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **image_quality** - the image compression quality
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanının boyutunu görüntü sıkıştırma kalitesiyle optimize et
+    pdf.optimize_file_size(50)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_optimize_file_size.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/optimize_resource/_index.md
+++ b/turkish/rust-cpp/organize/optimize_resource/_index.md
@@ -1,0 +1,40 @@
+---
+title: "optimize_resource"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanın kaynaklarını optimize eder."
+type: docs
+url: /tr/rust-cpp/organize/optimize_resource/
+---
+
+_PDF-dökümanın kaynaklarını optimize eder._
+
+```rust
+pub fn optimize_resource(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanın kaynaklarını optimize et
+    pdf.optimize_resource()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_optimize_resource.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_add_page_num/_index.md
+++ b/turkish/rust-cpp/organize/page_add_page_num/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_add_page_num"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfaya sayfa numarası ekler."
+type: docs
+url: /tr/rust-cpp/organize/page_add_page_num/
+---
+
+_Sayfaya sayfa numarası ekler._
+
+```rust
+pub fn page_add_page_num(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfaya sayfa numarası ekle
+    pdf.page_add_page_num(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_add_page_num.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_add_text/_index.md
+++ b/turkish/rust-cpp/organize/page_add_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Bir sayfaya metin ekler."
+type: docs
+url: /tr/rust-cpp/organize/page_add_text/
+---
+
+_Bir sayfaya metin ekler._
+
+```rust
+pub fn page_add_text(&self, num: i32, add_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **add_text** - the text to add
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfaya metin ekle
+    pdf.page_add_text(1, "added text")?;
+
+    // Önceden açılmış PDF-document'i kaydet
+    pdf.save()?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_add_text_footer/_index.md
+++ b/turkish/rust-cpp/organize/page_add_text_footer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_footer"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfa altbilgi kısmına metin ekler."
+type: docs
+url: /tr/rust-cpp/organize/page_add_text_footer/
+---
+
+_Sayfa altbilgi kısmına metin ekler._
+
+```rust
+pub fn page_add_text_footer(&self, num: i32, footer: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **footer** - the pages footer
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfa altbilgisine metin ekle
+    pdf.page_add_text_footer(1, "FOOTER")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_add_text_footer.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_add_text_header/_index.md
+++ b/turkish/rust-cpp/organize/page_add_text_header/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_add_text_header"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfa üstbilgisinde metin ekler."
+type: docs
+url: /tr/rust-cpp/organize/page_add_text_header/
+---
+
+_Sayfa üstbilgisinde metin ekler._
+
+```rust
+pub fn page_add_text_header(&self, num: i32, header: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **header** - the pages header
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfa başlığına metin ekle
+    pdf.page_add_text_header(1, "HEADER")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_add_text_header.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_add_watermark/_index.md
+++ b/turkish/rust-cpp/organize/page_add_watermark/_index.md
@@ -1,0 +1,72 @@
+---
+title: "page_add_watermark"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfaya filigran ekler."
+type: docs
+url: /tr/rust-cpp/organize/page_add_watermark/
+---
+
+_Sayfaya filigran ekler._
+
+```rust
+pub fn page_add_watermark(
+    &self,
+    num: i32,
+    text: &str,
+    font_name: &str,
+    font_size: f64,
+    foreground_color: &str,
+    x_position: i32,
+    y_position: i32,
+    rotation: i32,
+    is_background: bool,
+    opacity: f64,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **text** - the watermark text
+  * **font_name** - the font name
+  * **font_size** - the font size
+  * **foreground_color** - the text color (hexadecimal format "#RRGGBB", where RR-red, GG-green and BB-blue hexadecimal integers)
+  * **x_position** - the 'x' watermark position
+  * **y_position** - the 'y' watermark position
+  * **rotation** - the watermark rotation (0-360)
+  * **is_background** - the background
+  * **opacity** - the opacity (decimal)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfaya filigran ekle
+    pdf.page_add_watermark(
+        1,
+        "WATERMARK",
+        "Arial",
+        16.0,
+        "#010101",
+        100,
+        100,
+        45,
+        true,
+        0.5,
+    )?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_add_watermark.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_crop/_index.md
+++ b/turkish/rust-cpp/organize/page_crop/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_crop"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Bir sayfayı kırpar."
+type: docs
+url: /tr/rust-cpp/organize/page_crop/
+---
+
+_Bir sayfayı kırpar._
+
+```rust
+pub fn page_crop(&self, num: i32, margin: f64) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **margin** - page margins
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir sayfayı kırp
+    pdf.page_crop(1, 1.0)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_crop.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_grayscale/_index.md
+++ b/turkish/rust-cpp/organize/page_grayscale/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_grayscale"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Bir sayfayı siyah beyaza dönüştürür."
+type: docs
+url: /tr/rust-cpp/organize/page_grayscale/
+---
+
+_Bir sayfayı siyah beyaza dönüştürür._
+
+```rust
+pub fn page_grayscale(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfayı siyah beyaza dönüştür
+    pdf.page_grayscale(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_grayscale.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_layers/_index.md
+++ b/turkish/rust-cpp/organize/page_layers/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_layers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki katmanların adlarını alır."
+type: docs
+url: /tr/rust-cpp/organize/page_layers/
+---
+
+_Sayfadaki katmanların adlarını alır._
+
+```rust
+pub fn page_layers(&self, num: i32) -> Result<Vec<String>, PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(Vec\<String\>)** - the array layers' names
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample_layers.pdf")?;
+
+    // Sayfa 1'deki katmanların adlarını al
+    let layers: Vec<String> = pdf.page_layers(1)?;
+
+    println!("Layers on page 1:");
+    for name in layers {
+        println!("- {}", name);
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_merge_layers/_index.md
+++ b/turkish/rust-cpp/organize/page_merge_layers/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_merge_layers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmana birleştirir."
+type: docs
+url: /tr/rust-cpp/organize/page_merge_layers/
+---
+
+_Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmana birleştirir._
+
+```rust
+pub fn page_merge_layers(&self, num: i32, new_layer_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **new_layer_name** - the name of the new layer after merging
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki tüm katmanları belirtilen yeni katman adıyla tek bir katmana birleştir
+    pdf.page_merge_layers(1, "New Layer Name")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_merge_layers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_annotations/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_annotations"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki açıklamaları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_annotations/
+---
+
+_Sayfadaki açıklamaları kaldırır._
+
+```rust
+pub fn page_remove_annotations(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki açıklamaları kaldır
+    pdf.page_remove_annotations(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_hidden_text/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_hidden_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki gizli metni kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_hidden_text/
+---
+
+_Sayfadaki gizli metni kaldırır._
+
+```rust
+pub fn page_remove_hidden_text(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki gizli metni kaldır
+    pdf.page_remove_hidden_text(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_images/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_images"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki görüntüleri kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_images/
+---
+
+_Sayfadaki görüntüleri kaldırır._
+
+```rust
+pub fn page_remove_images(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki görüntüleri kaldır
+    pdf.page_remove_images(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_tables/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_tables"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki tabloları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_tables/
+---
+
+_Sayfadaki tabloları kaldırır._
+
+```rust
+pub fn page_remove_tables(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki tabloları kaldır
+    pdf.page_remove_tables(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_text_footers/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_footers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki metin altbilgilerini kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_text_footers/
+---
+
+_Sayfadaki metin altbilgilerini kaldırır._
+
+```rust
+pub fn page_remove_text_footers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki metin altbilgilerini kaldır
+    pdf.page_remove_text_footers(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_text_headers/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_text_headers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfada metin üstbilgilerini kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_text_headers/
+---
+
+_Sayfada metin üstbilgilerini kaldırır._
+
+```rust
+pub fn page_remove_text_headers(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfada metin üstbilgilerini kaldır
+    pdf.page_remove_text_headers(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_remove_watermarks/_index.md
+++ b/turkish/rust-cpp/organize/page_remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "page_remove_watermarks"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki filigranları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/page_remove_watermarks/
+---
+
+_Sayfadaki filigranları kaldırır._
+
+```rust
+pub fn page_remove_watermarks(&self, num: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki filigranları kaldır
+    pdf.page_remove_watermarks(1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_replace_font/_index.md
+++ b/turkish/rust-cpp/organize/page_replace_font/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_font"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki yazı tipini değiştirir."
+type: docs
+url: /tr/rust-cpp/organize/page_replace_font/
+---
+
+_Sayfadaki yazı tipini değiştirir._
+
+```rust
+pub fn page_replace_font(&self, num: i32, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki yazı tipini değiştir
+    pdf.page_replace_font(1, "Times-BoldItalic", "Helvetica-Bold")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_replace_text/_index.md
+++ b/turkish/rust-cpp/organize/page_replace_text/_index.md
@@ -1,0 +1,42 @@
+---
+title: "page_replace_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Sayfadaki metni değiştirir."
+type: docs
+url: /tr/rust-cpp/organize/page_replace_text/
+---
+
+_Sayfadaki metni değiştirir._
+
+```rust
+pub fn page_replace_text(&self, num: i32, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfadaki metni değiştir
+    pdf.page_replace_text(1, "PDF", "TXT")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_rotate/_index.md
+++ b/turkish/rust-cpp/organize/page_rotate/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_rotate"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandaki bir sayfayı döndürür."
+type: docs
+url: /tr/rust-cpp/organize/page_rotate/
+---
+
+_PDF-dokümandaki bir sayfayı döndürür._
+
+```rust
+pub fn page_rotate(&self, num: i32, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosyadan bir PDF-document aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Sayfayı döndür
+    pdf.page_rotate(1, Rotation::On180)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/page_set_size/_index.md
+++ b/turkish/rust-cpp/organize/page_set_size/_index.md
@@ -1,0 +1,41 @@
+---
+title: "page_set_size"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümandaki bir sayfanın boyutunu ayarlar."
+type: docs
+url: /tr/rust-cpp/organize/page_set_size/
+---
+
+_PDF-dökümandaki bir sayfanın boyutunu ayarlar._
+
+```rust
+pub fn page_set_size(&self, num: i32, page_size: PageSize) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **page_size** - page size as enum `PageSize`: `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `B5`, `PageLetter`, `PageLegal`, `PageLedger`, or `P11x17`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PageSize};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümandaki bir sayfanın boyutunu ayarla
+    pdf.page_set_size(1, PageSize::A1)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_page1_set_size_A1.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_annotations/_index.md
+++ b/turkish/rust-cpp/organize/remove_annotations/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_annotations"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-belgesinden ek açıklamaları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_annotations/
+---
+
+_PDF-belgesinden ek açıklamaları kaldırır._
+
+```rust
+pub fn remove_annotations(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından ek açıklamaları kaldır
+    pdf.remove_annotations()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_annotations.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_attachments/_index.md
+++ b/turkish/rust-cpp/organize/remove_attachments/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_attachments"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan ekleri kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_attachments/
+---
+
+_PDF-dokümandan ekleri kaldırır._
+
+```rust
+pub fn remove_attachments(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından ekleri kaldır
+    pdf.remove_attachments()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_attachments.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_blank_pages/_index.md
+++ b/turkish/rust-cpp/organize/remove_blank_pages/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_blank_pages"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dosyadan boş sayfaları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_blank_pages/
+---
+
+_PDF-dosyadan boş sayfaları kaldırır._
+
+```rust
+pub fn remove_blank_pages(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından boş sayfaları kaldır
+    pdf.remove_blank_pages()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_blank_pages.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_bookmarks/_index.md
+++ b/turkish/rust-cpp/organize/remove_bookmarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_bookmarks"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'ten yer imlerini kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_bookmarks/
+---
+
+_PDF-document'ten yer imlerini kaldırır._
+
+```rust
+pub fn remove_bookmarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından yer imlerini kaldır
+    pdf.remove_bookmarks()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_bookmarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_hidden_text/_index.md
+++ b/turkish/rust-cpp/organize/remove_hidden_text/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_hidden_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan gizli metni kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_hidden_text/
+---
+
+_PDF-dokümandan gizli metni kaldırır._
+
+```rust
+pub fn remove_hidden_text(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından gizli metni kaldır
+    pdf.remove_hidden_text()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_hidden_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_images/_index.md
+++ b/turkish/rust-cpp/organize/remove_images/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_images"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan görüntüleri kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_images/
+---
+
+_PDF-dokümandan görüntüleri kaldırır._
+
+```rust
+pub fn remove_images(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından görüntüleri kaldır
+    pdf.remove_images()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_images.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_javascripts/_index.md
+++ b/turkish/rust-cpp/organize/remove_javascripts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_javascripts"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan java betiklerini kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_javascripts/
+---
+
+_PDF-dokümandan java betiklerini kaldırır._
+
+```rust
+pub fn remove_javascripts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanından java script'leri kaldır
+    pdf.remove_javascripts()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_javascripts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_pdfa_compliance/_index.md
+++ b/turkish/rust-cpp/organize/remove_pdfa_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfa_compliance"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Bir PDF-dokümandan PDF/A uyumluluğunu kaldır."
+type: docs
+url: /tr/rust-cpp/organize/remove_pdfa_compliance/
+---
+
+_PDF-dökümanından PDF/A uyumluluğunu kaldır._
+
+```rust
+pub fn remove_pdfa_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir PDF-document'ten PDF/A uyumluluğunu kaldır
+    pdf.remove_pdfa_compliance()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_pdfa_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_pdfua_compliance/_index.md
+++ b/turkish/rust-cpp/organize/remove_pdfua_compliance/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_pdfua_compliance"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümandan PDF/UA uyumluluğunu kaldır."
+type: docs
+url: /tr/rust-cpp/organize/remove_pdfua_compliance/
+---
+
+_PDF-dökümandan PDF/UA uyumluluğunu kaldır._
+
+```rust
+pub fn remove_pdfua_compliance(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir PDF-document'ten PDF/UA uyumluluğunu kaldır
+    pdf.remove_pdfua_compliance()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_pdfua_compliance.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_tables/_index.md
+++ b/turkish/rust-cpp/organize/remove_tables/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_tables"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'ten tabloları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_tables/
+---
+
+_PDF-document'ten tabloları kaldırır._
+
+```rust
+pub fn remove_tables(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document'ten tabloları kaldır
+    pdf.remove_tables()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_tables.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_text_footers/_index.md
+++ b/turkish/rust-cpp/organize/remove_text_footers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_footers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan metin altbilgilerini kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_text_footers/
+---
+
+_PDF-dokümandan metin altbilgilerini kaldırır._
+
+```rust
+pub fn remove_text_footers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümandan metin altbilgilerini kaldır
+    pdf.remove_text_footers()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_text_footers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_text_headers/_index.md
+++ b/turkish/rust-cpp/organize/remove_text_headers/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_text_headers"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan metin başlıklarını kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_text_headers/
+---
+
+_PDF-dokümandan metin başlıklarını kaldırır._
+
+```rust
+pub fn remove_text_headers(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümandan metin başlıklarını kaldır
+    pdf.remove_text_headers()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_text_headers.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/remove_watermarks/_index.md
+++ b/turkish/rust-cpp/organize/remove_watermarks/_index.md
@@ -1,0 +1,40 @@
+---
+title: "remove_watermarks"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dokümandan filigranları kaldırır."
+type: docs
+url: /tr/rust-cpp/organize/remove_watermarks/
+---
+
+_PDF-dokümandan filigranları kaldırır._
+
+```rust
+pub fn remove_watermarks(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümandan filigranları kaldır
+    pdf.remove_watermarks()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_remove_watermarks.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/repair/_index.md
+++ b/turkish/rust-cpp/organize/repair/_index.md
@@ -1,0 +1,40 @@
+---
+title: "repair"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanı onarır."
+type: docs
+url: /tr/rust-cpp/organize/repair/
+---
+
+_PDF-dosyayı onarır._
+
+```rust
+pub fn repair(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dosyayı Onar
+    pdf.repair()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_repair.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/replace_font/_index.md
+++ b/turkish/rust-cpp/organize/replace_font/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_font"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dosyadaki yazı tipini değiştirir."
+type: docs
+url: /tr/rust-cpp/organize/replace_font/
+---
+
+_PDF-dosyadaki yazı tipini değiştirir._
+
+```rust
+pub fn replace_font(&self, find_font_name: &str, replace_font_name: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_font_name** - the font name to search
+  * **replace_font_name** - the font name to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir PDF-document'teki yazı tipini değiştir.
+    pdf.replace_font("Helvetica", "Courier")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_replace_font.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/replace_text/_index.md
+++ b/turkish/rust-cpp/organize/replace_text/_index.md
@@ -1,0 +1,41 @@
+---
+title: "replace_text"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Metni değiştirir."
+type: docs
+url: /tr/rust-cpp/organize/replace_text/
+---
+
+_Metni değiştirir._
+
+```rust
+pub fn replace_text(&self, find_text: &str, replace_text: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **find_text** - the text fragment to search
+  * **replace_text** - the text fragment to replace
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dokümanındaki metni değiştir
+    pdf.replace_text("PDF", "TXT")?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_replace_text.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/rotate/_index.md
+++ b/turkish/rust-cpp/organize/rotate/_index.md
@@ -1,0 +1,40 @@
+---
+title: "rotate"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dosyayı döndürür."
+type: docs
+url: /tr/rust-cpp/organize/rotate/
+---
+
+_PDF-dosyayı döndürür._
+
+```rust
+pub fn rotate(&self, rotation: Rotation) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **rotation** - rotation angle as enum `Rotation`: `None`, `On90`, `On180`, `On270`, or `On360`
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Rotation};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dosyayı Döndür
+    pdf.rotate(Rotation::On270)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_rotate.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/set_background/_index.md
+++ b/turkish/rust-cpp/organize/set_background/_index.md
@@ -1,0 +1,42 @@
+---
+title: "set_background"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının arka plan rengini RGB değerleriyle ayarlar."
+type: docs
+url: /tr/rust-cpp/organize/set_background/
+---
+
+_PDF-dökümanının arka plan rengini RGB değerleriyle ayarlar._
+
+```rust
+pub fn set_background(&self, r: i32, g: i32, b: i32) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **r** - red component (0-255)
+  * **g** - green component (0-255)
+  * **b** - blue component (0-255)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-dökümanının arka plan rengini RGB değerleriyle ayarla
+    pdf.set_background(200, 100, 101)?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_set_background.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/unembed_fonts/_index.md
+++ b/turkish/rust-cpp/organize/unembed_fonts/_index.md
@@ -1,0 +1,40 @@
+---
+title: "unembed_fonts"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-document'tan yazı tiplerini ayıklar."
+type: docs
+url: /tr/rust-cpp/organize/unembed_fonts/
+---
+
+_PDF-document'tan yazı tiplerini ayıklar._
+
+```rust
+pub fn unembed_fonts(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PDF-document'tan yazı tiplerini ayıkla
+    pdf.unembed_fonts()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_unembed_fonts.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/organize/validate/_index.md
+++ b/turkish/rust-cpp/organize/validate/_index.md
@@ -1,0 +1,44 @@
+---
+title: "validate"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanını PDF formatına uygunluk açısından doğrular."
+type: docs
+url: /tr/rust-cpp/organize/validate/
+---
+
+_PDF-dökümanını PDF formatına uygunluk açısından doğrular._
+
+```rust
+    pub fn validate(
+        &self,
+        pdf_format: PdfFormat,
+    ) -> Result<(bool, String), PdfError>
+```
+
+**Arguments**
+  * **pdf_format** - the target PDF format standard (enum [PdfFormat](../../))
+
+**Returns**
+  * **Ok((bool, String))** - the operation result, `String` contains the validation log
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, PdfFormat};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // Bir PDF-document'in PDF formatına uyumluluğunu doğrula
+    let (ok, log) = pdf.validate(PdfFormat::PDF_A_2A)?;
+
+    // Doğrulama sonucunu ve tam logu yazdır
+    println!("Validate PDF/A result: {}", ok);
+    println!("Validate PDF/A log:\n{}", log);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/_index.md
+++ b/turkish/rust-cpp/security/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Güvenlik işlevleri"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Güvenlik işlevleri."
+type: docs
+url: /tr/rust-cpp/security/
+---
+
+## Security
+
+| Fonksiyon | Açıklama |
+| -------- | ----------- |
+| [open_with_password](./open_with_password/) | Şifre korumalı bir PDF-dökümanını aç. |
+| [encrypt](./encrypt/) | PDF-dökümanını şifrele. |
+| [decrypt](./decrypt/) | PDF-dökümanının şifresini çöz. |
+| [set_permissions](./set_permissions/) | PDF-dökümanı için izinleri ayarla. |
+| [get_permissions](./get_permissions/) | PDF-dökümanının mevcut izinlerini al. |
+| [is_encrypted](./is_encrypted/) | PDF-dökümanının şifrelenme durumunu al. |
+| [sign_pkcs7](./sign_pkcs7/) | PDF-dökümanını PKCS#7 dijital imzalarıyla imzala. |
+| [sign_pkcs7_detached](./sign_pkcs7_detached/) | PDF-dökümanını PKCS#7 Ayrık dijital imzalarıyla imzala. |
+| [is_signed](./is_signed/) | PDF-dökümanının imzalı durumunu al. |
+| [remove_signs](./remove_signs/) | PDF-dökümanından imzaları kaldır. |
+
+
+## Detailed Description
+
+Güvenlik işlevleri.
+

--- a/turkish/rust-cpp/security/decrypt/_index.md
+++ b/turkish/rust-cpp/security/decrypt/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Şifre Çöz"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının şifresini çöz."
+type: docs
+url: /tr/rust-cpp/security/decrypt/
+---
+
+_PDF-document şifresini çöz._
+
+```rust
+pub fn decrypt(&self) -> Result<(), PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Şifre korumalı bir PDF-document aç
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // PDF-document şifresini çöz
+    pdf.decrypt()?;
+
+    // Daha önce açılmış PDF belgesini yeni dosya adıyla kaydet
+    pdf.save_as("sample_decrypt.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/encrypt/_index.md
+++ b/turkish/rust-cpp/security/encrypt/_index.md
@@ -1,0 +1,57 @@
+---
+title: "şifrele"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanını şifrele."
+type: docs
+url: /tr/rust-cpp/security/encrypt/
+---
+
+_Şifrele PDF-document._
+
+```rust
+pub fn encrypt(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+    crypto_algorithm: CryptoAlgorithm,
+    use_pdf_20: bool,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+  * **crypto_algorithm** - the encryption algorithm (`CryptoAlgorithm` enum)
+  * **use_pdf_20** - whether to use PDF 2.0 encryption
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{CryptoAlgorithm, Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // Şifrele PDF-document
+    pdf.encrypt(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+        CryptoAlgorithm::AESx128, // Encryption algorithm
+        true,                     // Use PDF 2.0 encryption
+    )?;
+
+    // Şifrelenmiş PDF-document'i kaydet
+    pdf.save_as("sample_with_password.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/get_permissions/_index.md
+++ b/turkish/rust-cpp/security/get_permissions/_index.md
@@ -1,0 +1,40 @@
+---
+title: "get_permissions"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının mevcut izinlerini al."
+type: docs
+url: /tr/rust-cpp/security/get_permissions/
+---
+
+_PDF-document mevcut izinlerini al._
+
+```rust
+pub fn get_permissions(&self) -> Result<Permissions, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(Permissions)** - the bitmask of permissions, if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Şifre korumalı bir PDF-document aç
+    let pdf = Document::open_with_password("sample_with_permissions.pdf", "ownerpass")?;
+
+    // PDF-document mevcut izinlerini al
+    let permissions: Permissions = pdf.get_permissions()?;
+
+    // İzinleri yazdır
+    println!("Permissions: {}", permissions);
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/is_encrypted/_index.md
+++ b/turkish/rust-cpp/security/is_encrypted/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_encrypted"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının şifrelenme durumunu al."
+type: docs
+url: /tr/rust-cpp/security/is_encrypted/
+---
+
+_PDF-document şifreli durumunu al._
+
+```rust
+pub fn is_encrypted(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Şifre korumalı bir PDF-document aç
+    let pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // PDF-document şifreli durumunu al
+    if pdf.is_encrypted()? {
+        println!("The document is encrypted.");
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/is_signed/_index.md
+++ b/turkish/rust-cpp/security/is_signed/_index.md
@@ -1,0 +1,39 @@
+---
+title: "is_signed"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanının imzalı durumunu al."
+type: docs
+url: /tr/rust-cpp/security/is_signed/
+---
+
+_PDF-document'in imzalı durumunu al._
+
+```rust
+pub fn is_signed(&self) -> Result<bool, PdfError>
+```
+
+**Arguments**
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample_with_sign.pdf" adlı bir PDF-document aç
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // PDF-document'in imzalı durumunu al
+    if pdf.is_signed()? {
+        println!("The document is signed.");
+    }
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/open_with_password/_index.md
+++ b/turkish/rust-cpp/security/open_with_password/_index.md
@@ -1,0 +1,37 @@
+---
+title: "open_with_password"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "Şifre korumalı bir PDF-dökümanını aç."
+type: docs
+url: /tr/rust-cpp/security/open_with_password/
+---
+
+_Şifre korumalı bir PDF-document aç._
+
+```rust
+pub fn open_with_password(filename: &str, password: &str) -> Result<Self, PdfError>
+```
+
+**Arguments**
+  * **filename** - path to the PDF-document to open
+  * **password** - user/owner password of the password-protected PDF-document
+
+**Returns**
+  * **Ok(Self)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Şifre korumalı bir PDF-document aç
+    let _pdf = Document::open_with_password("sample_with_password.pdf", "ownerpass")?;
+
+    // çalışıyor...
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/remove_signs/_index.md
+++ b/turkish/rust-cpp/security/remove_signs/_index.md
@@ -1,0 +1,38 @@
+---
+title: "remove_signs"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanından imzaları kaldır."
+type: docs
+url: /tr/rust-cpp/security/remove_signs/
+---
+
+_PDF-document üzerindeki imzaları kaldır._
+
+```rust
+pub fn remove_signs(&self, filename: &str) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **filename** - the path to the resulting PDF-document without signatures
+
+
+**Returns**
+  * **Ok(bool)** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // "sample_with_sign.pdf" adlı bir PDF-document aç
+    let pdf = Document::open("sample_with_sign.pdf")?;
+
+    // PDF-document üzerindeki imzaları kaldır
+    pdf.remove_signs("sample_remove_signs.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/set_permissions/_index.md
+++ b/turkish/rust-cpp/security/set_permissions/_index.md
@@ -1,0 +1,51 @@
+---
+title: "set_permissions"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanı için izinleri ayarla."
+type: docs
+url: /tr/rust-cpp/security/set_permissions/
+---
+
+_PDF-document için izinleri ayarla._
+
+```rust
+pub fn set_permissions(
+    &self,
+    user_password: &str,
+    owner_password: &str,
+    permissions: Permissions,
+) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **user_password** - the user password
+  * **owner_password** - the owner password
+  * **permissions** - the allowed permissions (bitflags `Permissions`)
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::{Document, Permissions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Yeni bir PDF-document oluştur
+    let pdf = Document::new()?;
+
+    // PDF-dökümanı için izinleri ayarla.
+    pdf.set_permissions(
+        "userpass",  // User password
+        "ownerpass", // Owner password
+        Permissions::PRINT_DOCUMENT | Permissions::MODIFY_CONTENT | Permissions::FILL_FORM, // Permissions bitmask
+    )?;
+
+    // Güncellenmiş izinlerle PDF-document'i kaydet
+    pdf.save_as("sample_with_permissions.pdf")?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/sign_pkcs7/_index.md
+++ b/turkish/rust-cpp/security/sign_pkcs7/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanını PKCS#7 dijital imzalarıyla imzala."
+type: docs
+url: /tr/rust-cpp/security/sign_pkcs7/
+---
+
+_PKCS#7 dijital imzalarını kullanarak bir PDF-document imzala._
+
+```rust
+    pub fn sign_pkcs7(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Sertifika ve görüntü dosyalarını bayt vektörlerine oku
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PKCS#7 dijital imzalarını kullanarak bir PDF-document imzala
+    pdf.sign_pkcs7(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7.pdf",
+    )?;
+
+    Ok(())
+}
+
+```

--- a/turkish/rust-cpp/security/sign_pkcs7_detached/_index.md
+++ b/turkish/rust-cpp/security/sign_pkcs7_detached/_index.md
@@ -1,0 +1,84 @@
+---
+title: "sign_pkcs7_detached"
+second_title: "Rust için C++ aracılığıyla Aspose.PDF"
+description: "PDF-dökümanını PKCS#7 Ayrık dijital imzalarıyla imzala."
+type: docs
+url: /tr/rust-cpp/security/sign_pkcs7_detached/
+---
+
+_PKCS#7 Ayrı dijital imzalarını kullanarak bir PDF-document imzala._
+
+```rust
+    pub fn sign_pkcs7_detached(
+        &self,
+        num: i32,
+        sign_data: &[u8],
+        psw_sign: &str,
+        set_x_indent: i32,
+        set_y_indent: i32,
+        set_height: i32,
+        set_width: i32,
+        reason: &str,
+        contact: &str,
+        location: &str,
+        is_visible: bool,
+        appearance_data: &[u8],
+        filename: &str,
+    ) -> Result<(), PdfError>
+```
+
+**Arguments**
+  * **num** - the page number (1-based)
+  * **sign_data** - the raw bytes of the signature (PKCS#7 specification in Internet RFC 2315)
+  * **psw_sign** - the password of the signature
+  * **set_x_indent** - the x indent of the signature
+  * **set_y_indent** - the y indent of the signature
+  * **set_height** - the height of the signature
+  * **set_width** - the width of the signature
+  * **reason** - the reason of a signature
+  * **contact** - the contact of a signature
+  * **location** - the location of a signature
+  * **is_visible** - the visiblity of signature
+  * **appearance_data** - the raw bytes of the graphic appearance for the signature
+  * **filename** - the path to the resulting PDF-document with signature
+
+
+**Returns**
+  * **Ok(())** - if the operation succeeds
+  * **Err(PdfError)** - if the operation fails
+
+**Example**
+
+```rust
+use asposepdf::Document;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Sertifika ve görüntü dosyalarını bayt vektörlerine oku
+    let cert = fs::read("sign.pfx")?;
+    let img = fs::read("sign.png")?;
+
+    // Dosya adıyla bir PDF-belgesi aç
+    let pdf = Document::open("sample.pdf")?;
+
+    // PKCS#7 Ayrı dijital imzalarını kullanarak bir PDF-document imzala
+    pdf.sign_pkcs7_detached(
+        1,
+        &cert,
+        "Pa$$w0rd2023",
+        100,
+        100,
+        70,
+        100,
+        "Reason",
+        "Contact",
+        "Location",
+        true,
+        &img,
+        "sample_sign_pkcs7_detached.pdf",
+    )?;
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Automated translation of the RUST-CPP API Reference to **Turkish** (`tr`) generated by RDA.

- Pages translated: 122/122
- Errors: 0
- Source: `english/rust-cpp`
- Output: `turkish/rust-cpp`

🤖 Generated by RDA